### PR TITLE
fix(deps): restore scipy floor that resolves on Python 3.10/3.11

### DIFF
--- a/requirements/ser.txt
+++ b/requirements/ser.txt
@@ -6,5 +6,5 @@ torchaudio==2.10.0
 fastapi>=0.115,<1
 uvicorn>=0.30,<1
 numpy>=1.26,<3
-scipy>=1.18.0,<2
+scipy>=1.11,<2
 soundfile>=0.14.0,<1

--- a/requirements/turn.txt
+++ b/requirements/turn.txt
@@ -5,4 +5,4 @@ transformers>=4.47,<6
 fastapi>=0.115,<1
 uvicorn>=0.30,<1
 numpy>=1.26,<3
-scipy>=1.18.0,<2
+scipy>=1.11,<2


### PR DESCRIPTION
Every PR currently shows a red **Python paths and manifests (ubuntu/windows)** — including PRs whose required checks are all green (see #1, #2). Root cause is on main, not in those PRs: an og-repo Dependabot merge raised scipy to `>=1.18.0` in `requirements/ser.txt` + `turn.txt`, and scipy 1.18.0 requires Python ≥3.12, so the job's `uv pip compile --python-version 3.11` is unsatisfiable. It landed while Actions were disabled — the local merge gate never ran this matrix — and today's first public runs surfaced it.

**Fix:** restore the pre-bump floor `scipy>=1.11,<2`; uv picks the newest scipy each interpreter actually supports.

**Verified:** the job's exact compile (`--python-version 3.11`, linux + windows platforms) and 3.11→3.10 both resolve locally for both manifests. This PR's own **Python paths and manifests** checks going green is the end-to-end proof.

Triage note for the open Dependabot PRs: #1/#2 (uvicorn, websockets) fail *only* this job — rebase/rerun after this merges and they should be fully green. #3/#4/#5 (transformers, onnxruntime, numpy) additionally fail their **required** sidecar checks on their own bumps (e.g. numpy 2.5.1 needs Python ≥3.12) — those are genuinely bad bumps for the supported matrix.