### PR TITLE
Hand delivered notifications to the brain as one-shot turn context

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -57,6 +57,7 @@ import { makeSpeculator } from "./web-voice/speculative";
 import { MAX_TURN_AUDIO_BYTES } from "./web-voice/protocol";
 import { TurnHistory } from "./web-voice/history";
 import { classifyCallIntent, sendTelegramVoice, sendTelegramText, startTelegramUpdatePoller } from "./notify/telegram";
+import { notificationTurnContext } from "./notify/context";
 import { KanbanWatcher, listViaCli, nudgeLine, spokenLine, taskLinkViaCli, type KanbanTask } from "./notify/kanban-watch";
 import { inQuietHours, composeBriefing, composeBriefingDigest, minutesPrompt, worthMinutes, callMinutesThresholdMs, parseHm, hmOf, dayOf } from "./notify/briefing";
 import { PromptScheduler, scheduleLabel } from "./notify/schedules";
@@ -970,6 +971,10 @@ export class CiceroDaemon {
         // If a Telegram bot is configured, the same clip also goes to the
         // phone as a voice note. The browser does not wait, but daemon shutdown
         // retains the delivery through its background-task drain.
+        // A notification that went out (spoken or parked — not quiet-hours
+        // deferred) becomes one-shot brain context, so "call me" or "what do
+        // we do about that?" right after an announcement lands on-topic.
+        onNotified: (text) => this.brain.injectContext(notificationTurnContext(text, new Date())),
         onNotify: async (text, voice, opts) => {
           try {
             if (opts?.signal?.aborted) return null;

--- a/src/notify/context.ts
+++ b/src/notify/context.ts
@@ -1,0 +1,16 @@
+/**
+ * One-shot brain context for a proactive notification that actually went out.
+ *
+ * Notifications are rendered and delivered (or parked) without the brain ever
+ * seeing them, so a follow-up on any surface — a dial-back call after texting
+ * "call me", a typed "what should we do about that?" — used to land on a brain
+ * that had no idea what "that" was. Injecting the delivered text as turn
+ * context closes that gap; BrainTurnContext accumulates and bounds entries, so
+ * a burst of notifications stacks safely.
+ */
+export function notificationTurnContext(text: string, at: Date): string {
+  return (
+    `[Proactive notification delivered to the user at ${at.toISOString()}] ${text}\n` +
+    "If the user follows up without naming a topic, assume they mean the most recent notification."
+  );
+}

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -95,6 +95,14 @@ export interface WebVoiceServerOptions {
    */
   onNotify?: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal }) => Promise<ArrayBuffer | null>;
   /**
+   * A notification actually went out (broadcast to clients, or parked for the
+   * next one — not deferred by quiet hours). The daemon uses this to hand the
+   * text to the brain as one-shot turn context, so a follow-up that names no
+   * topic ("call me", "what should we do about that?") lands on the right
+   * subject. Fire-and-forget: a throw here must not fail the delivery.
+   */
+  onNotified?: (text: string, outcome: { delivered: number; parked: boolean }) => void | Promise<void>;
+  /**
    * Render text to WAV with NO side effects (no broadcast, no Telegram, no
    * parking) — backs POST /api/say for callers that carry their own audio
    * channel. Deliberately separate from onNotify, which may fan out.
@@ -291,7 +299,7 @@ function requestedId(req: Request, url: URL, header: string, query: string): str
  * because a headless box is driven from another machine's browser.
  */
 export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle | null {
-  const { host = "0.0.0.0", port, token, tls, onTurn, onStreamTurn, onTextTurn, onNotify, onSay, onChat, onHistory, onHealth, onTurnProbe, onSpeculate, readiness } = opts;
+  const { host = "0.0.0.0", port, token, tls, onTurn, onStreamTurn, onTextTurn, onNotify, onNotified, onSay, onChat, onHistory, onHealth, onTurnProbe, onSpeculate, readiness } = opts;
   const scheme: "http" | "https" = tls ? "https" : "http";
   const configuredDrainTimeout = opts.shutdownDrainTimeoutMs;
   const shutdownDrainTimeoutMs = typeof configuredDrainTimeout === "number" && Number.isFinite(configuredDrainTimeout) && configuredDrainTimeout >= 1
@@ -528,10 +536,24 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       parked.push({ text, audioBase64, at: Date.now() });
       if (parked.length > PARK_MAX) parked.shift();
       log("info", `notify: "${text.substring(0, 60)}" — no client connected, parked for the next one`);
+      reportNotified(text, { delivered, parked: true });
       return { delivered, parked: true };
     }
     log("info", `notify: "${text.substring(0, 60)}" → ${delivered} client(s)`);
+    reportNotified(text, { delivered, parked: false });
     return { delivered, parked: false };
+  };
+  const reportNotified = (text: string, outcome: { delivered: number; parked: boolean }) => {
+    if (!onNotified) return;
+    const warn = (error: unknown) =>
+      log("warn", `onNotified hook failed: ${error instanceof Error ? error.message : String(error)}`);
+    // Both a synchronous throw and an async rejection must stay contained —
+    // the notification is already delivered; the hook is fire-and-forget.
+    try {
+      Promise.resolve(onNotified(text, outcome)).catch(warn);
+    } catch (error) {
+      warn(error);
+    }
   };
 
   const notify = async (

--- a/tests/notify/context.test.ts
+++ b/tests/notify/context.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { notificationTurnContext } from "../../src/notify/context";
+
+describe("notificationTurnContext", () => {
+  test("carries the delivered text, the timestamp, and the follow-up hint", () => {
+    const at = new Date("2026-07-14T18:00:00.000Z");
+    const ctx = notificationTurnContext("Fork sync: rebase hit conflicts.", at);
+    expect(ctx).toContain("2026-07-14T18:00:00.000Z");
+    expect(ctx).toContain("Fork sync: rebase hit conflicts.");
+    expect(ctx).toContain("most recent notification");
+    // One-shot context rides a prompt: it must stay a compact block, not grow prose.
+    expect(ctx.split("\n").length).toBe(2);
+  });
+});

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -79,6 +79,7 @@ function start(opts: {
   onStreamTurn?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onStreamTurn"]>;
   onTextTurn?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onTextTurn"]>;
   onNotify?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onNotify"]>;
+  onNotified?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onNotified"]>;
   onSay?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onSay"]>;
   onChat?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onChat"]>;
   onHistory?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onHistory"]>;
@@ -98,6 +99,7 @@ function start(opts: {
     onStreamTurn: opts.onStreamTurn,
     onTextTurn: opts.onTextTurn,
     onNotify: opts.onNotify,
+    onNotified: opts.onNotified,
     onSay: opts.onSay,
     onChat: opts.onChat,
     onHistory: opts.onHistory,
@@ -896,6 +898,89 @@ test("POST /api/notify renders and broadcasts to connected ws clients", async ()
   expect(got.type).toBe("notify");
   expect(got.text).toBe("PR 142 is up.");
   expect(got.audioBase64).toBe(Buffer.from(wav(7)).toString("base64"));
+});
+
+test("onNotified fires when a notification parks (no client connected)", async () => {
+  const seen: Array<{ text: string; delivered: number; parked: boolean }> = [];
+  const base = start({
+    onNotify: async () => wav(5),
+    onNotified: (text, outcome) => seen.push({ text, ...outcome }),
+  });
+  const res = await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "Fork sync failed, needs a decision." }),
+  });
+  expect(res.status).toBe(200);
+  expect(seen).toEqual([{ text: "Fork sync failed, needs a decision.", delivered: 0, parked: true }]);
+});
+
+test("onNotified fires on broadcast delivery with the client count", async () => {
+  const seen: Array<{ delivered: number; parked: boolean }> = [];
+  const base = start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async () => wav(5),
+    onNotified: (_text, outcome) => seen.push(outcome),
+  });
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+    const timer = setTimeout(() => reject(new Error("notify timeout")), 3000);
+    ws.onopen = async () => {
+      await fetch(base + "/api/notify", {
+        method: "POST",
+        headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "PR 142 is up." }),
+      });
+    };
+    ws.onmessage = () => { clearTimeout(timer); ws.close(); resolve(); };
+    ws.onerror = () => { clearTimeout(timer); reject(new Error("ws error")); };
+  });
+  expect(seen).toEqual([{ delivered: 1, parked: false }]);
+});
+
+test("onNotified does NOT fire when the daemon defers the notification (quiet hours)", async () => {
+  let called = 0;
+  const base = start({
+    onNotify: async () => null, // daemon signals quiet-hours deferral
+    onNotified: () => { called += 1; },
+  });
+  const res = await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "late night news" }),
+  });
+  expect(res.status).toBe(200);
+  expect(called).toBe(0);
+});
+
+test("a throwing onNotified hook does not fail the delivery", async () => {
+  const base = start({
+    onNotify: async () => wav(5),
+    onNotified: () => { throw new Error("brain unavailable"); },
+  });
+  const res = await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "still delivered" }),
+  });
+  expect(res.status).toBe(200);
+  expect(((await res.json()) as { parked: boolean }).parked).toBe(true);
+});
+
+test("an async-rejecting onNotified hook does not fail the delivery", async () => {
+  const base = start({
+    onNotify: async () => wav(5),
+    onNotified: async () => { throw new Error("brain went away mid-hook"); },
+  });
+  const res = await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "still delivered async" }),
+  });
+  expect(res.status).toBe(200);
+  expect(((await res.json()) as { parked: boolean }).parked).toBe(true);
+  // Let the rejected hook promise settle; an unhandled rejection here fails the run.
+  await new Promise((r) => setTimeout(r, 10));
 });
 
 test("/api/notify without onNotify is a 501; bad bodies are 400s; token required", async () => {


### PR DESCRIPTION
## Problem

A proactive notification is rendered, spoken (or parked), and mirrored to Telegram — but the brain never sees it. A follow-up on any surface (a dial-back call after texting "call me", a typed "what should we do about that?") lands on a brain that has no idea what "that" refers to.

## Change

- New optional `onNotified` hook on the web-voice server, fired only when a notification actually goes out — broadcast to clients or parked for the next one. Quiet-hours deferrals do not fire it. A sync throw or async rejection in the hook is contained and never fails the delivery.
- The daemon wires it to `brain.injectContext()` with the delivered text + timestamp (`notificationTurnContext` helper). The switchboard already routes one-shot context to whichever lane answers the next turn, and `BrainTurnContext` bounds stacked entries, so notification bursts are safe.

Covers every notify source in one place: `/api/notify` (CLI, cron escalations), kanban watch, scheduled prompts, briefing.

## Tests

- `onNotified` fires on park (delivered=0) and on broadcast (delivered=1) with the outcome.
- Does NOT fire on quiet-hours deferral.
- Throwing and async-rejecting hooks don't fail the delivery.
- Helper format regression.

`bun run typecheck` clean, full `bun test` 1837 pass / 0 fail, `git diff --check` clean. Codex review (gpt-5.6-sol) run; its async-rejection containment flag was applied, its redaction flag was a false positive (the logger already redacts via `redactLogSecrets`).