### PR TITLE
test: close the SIGTERM readiness race in tree-termination fixture

### DIFF
--- a/tests/process/owned-process.test.ts
+++ b/tests/process/owned-process.test.ts
@@ -89,11 +89,17 @@ test("tree termination rejects invalid process-group identifiers before signalli
 test.skipIf(process.platform === "win32")(
   "shared tree termination escalates TERM-resistant leaders and descendants",
   async () => {
-    const childSource = `process.on("SIGTERM", () => {}); setInterval(() => {}, 1000);`;
+    // The PID line doubles as a readiness handshake: the child reports its own
+    // pid only after installing its SIGTERM handler (stdout inherited through
+    // the parent), and the parent installs its handler before spawning — so by
+    // the time the line arrives, both processes are provably TERM-resistant.
+    // Printing the pid before the handlers exist let SIGTERM land in the gap
+    // on slow CI runners, and the tree died fast enough to fail the >=30ms
+    // escalation floor below.
+    const childSource = `process.on("SIGTERM", () => {}); process.stdout.write(String(process.pid) + "\\n"); setInterval(() => {}, 1000);`;
     const parentSource = [
-      `const child = Bun.spawn([${JSON.stringify(process.execPath)}, "-e", ${JSON.stringify(childSource)}], { stdin: "ignore", stdout: "ignore", stderr: "ignore" });`,
-      `process.stdout.write(String(child.pid) + "\\n");`,
       `process.on("SIGTERM", () => {});`,
+      `Bun.spawn([${JSON.stringify(process.execPath)}, "-e", ${JSON.stringify(childSource)}], { stdin: "ignore", stdout: "inherit", stderr: "ignore" });`,
       `setInterval(() => {}, 1000);`,
     ].join("\n");
     const proc = spawnOwnedProcess([process.execPath, "-e", parentSource], {


### PR DESCRIPTION
## Why

Main run [29371922827](https://github.com/5uck1ess/cicero/actions/runs/29371922827) failed on `shared tree termination escalates TERM-resistant leaders and descendants`: expected termination to take ≥30 ms (proving SIGKILL escalation waited out the 40 ms grace), got 10.2 ms.

Root cause is a race in the fixture, not in `terminateOwnedProcessTree`: the parent printed the child pid **before** installing its SIGTERM-ignore handler, and the child needed its own interpreter startup before its handler existed. The test signals the tree the moment it reads the pid line — on a slow shared runner SIGTERM landed in that gap, both processes died politely, and the escalation floor failed. The product code behaved correctly in both the fast and slow orderings.

## What

The pid line becomes a readiness handshake: the **child** reports its own pid only after installing its handler (stdout inherited through the parent), and the **parent** installs its handler before spawning the child. When the test reads the line, both processes are provably TERM-resistant — deterministic, no added sleeps or timing assumptions.

## Verification

- 25 consecutive runs of `tests/process/owned-process.test.ts` pass (the pre-fix race was load-dependent, so this is confidence, not proof — the real proof is that the handshake removes the ordering assumption entirely).
- `bun run typecheck` clean, full `bun test` 1832 pass / 0 fail, `git diff --check` clean.