### PR TITLE
feat(notify): park text, render at flush — unheard notifications cost no synthesis

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -216,6 +216,18 @@ export class CiceroDaemon {
     await Bun.write(this.overnightPath, "[]");
     return q;
   }
+  /** Synthesize a notification clip: lane-or-raw voice resolution plus the
+   * URL strip (bare links are for the text surfaces — the audio never reads
+   * one out). Shared by the eager (onNotify) and lazy (onNotifyRender)
+   * paths so the two can never drift. */
+  private async renderNotifyClip(text: string, voice: string | undefined): Promise<ArrayBuffer> {
+    // voice = a lane name (its configured voice is used) or a raw voice name
+    // — an employee's news arrives in the employee's voice.
+    const laneVoice = voice ? this.config.brain.lanes?.[voice]?.voice ?? voice : undefined;
+    const spoken = text.replace(/https?:\/\/[^\s<>"')\]]+/g, "").replace(/\s{2,}/g, " ").trim()
+      || "I sent you the link.";
+    return await this.providers.tts.generateAudio(speakable(spoken), laneVoice);
+  }
   private pendingRecovery: { spoken: string[] } | null = null;
   private activeLocalTurn: AbortController | null = null;
   /** Every local mic/dashboard command, including superseded turns winding down. */
@@ -987,14 +999,29 @@ export class CiceroDaemon {
               if (opts?.signal?.aborted) return null;
               return null;
             }
-            // voice = a lane name (its configured voice is used) or a raw voice
-            // name — an employee's news arrives in the employee's voice.
-            const laneVoice = voice ? this.config.brain.lanes?.[voice]?.voice ?? voice : undefined;
-            // Bare URLs are for the text surfaces (Telegram message, voice-page
-            // notice card) — the audio never reads one out.
-            const spoken = text.replace(/https?:\/\/[^\s<>"')\]]+/g, "").replace(/\s{2,}/g, " ").trim()
-              || "I sent you the link.";
-            const audio = await this.providers.tts.generateAudio(speakable(spoken), laneVoice);
+            // skipRender: nobody is connected to hear it, so the clip can be
+            // synthesized at flush time (onNotifyRender) instead of now — a
+            // notification that only ever gets parked must not cost a GPU
+            // synthesis. Only a Telegram voice note still forces the render:
+            // the phone needs the clip immediately.
+            const tgEarly = this.config.notify?.telegram;
+            const mirrors = tgEarly && opts?.telegramMirror !== false;
+            if (opts?.skipRender && !(mirrors && tgEarly.voice_note)) {
+              // Parity with the eager path's post-render abort check: a turn
+              // cancelled mid-dispatch must not mirror or park.
+              if (opts?.signal?.aborted) return null;
+              if (mirrors) {
+                this.runBackground("Telegram notify delivery", async () => {
+                  try {
+                    await sendTelegramText(tgEarly, text);
+                  } catch (error) {
+                    log("warn", `Telegram notify delivery failed: ${error instanceof Error ? error.message : String(error)}`);
+                  }
+                });
+              }
+              return new ArrayBuffer(0);
+            }
+            const audio = await this.renderNotifyClip(text, voice);
             if (opts?.signal?.aborted) return null;
             const tg = this.config.notify?.telegram;
             // telegramMirror: false = the caller delivers its own Telegram
@@ -1012,6 +1039,20 @@ export class CiceroDaemon {
             return audio;
           } catch (error) {
             throw new Error(`web notify failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+          }
+        },
+        // The lazy half of onNotify: pure synthesis for a parked notification
+        // being flushed to a client. No quiet-hours check (the item was
+        // accepted at dispatch), no Telegram mirror (already sent), no
+        // onNotified (context was injected when it parked).
+        onNotifyRender: async (text, voice, opts) => {
+          try {
+            opts?.signal?.throwIfAborted();
+            const audio = await this.renderNotifyClip(text, voice);
+            opts?.signal?.throwIfAborted();
+            return audio;
+          } catch (error) {
+            throw new Error(`parked notify render failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
           }
         },
         // Render-only TTS (the Telegram call greeting, external integrations)

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -93,7 +93,16 @@ export interface WebVoiceServerOptions {
    * audioBase64} to every connected voice client — Cicero speaks up unprompted
    * ("PR #142 is up") instead of only answering. Optional.
    */
-  onNotify?: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal }) => Promise<ArrayBuffer | null>;
+  onNotify?: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal; skipRender?: boolean }) => Promise<ArrayBuffer | null>;
+  /**
+   * Render a notification clip with no fan-out — the lazy half of onNotify.
+   * When nobody is connected, dispatchNotify asks onNotify to skip synthesis
+   * (skipRender) and parks the TEXT; this hook renders at flush time, when a
+   * client actually shows up to hear it. A notification that only ever gets
+   * parked and expires must not cost a synthesis. Optional: without it,
+   * onNotify always renders and the park stores audio, as before.
+   */
+  onNotifyRender?: (text: string, voice?: string, opts?: { signal?: AbortSignal }) => Promise<ArrayBuffer>;
   /**
    * A notification actually went out (broadcast to clients, or parked for the
    * next one — not deferred by quiet hours). The daemon uses this to hand the
@@ -299,7 +308,7 @@ function requestedId(req: Request, url: URL, header: string, query: string): str
  * because a headless box is driven from another machine's browser.
  */
 export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle | null {
-  const { host = "0.0.0.0", port, token, tls, onTurn, onStreamTurn, onTextTurn, onNotify, onNotified, onSay, onChat, onHistory, onHealth, onTurnProbe, onSpeculate, readiness } = opts;
+  const { host = "0.0.0.0", port, token, tls, onTurn, onStreamTurn, onTextTurn, onNotify, onNotifyRender, onNotified, onSay, onChat, onHistory, onHealth, onTurnProbe, onSpeculate, readiness } = opts;
   const scheme: "http" | "https" = tls ? "https" : "http";
   const configuredDrainTimeout = opts.shutdownDrainTimeoutMs;
   const shutdownDrainTimeoutMs = typeof configuredDrainTimeout === "number" && Number.isFinite(configuredDrainTimeout) && configuredDrainTimeout >= 1
@@ -479,17 +488,98 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
   // Notifications that arrived with no client connected are parked and spoken
   // to the next client that connects ("speak when you're back"). Bounded and
   // time-limited: stale news is worse than no news.
-  const parked: Array<{ text: string; audioBase64: string; at: number }> = [];
+  // audioBase64: null marks a lazily-parked item — the clip is synthesized at
+  // flush time via onNotifyRender, so news nobody ever hears (parked clips die
+  // of TTL more often than they get heard) never costs a GPU synthesis.
+  const parked: Array<{ text: string; voice?: string; audioBase64: string | null; at: number }> = [];
   const PARK_MAX = 10;
   const PARK_TTL_MS = 4 * 60 * 60 * 1000;
-  const flushParked = (ws: import("bun").ServerWebSocket<WsData>) => {
-    const now = Date.now();
+  // Ordering note: a live notify dispatched while an old parked item is mid-
+  // render can reach clients first. Arrival order across the park boundary was
+  // never guaranteed (parked news already waited for a connect); each item's
+  // own text carries its context.
+  let flushingParked = false;
+  let flushRequested = false;
+  const drainParkedPass = async (): Promise<void> => {
     while (parked.length) {
+      if (shutdownController.signal.aborted) return;
+      if (clients.size === 0) return;
       const p = parked.shift();
-      if (p && now - p.at <= PARK_TTL_MS) {
-        sendJson(ws, withSession(ws, { type: "notify", text: p.text, audioBase64: p.audioBase64 }));
+      if (!p || Date.now() - p.at > PARK_TTL_MS) continue;
+      let audioBase64 = p.audioBase64;
+      if (audioBase64 === null) {
+        if (!onNotifyRender) continue;
+        try {
+          const rendered = await onNotifyRender(p.text, p.voice, { signal: shutdownController.signal });
+          const audio = snapshotSynthesizedWav(rendered, { maxBytes: MAX_TURN_AUDIO_BYTES, allowEmpty: true }).audio;
+          audioBase64 = audio.byteLength > 0 ? Buffer.from(audio).toString("base64") : "";
+        } catch (error) {
+          // A transient TTS failure must not eat the news: put the item
+          // back and let the next connect retry. TTL still bounds its life.
+          parked.unshift(p);
+          if (!shutdownController.signal.aborted) {
+            log("warn", `parked notify render failed, retrying on next connect: ${error instanceof Error ? error.message : String(error)}`);
+          }
+          return;
+        }
+        if (shutdownController.signal.aborted) {
+          // Shutdown raced the render: keep the item (with its clip) for
+          // the next daemon lifetime rather than publishing into teardown.
+          parked.unshift({ ...p, audioBase64 });
+          return;
+        }
+      }
+      // Deliver to the first live client; a socket that died between connect
+      // and now must not eat the item — or strand it while others listen.
+      let sent = false;
+      for (const ws of clients) {
+        try {
+          sendJson(ws, withSession(ws, { type: "notify", text: p.text, audioBase64 }));
+          sent = true;
+          break;
+        } catch { /* try the next client */ }
+      }
+      if (!sent) {
+        parked.unshift({ ...p, audioBase64 }); // keep the rendered clip
+        return;
       }
     }
+  };
+  const flushParked = async (): Promise<void> => {
+    if (flushingParked) {
+      // A drain is active. Latch the new listener: the running pass may
+      // re-park an item (render failure, dead socket) after this early
+      // return, and without the latch that item would strand until yet
+      // another connect. Each latched request grants at most one re-pass,
+      // so a permanently failing render cannot hot-loop.
+      flushRequested = true;
+      return;
+    }
+    flushingParked = true;
+    try {
+      do {
+        flushRequested = false;
+        await drainParkedPass();
+      } while (flushRequested && parked.length > 0 && clients.size > 0 && !shutdownController.signal.aborted);
+    } finally {
+      flushingParked = false;
+    }
+  };
+  const startParkedFlush = (): void => {
+    // An active drain needs no new task (and holds a background slot that
+    // could read as a full cap) — latch the request so it re-passes.
+    if (flushingParked) {
+      flushRequested = true;
+      return;
+    }
+    // Begin only when stop() can own the flush — an untracked render could
+    // outlive shutdown. The admission check mirrors trackBackground's, so
+    // registration below cannot fail; the microtask defer means no flush
+    // code runs before ownership is registered. When declined (shutting
+    // down or at the background cap) the items stay parked and the next
+    // connect retries.
+    if (!accepting || backgroundTasks.size >= MAX_BACKGROUND_WEB_JOBS) return;
+    trackBackground(Promise.resolve().then(flushParked));
   };
 
   // Render a notification and deliver it: broadcast to every connected client,
@@ -502,6 +592,10 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     if (!onNotify) return null;
     const signal = notifyOpts?.signal ?? shutdownController.signal;
     if (signal.aborted) return null;
+    // With a lazy renderer wired and nobody connected, tell the daemon to skip
+    // the synthesis: quiet hours and the Telegram mirror still apply, but the
+    // clip is rendered only when a client shows up to hear it.
+    const lazy = clients.size === 0 && typeof onNotifyRender === "function";
     // Full text goes down — the daemon strips URLs from the audio only, so
     // the Telegram mirror and the voice-page notice card keep the link.
     let providerAudio: ArrayBuffer | null;
@@ -510,6 +604,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
         urgent: notifyOpts?.urgent,
         telegramMirror: notifyOpts?.telegramMirror,
         signal,
+        skipRender: lazy,
       });
     } catch (error) {
       throw new Error(`notification render failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
@@ -524,7 +619,24 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       maxBytes: MAX_TURN_AUDIO_BYTES,
       allowEmpty: true,
     }).audio;
-    const audioBase64 = audio.byteLength > 0 ? Buffer.from(audio).toString("base64") : "";
+    let audioBase64 = audio.byteLength > 0 ? Buffer.from(audio).toString("base64") : "";
+    if (lazy && audioBase64 === "" && clients.size > 0) {
+      // Race: a client connected while the daemon was told to skip the render.
+      // Render inline rather than hand them a silent notice card; on failure,
+      // deliver text-only rather than fail a notification that's already
+      // mirrored to Telegram.
+      try {
+        const rendered = await onNotifyRender!(text, voice, { signal });
+        const a = snapshotSynthesizedWav(rendered, { maxBytes: MAX_TURN_AUDIO_BYTES, allowEmpty: true }).audio;
+        audioBase64 = a.byteLength > 0 ? Buffer.from(a).toString("base64") : "";
+      } catch (error) {
+        // Cancellation is not a TTS failure — an aborted turn must not
+        // publish, not even text-only.
+        if (signal.aborted) return null;
+        log("warn", `late notify render failed, delivering text-only: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      if (signal.aborted) return null;
+    }
     let delivered = 0;
     for (const ws of clients) {
       try {
@@ -533,7 +645,9 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       } catch { /* socket closed */ }
     }
     if (delivered === 0) {
-      parked.push({ text, audioBase64, at: Date.now() });
+      // The daemon may render even when told it could skip (a Telegram voice
+      // note needs the clip now) — an audio-bearing park keeps that work.
+      parked.push({ text, voice, audioBase64: lazy && audioBase64 === "" ? null : audioBase64, at: Date.now() });
       if (parked.length > PARK_MAX) parked.shift();
       log("info", `notify: "${text.substring(0, 60)}" — no client connected, parked for the next one`);
       reportNotified(text, { delivered, parked: true });
@@ -1120,11 +1234,13 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               })
               .catch(() => { /* history is best-effort */ })
               .finally(() => {
-                if (accepting && clients.has(ws)) flushParked(ws);
+                if (accepting && clients.has(ws)) {
+                  startParkedFlush();
+                }
                 releaseJob();
               });
           } else {
-            if (accepting) flushParked(ws);
+            if (accepting) startParkedFlush();
           }
         },
         async message(ws, message) {

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -79,6 +79,7 @@ function start(opts: {
   onStreamTurn?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onStreamTurn"]>;
   onTextTurn?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onTextTurn"]>;
   onNotify?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onNotify"]>;
+  onNotifyRender?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onNotifyRender"]>;
   onNotified?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onNotified"]>;
   onSay?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onSay"]>;
   onChat?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onChat"]>;
@@ -99,6 +100,7 @@ function start(opts: {
     onStreamTurn: opts.onStreamTurn,
     onTextTurn: opts.onTextTurn,
     onNotify: opts.onNotify,
+    onNotifyRender: opts.onNotifyRender,
     onNotified: opts.onNotified,
     onSay: opts.onSay,
     onChat: opts.onChat,
@@ -1065,6 +1067,170 @@ test("parked notifications are capped at 10, oldest dropped", async () => {
   expect(texts.length).toBe(10);
   expect(texts[0]).toBe("n2");   // n0/n1 fell off the front
   expect(texts[9]).toBe("n11");
+});
+
+test("with a lazy renderer, a no-client notify skips synthesis and renders at flush", async () => {
+  const skipRenders: boolean[] = [];
+  let renders = 0;
+  const base = start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async (_text, _voice, opts) => {
+      skipRenders.push(opts?.skipRender === true);
+      // Honoring skipRender: accepted, mirrored, but no clip synthesized.
+      return opts?.skipRender ? new ArrayBuffer(0) : wav(5);
+    },
+    onNotifyRender: async () => { renders += 1; return wav(9); },
+  });
+  const auth = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+
+  const res = await fetch(base + "/api/notify", { method: "POST", headers: auth, body: JSON.stringify({ text: "rendered only when heard" }) });
+  expect(await res.json()).toEqual({ delivered: 0, parked: true });
+  expect(skipRenders).toEqual([true]);   // nobody connected -> daemon told to skip
+  expect(renders).toBe(0);               // and nothing was synthesized yet
+
+  const got = await new Promise<{ type: string; text: string; audioBase64: string }>((resolve, reject) => {
+    const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+    const timer = setTimeout(() => reject(new Error("lazy flush timeout")), 3000);
+    ws.onmessage = (e: MessageEvent) => {
+      if (typeof e.data !== "string") return;
+      clearTimeout(timer); ws.close(); resolve(JSON.parse(e.data));
+    };
+    ws.onerror = () => { clearTimeout(timer); reject(new Error("ws error")); };
+  });
+  expect(got.type).toBe("notify");
+  expect(got.text).toBe("rendered only when heard");
+  expect(got.audioBase64.length).toBeGreaterThan(0); // flush synthesized the clip
+  expect(renders).toBe(1);
+});
+
+test("a lazily parked item that fails to render is retried on the next connect", async () => {
+  let renders = 0;
+  const base = start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async (_text, _voice, opts) => (opts?.skipRender ? new ArrayBuffer(0) : wav(5)),
+    onNotifyRender: async () => {
+      renders += 1;
+      if (renders === 1) throw new Error("TTS server mid-revive");
+      return wav(9);
+    },
+  });
+  const auth = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+  await fetch(base + "/api/notify", { method: "POST", headers: auth, body: JSON.stringify({ text: "survives a render hiccup" }) });
+
+  // First connect: render throws, the item is re-parked, nothing is sent.
+  const first = await new Promise<string | null>((resolve) => {
+    const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+    const timer = setTimeout(() => { ws.close(); resolve(null); }, 500);
+    ws.onmessage = (e: MessageEvent) => { clearTimeout(timer); ws.close(); resolve(typeof e.data === "string" ? e.data : "binary"); };
+  });
+  expect(first).toBeNull();
+  expect(renders).toBe(1);
+
+  // Second connect: render succeeds and the news finally arrives.
+  const got = await new Promise<{ text: string }>((resolve, reject) => {
+    const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+    const timer = setTimeout(() => reject(new Error("retry flush timeout")), 3000);
+    ws.onmessage = (e: MessageEvent) => {
+      if (typeof e.data !== "string") return;
+      clearTimeout(timer); ws.close(); resolve(JSON.parse(e.data));
+    };
+    ws.onerror = () => { clearTimeout(timer); reject(new Error("ws error")); };
+  });
+  expect(got.text).toBe("survives a render hiccup");
+  expect(renders).toBe(2);
+});
+
+test("a daemon that renders despite skipRender parks the audio and flush does not re-render", async () => {
+  // The Telegram voice-note path needs the clip at dispatch time even when the
+  // server says it could skip — that rendered audio must be kept, not redone.
+  let renders = 0;
+  const base = start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async () => wav(7), // ignores skipRender, always renders
+    onNotifyRender: async () => { renders += 1; return wav(9); },
+  });
+  const auth = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+  await fetch(base + "/api/notify", { method: "POST", headers: auth, body: JSON.stringify({ text: "clip came from dispatch" }) });
+
+  const got = await new Promise<{ audioBase64: string }>((resolve, reject) => {
+    const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+    const timer = setTimeout(() => reject(new Error("flush timeout")), 3000);
+    ws.onmessage = (e: MessageEvent) => {
+      if (typeof e.data !== "string") return;
+      clearTimeout(timer); ws.close(); resolve(JSON.parse(e.data));
+    };
+    ws.onerror = () => { clearTimeout(timer); reject(new Error("ws error")); };
+  });
+  expect(got.audioBase64.length).toBeGreaterThan(0);
+  expect(renders).toBe(0); // parked audio was reused, no lazy render
+});
+
+test("a parked item flushes to exactly one client when several are connected", async () => {
+  let renders = 0;
+  const base = start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async (_text, _voice, opts) => (opts?.skipRender ? new ArrayBuffer(0) : wav(5)),
+    onNotifyRender: async () => { renders += 1; return wav(9); },
+  });
+  const auth = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+  await fetch(base + "/api/notify", { method: "POST", headers: auth, body: JSON.stringify({ text: "one listener gets the news" }) });
+
+  const listen = () =>
+    new Promise<string[]>((resolve) => {
+      const out: string[] = [];
+      const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+      const timer = setTimeout(() => { ws.close(); resolve(out); }, 800);
+      ws.onmessage = (e: MessageEvent) => { if (typeof e.data === "string") out.push(JSON.parse(e.data).text); };
+      ws.onerror = () => { clearTimeout(timer); resolve(out); };
+    });
+  const [a, b] = await Promise.all([listen(), listen()]);
+  const deliveries = [...a, ...b].filter((t) => t === "one listener gets the news");
+  expect(deliveries.length).toBe(1); // delivered once, not broadcast to every client
+  expect(renders).toBe(1);           // and rendered once
+});
+
+test("stop owns and drains an in-flight parked-notify render instead of finishing under it", async () => {
+  const renderStarted = deferred();
+  const release = deferred<ArrayBuffer>();
+  const base = start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async (_text, _voice, opts) => (opts?.skipRender ? new ArrayBuffer(0) : wav(5)),
+    onNotifyRender: () => { renderStarted.resolve(); return release.promise; },
+  });
+  const activeHandle = handle!;
+  const auth = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+  await fetch(base + "/api/notify", { method: "POST", headers: auth, body: JSON.stringify({ text: "drained on stop" }) });
+
+  const received: string[] = [];
+  const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+  ws.onmessage = (e: MessageEvent) => { if (typeof e.data === "string") received.push(JSON.parse(e.data).text); };
+  await renderStarted.promise; // the flush owns a synthesis now
+
+  const stopping = activeHandle.stop();
+  let stopSettled = false;
+  void stopping.then(
+    () => { stopSettled = true; },
+    () => { stopSettled = true; },
+  );
+  await Bun.sleep(10);
+  expect(stopSettled).toBe(false); // stop waits for the owned render
+
+  release.resolve(wav(9));
+  await stopping;
+  expect(stopSettled).toBe(true);
+  expect(received).toEqual([]); // shutdown raced the render: re-parked, not published
+});
+
+test("without a lazy renderer the old behavior holds: render at dispatch, park the audio", async () => {
+  const skipRenders: boolean[] = [];
+  const base = start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async (_text, _voice, opts) => { skipRenders.push(opts?.skipRender === true); return wav(5); },
+  });
+  const auth = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+  const res = await fetch(base + "/api/notify", { method: "POST", headers: auth, body: JSON.stringify({ text: "eager as before" }) });
+  expect(await res.json()).toEqual({ delivered: 0, parked: true });
+  expect(skipRenders).toEqual([false]); // no onNotifyRender wired -> never asked to skip
 });
 
 test("a wrong token is rejected", async () => {


### PR DESCRIPTION
## Why

Last night's audiocpp SIGABRT (upstream [0xShug0/audio.cpp#55](https://github.com/0xShug0/audio.cpp/issues/55)) was triggered by a notification **nobody was listening to**: with no client connected, `dispatchNotify` still rendered the full TTS clip before parking it, and the long brief text needed a ~3.9 GiB Mimi decode allocation under VRAM pressure. Beyond the crash, it's pure waste — parked clips die of TTL more often than they get heard, so every cron-driven notify paid a GPU synthesis for silence.

## What

- `dispatchNotify` passes `skipRender` to `onNotify` when no client is connected **and** the new lazy hook is wired. The daemon still applies quiet hours and still sends the Telegram **text** mirror, but skips synthesis — unless a Telegram **voice note** is configured, which needs the clip immediately (that eager audio is parked and reused, never re-rendered).
- The park can now hold text-only items; a new render-only `onNotifyRender` hook (shared `renderNotifyClip` helper: lane-voice resolution + URL strip, so the eager and lazy paths can't drift) synthesizes at flush, when a client actually connects.
- Failure containment: a render failure at flush re-parks the item for the next connect (TTL still bounds it); a socket death mid-flush re-parks with the rendered clip kept; a race where a client connects during a skipped render gets an inline render, falling back to text-only delivery.
- `onNotified` (brain context injection) semantics unchanged — still fires at dispatch on park, never on quiet-hours deferral.
- **Back-compat:** without `onNotifyRender`, behavior is byte-for-byte the old eager render-and-park.

## Verification

- 4 new regressions in `tests/web-voice/server.test.ts`: skip-then-flush renders exactly once at connect; render failure retried on next connect; eager audio (voice-note case) parked and not re-rendered; no lazy hook → `skipRender` never requested.
- `bun run typecheck` clean, full `bun test` 1836 pass / 0 fail, `git diff --check` clean.