### PR TITLE
Log the full retained stderr tail on managed-server crashes

### DIFF
--- a/src/backends/managed-server.ts
+++ b/src/backends/managed-server.ts
@@ -131,7 +131,10 @@ async function runSupervisor(
       await finishStderrTail(crashTail);
       stderrTailCaptures.delete(proc);
       if (crashTail.lines.length > 0) {
-        log("error", `${opts.name} crash stderr (last ${Math.min(crashTail.lines.length, 5)} lines):\n  ${crashTail.lines.slice(-5).join("\n  ")}`);
+        // Print the whole retained tail: native aborts (GGML_ASSERT, CUDA
+        // errors) put the reason line well above the backtrace frames, so a
+        // short slice logs only anonymous addresses.
+        log("error", `${opts.name} crash stderr (last ${crashTail.lines.length} lines):\n  ${crashTail.lines.join("\n  ")}`);
       }
     }
 
@@ -181,7 +184,7 @@ async function runSupervisor(
       await finishStderrTail(stderrTail);
       stderrTailCaptures.delete(next);
       if (stderrTail.lines.length > 0) {
-        log("error", `${opts.name} revival stderr (last ${Math.min(stderrTail.lines.length, 5)} lines):\n  ${stderrTail.lines.slice(-5).join("\n  ")}`);
+        log("error", `${opts.name} revival stderr (last ${stderrTail.lines.length} lines):\n  ${stderrTail.lines.join("\n  ")}`);
       }
       code = next.exitCode ?? next.signalCode ?? -1;
       attempt += 1;
@@ -464,7 +467,7 @@ export async function startManagedServer(opts: StartOpts): Promise<ManagedProces
   await finishStderrTail(stderrTail);
   stderrTailCaptures.delete(proc);
   if (stderrTail.lines.length > 0) {
-    log("error", `${name} stderr (last ${Math.min(stderrTail.lines.length, 10)} lines):\n  ${stderrTail.lines.slice(-10).join("\n  ")}`);
+    log("error", `${name} stderr (last ${stderrTail.lines.length} lines):\n  ${stderrTail.lines.join("\n  ")}`);
   }
   return null;
 }


### PR DESCRIPTION
## Why

The supervisor keeps a rolling 40-line stderr tail per managed child, but on crash it printed only the last 5 lines (10 on startup failure). For native aborts — `GGML_ASSERT`, CUDA `cudaMalloc failed: out of memory` — the reason line sits well above the backtrace frames, so the daemon logged five anonymous addresses and threw away the one line that named the cause. The three identical audiocpp SIGABRTs during a call on 2026-07-14 were undiagnosable from the daemon log for exactly this reason (root cause turned out to be a failed ~5 GB CUDA allocation asserting later at `ggml-backend.cpp:327`; recovered via addr2line + out-of-band stderr capture).

## What

Print the entire retained tail on crash, revival failure, and startup failure. Output stays bounded by the existing capture limits (40 lines, 16 KB per partial line) — this changes which retained lines are shown, not how much is retained.

## Verification

- `bun run typecheck` clean
- `bun test`: 1826 pass / 0 fail
- `git diff --check` clean
- The fix is already running on the live daemon (deployed at 15:07 UTC with an announced restart); next audiocpp abort will log its reason line.