### PR TITLE
feat(brain): attach to live Hermes sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ web_voice: { enabled: true, host: 0.0.0.0, port: 8090 } # a fresh token prints a
 stt: { backend: faster-whisper, port: 8083, model: large-v3-turbo }
 tts: { backend: pocket-tts, port: 8095, voice: alba }
 llm: { backend: ollama, port: 11434, model: qwen3.5:4b }
-brain: { backend: claude-code, mode: subprocess } # or acp / codex / gemini / ollama / any OpenAI-compatible URL
+brain: { backend: claude-code, mode: subprocess } # or acp / hermes-gateway / codex / gemini / ollama / any OpenAI-compatible URL
 ```
 
-**4. Pick your brain.** The config above expects the Claude Code CLI — install it and log in before continuing. For Hermes or another ACP harness, set `brain: { backend: acp, binary: …, binary_args: […] }` instead — see [Brains](docs/brains.md).
+**4. Pick your brain.** The config above expects the Claude Code CLI — install it and log in before continuing. For a new Hermes/ACP session, set `brain: { backend: acp, binary: …, binary_args: […] }`; to reuse the exact Hermes agent already open in a TUI or desktop client, use `hermes-gateway` — see [Brains](docs/brains.md).
 
 **5. Check, start, talk:**
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -127,6 +127,7 @@ llm:
 #   brain: { backend: codex }                              # Codex CLI
 #   brain: { backend: ollama, ollama_model: qwen3.5:4b }   # fully local
 #   brain: { backend: openai-compatible, base_url: http://127.0.0.1:8080/v1, model: your-model, timeout_ms: 120000 }
+#   brain: { backend: hermes-gateway, gateway_url_env: HERMES_TUI_GATEWAY_URL, session: main } # exact live Hermes TUI session
 brain:
   backend: acp
   binary: hermes                # install/auth this ACP agent, or replace it; see docs/brains.md

--- a/docs/brains.md
+++ b/docs/brains.md
@@ -1,11 +1,12 @@
 # Choosing a brain
 
-Cicero's "brain" is the agent that handles complex requests. Seven integration
+Cicero's "brain" is the agent that handles complex requests. Eight integration
 families are supported, with additional named presets for compatible APIs:
 
 | Backend | What it is | Default binary | Setup |
 |---|---|---|---|
 | `acp` | **Any [ACP](https://agentclientprotocol.com)-speaking agent harness** — the modular slot. Reference driver: [hermes](https://hermes-agent.nousresearch.com); anything that speaks ACP over stdio drops in via `binary` + `binary_args` (verified matrix below) | configurable | e.g. `brain: { backend: acp, binary: hermes, binary_args: [-p, voice, acp] }` |
+| `hermes-gateway` | An **already-live Hermes TUI/desktop session** through Hermes's TUI Gateway JSON-RPC WebSocket. Reuses that exact agent, transcript, tools, skills, profile, and working directory; never creates a session | n/a | set `gateway_url` (or `gateway_url_env`) + `session` |
 | `claude-code` (default) | Claude Code CLI in print mode | `claude` | `npm i -g @anthropic-ai/claude-code` + auth |
 | `codex` | OpenAI Codex CLI | `codex` | Install and authenticate the Codex CLI |
 | `gemini` | Google Gemini CLI | `gemini` | Install Gemini CLI + auth |
@@ -14,6 +15,50 @@ families are supported, with additional named presets for compatible APIs:
 | `openai-compatible` | Any OpenAI chat API — OpenRouter, a local server, or a LAN model server | n/a (in-process via fetch) | set `base_url` + `model` (+ key if the server needs one) |
 
 **Agentic vs answer-only:** the CLI brains (`claude-code`, `codex`, `gemini`, `qwen`) are *agents* — they run commands and edit files. `ollama` and `openai-compatible` *answer with a model* — no tool use. Pick a CLI agent when a turn must take actions; pick a model brain for fast local/cloud answers.
+
+## Attach to the agent already open in Hermes
+
+ACP sessions belong to the ACP server process. Passing a profile to `hermes
+acp` therefore starts a separate agent; it cannot attach Cicero to the session
+already open in the Hermes TUI. Use `hermes-gateway` for that case. It speaks
+Hermes's [TUI Gateway JSON-RPC](https://hermes-agent.nousresearch.com/docs/developer-guide/programmatic-integration#tui-gateway-json-rpc), selects an entry from `session.active_list`, and calls `session.activate` before sending a turn.
+
+Hermes's terminal TUI and Cicero must connect to the same long-lived Hermes
+backend process. Give that local backend a stable process credential, then pass
+the same authenticated WebSocket URL to the TUI and Cicero:
+
+```bash
+export HERMES_DASHBOARD_SESSION_TOKEN="$(openssl rand -hex 32)"
+export HERMES_TUI_GATEWAY_URL="ws://127.0.0.1:9119/api/ws?token=$HERMES_DASHBOARD_SESSION_TOKEN"
+hermes serve --host 127.0.0.1 --port 9119
+
+# In another terminal, using the same environment:
+hermes --tui
+```
+
+After the TUI opens or resumes the desired conversation, configure Cicero with
+its exact title, durable Hermes session key, or gateway-local live ID. Prefer an
+environment variable because the WebSocket URL contains a credential:
+
+```yaml
+brain:
+  backend: hermes-gateway
+  gateway_url_env: HERMES_TUI_GATEWAY_URL
+  session: main
+  auto_approve_tools: false
+  timeout_ms: 600000
+```
+
+The environment variable must also exist in Cicero's service environment.
+Startup fails closed if the named live session is absent or ambiguous, and the
+adapter never falls back to `session.create`. Plain `ws://` is accepted only on
+loopback; use an authenticated `wss://` endpoint for another machine.
+
+Hermes currently routes a live session's streaming events to the client that
+submitted or activated the turn. A Cicero voice turn therefore updates the
+shared agent and durable transcript, while its live token/tool feed is delivered
+to Cicero for speech. Switch away and back in the TUI to redraw from the shared
+history if that terminal was open during the voice turn.
 
 ## Verified ACP harnesses
 

--- a/src/brain/hermes-gateway.ts
+++ b/src/brain/hermes-gateway.ts
@@ -1,0 +1,469 @@
+import type { Brain, BrainTurnOptions } from "../types";
+import { log } from "../logger";
+import { BrainTurnContext } from "./turn-context";
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+const DEFAULT_TURN_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_GATEWAY_FRAME_BYTES = 4 * 1024 * 1024;
+const UTF8 = new TextEncoder();
+
+type GatewayFrame = {
+  id?: number;
+  method?: string;
+  result?: unknown;
+  error?: { message?: string };
+  params?: {
+    type?: string;
+    session_id?: string;
+    payload?: Record<string, unknown>;
+  };
+};
+
+type ActiveSession = {
+  id: string;
+  session_key?: string;
+  title?: string;
+  status?: string;
+};
+
+type PendingRpc = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type ActiveTurn = {
+  sessionId: string;
+  queue: TextQueue;
+  sawDelta: boolean;
+};
+
+type TurnWaiter = {
+  resolve: (release: () => void) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+};
+
+export interface HermesGatewayBrainConfig {
+  /** Hermes `serve`/dashboard JSON-RPC WebSocket URL, including its credential. */
+  url: string;
+  /** Exact live-session title, durable session key, or gateway-local live id. */
+  session: string;
+  autoApproveTools?: boolean;
+  connectTimeoutMs?: number;
+  turnTimeoutMs?: number;
+  maxResponseBytes?: number;
+  socketFactory?: (url: string) => WebSocket;
+}
+
+class TextQueue {
+  private chunks: Array<string | null> = [];
+  private wake: (() => void) | null = null;
+  private ended = false;
+  private error: Error | null = null;
+  private bytes = 0;
+
+  constructor(private readonly limitBytes: number) {}
+
+  push(text: string): void {
+    if (this.ended || !text) return;
+    const bytes = UTF8.encode(text).byteLength;
+    if (bytes > this.limitBytes - this.bytes) {
+      this.end(new Error(`Hermes gateway stream queue exceeded ${this.limitBytes} bytes`));
+      return;
+    }
+    this.chunks.push(text);
+    this.bytes += bytes;
+    this.signal();
+  }
+
+  end(error?: Error): void {
+    if (this.ended) return;
+    this.ended = true;
+    this.error = error ?? null;
+    this.signal();
+  }
+
+  async *drain(): AsyncGenerator<string> {
+    while (true) {
+      while (this.chunks.length > 0) {
+        const chunk = this.chunks.shift();
+        if (chunk) {
+          this.bytes -= UTF8.encode(chunk).byteLength;
+          yield chunk;
+        }
+      }
+      if (this.ended) {
+        if (this.error) throw this.error;
+        return;
+      }
+      await new Promise<void>((resolve) => { this.wake = resolve; });
+    }
+  }
+
+  private signal(): void {
+    const wake = this.wake;
+    this.wake = null;
+    wake?.();
+  }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function abortError(): Error {
+  return new DOMException("Aborted", "AbortError");
+}
+
+function validateGatewayUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("brain.gateway_url must be a valid WebSocket URL");
+  }
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error("brain.gateway_url must use ws:// or wss://");
+  }
+  const loopback = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+  if (url.protocol === "ws:" && !loopback.has(url.hostname)) {
+    throw new Error("brain.gateway_url must use wss:// outside the local machine");
+  }
+  return url.toString();
+}
+
+/** Drive an already-live Hermes TUI Gateway session without creating an agent. */
+export class HermesGatewayBrain implements Brain {
+  private readonly url: string;
+  private readonly selector: string;
+  private readonly autoApproveTools: boolean;
+  private readonly connectTimeoutMs: number;
+  private readonly turnTimeoutMs: number;
+  private readonly maxResponseBytes: number;
+  private readonly socketFactory: (url: string) => WebSocket;
+  private readonly turnContext = new BrainTurnContext();
+  private socket: WebSocket | null = null;
+  private sessionId: string | null = null;
+  private nextRequestId = 0;
+  private readonly pending = new Map<number, PendingRpc>();
+  private activeTurn: ActiveTurn | null = null;
+  private turnHeld = false;
+  private readonly turnWaiters: TurnWaiter[] = [];
+
+  constructor(config: HermesGatewayBrainConfig) {
+    this.url = validateGatewayUrl(config.url);
+    this.selector = config.session.trim();
+    if (!this.selector) throw new Error("brain.session is required for hermes-gateway");
+    this.autoApproveTools = config.autoApproveTools ?? false;
+    this.connectTimeoutMs = config.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    this.turnTimeoutMs = config.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
+    this.maxResponseBytes = config.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+    this.socketFactory = config.socketFactory ?? ((url) => new WebSocket(url));
+  }
+
+  async start(): Promise<void> {
+    await this.ensureAttached();
+    log("info", `Brain (hermes-gateway) attached to live session '${this.selector}'`);
+  }
+
+  async stop(): Promise<void> {
+    const turn = this.activeTurn;
+    if (turn) await this.interrupt();
+    this.activeTurn = null;
+    turn?.queue.end(new Error("Hermes gateway stopped"));
+    this.rejectPending(new Error("Hermes gateway stopped"));
+    this.rejectTurnWaiters(new Error("Hermes gateway stopped"));
+    const socket = this.socket;
+    this.socket = null;
+    this.sessionId = null;
+    socket?.close();
+  }
+
+  async send(message: string, options?: BrainTurnOptions): Promise<string> {
+    let output = "";
+    let bytes = 0;
+    for await (const chunk of this.sendStream(message, options)) {
+      bytes += UTF8.encode(chunk).byteLength;
+      if (bytes > this.maxResponseBytes) {
+        await this.interrupt();
+        throw new Error(`Hermes gateway response exceeded ${this.maxResponseBytes} bytes`);
+      }
+      output += chunk;
+    }
+    return output.trim();
+  }
+
+  async *sendStream(message: string, options?: BrainTurnOptions): AsyncGenerator<string> {
+    const release = await this.reserveTurn(options?.signal);
+    const queue = new TextQueue(this.maxResponseBytes);
+    let abortListener: (() => void) | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const live = await this.ensureAttached();
+      if (options?.signal?.aborted) throw abortError();
+      if (live.status === "working" || live.status === "waiting") {
+        throw new Error(`Hermes live session '${this.selector}' is ${live.status}`);
+      }
+      const sessionId = this.sessionId!;
+      this.activeTurn = { sessionId, queue, sawDelta: false };
+
+      abortListener = () => {
+        queue.end(abortError());
+        void this.interrupt();
+      };
+      options?.signal?.addEventListener("abort", abortListener, { once: true });
+      timeout = setTimeout(() => {
+        queue.end(new Error(`Hermes gateway turn timed out after ${this.turnTimeoutMs}ms`));
+        void this.interrupt();
+      }, this.turnTimeoutMs);
+
+      const prompt = this.turnContext.buildTextPrompt(message, false);
+      const accepted = await this.request<{ status?: string }>("prompt.submit", {
+        session_id: sessionId,
+        text: prompt,
+      });
+      if (accepted.status === "queued") {
+        await this.interrupt();
+        throw new Error("Hermes live session became busy before the voice turn started");
+      }
+
+      for await (const chunk of queue.drain()) yield chunk;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") throw error;
+      throw new Error(`hermes-gateway brain turn failed: ${asError(error).message}`, { cause: error });
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      if (abortListener) options?.signal?.removeEventListener("abort", abortListener);
+      if (this.activeTurn?.queue === queue) this.activeTurn = null;
+      release();
+    }
+  }
+
+  injectContext(context: string): void {
+    this.turnContext.inject(context);
+  }
+
+  async restart(): Promise<void> {
+    this.turnContext.clear();
+    await this.stop();
+    await this.start();
+  }
+
+  async health(): Promise<boolean> {
+    try {
+      await this.ensureAttached();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async ensureAttached(): Promise<ActiveSession> {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) await this.connect();
+    const result = await this.request<{ sessions?: ActiveSession[] }>("session.active_list");
+    const sessions = result.sessions ?? [];
+    if (this.sessionId) {
+      const attached = sessions.find((session) => session.id === this.sessionId);
+      if (attached) return attached;
+      this.sessionId = null;
+    }
+    const selected = this.selectSession(sessions);
+    await this.request("session.activate", { session_id: selected.id });
+    this.sessionId = selected.id;
+    return selected;
+  }
+
+  private selectSession(sessions: ActiveSession[]): ActiveSession {
+    const exact = sessions.filter((session) =>
+      session.id === this.selector
+      || session.session_key === this.selector
+      || session.title === this.selector);
+    if (exact.length === 1) return exact[0];
+    if (exact.length > 1) throw new Error(`multiple live Hermes sessions match '${this.selector}'`);
+
+    const folded = this.selector.toLocaleLowerCase();
+    const insensitive = sessions.filter((session) => session.title?.toLocaleLowerCase() === folded);
+    if (insensitive.length === 1) return insensitive[0];
+    const available = sessions
+      .map((session) => session.title || session.session_key || session.id)
+      .filter(Boolean)
+      .join(", ");
+    throw new Error(
+      `live Hermes session '${this.selector}' was not found`
+      + (available ? `; active sessions: ${available}` : "; no sessions are active in that gateway"),
+    );
+  }
+
+  private async connect(): Promise<void> {
+    this.rejectPending(new Error("Hermes gateway reconnecting"));
+    this.socket?.close();
+    this.sessionId = null;
+    const socket = this.socketFactory(this.url);
+    this.socket = socket;
+    socket.addEventListener("message", (event) => this.onMessage(event.data));
+    socket.addEventListener("close", () => {
+      if (this.socket !== socket) return;
+      this.socket = null;
+      this.sessionId = null;
+      const error = new Error("Hermes gateway connection closed");
+      this.rejectPending(error);
+      this.activeTurn?.queue.end(error);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => finish(new Error("Hermes gateway connection timed out")), this.connectTimeoutMs);
+      const finish = (error?: Error): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        socket.removeEventListener("open", onOpen);
+        socket.removeEventListener("error", onError);
+        socket.removeEventListener("close", onClose);
+        if (error) reject(error); else resolve();
+      };
+      const onOpen = () => finish();
+      const onError = () => finish(new Error("Hermes gateway connection failed"));
+      const onClose = () => finish(new Error("Hermes gateway connection closed during startup"));
+      socket.addEventListener("open", onOpen, { once: true });
+      socket.addEventListener("error", onError, { once: true });
+      socket.addEventListener("close", onClose, { once: true });
+    });
+  }
+
+  private request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("Hermes gateway is not connected"));
+    }
+    const id = ++this.nextRequestId;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Hermes gateway request timed out: ${method}`));
+      }, this.connectTimeoutMs);
+      this.pending.set(id, { resolve: (value) => resolve(value as T), reject, timer });
+      try {
+        socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(asError(error));
+      }
+    });
+  }
+
+  private onMessage(raw: unknown): void {
+    let frame: GatewayFrame;
+    try {
+      const text = typeof raw === "string" ? raw : new TextDecoder().decode(raw as ArrayBuffer);
+      const frameBytes = typeof raw === "string" ? UTF8.encode(raw).byteLength : (raw as ArrayBuffer).byteLength;
+      if (frameBytes > MAX_GATEWAY_FRAME_BYTES) {
+        this.activeTurn?.queue.end(new Error(`Hermes gateway frame exceeded ${MAX_GATEWAY_FRAME_BYTES} bytes`));
+        this.socket?.close();
+        return;
+      }
+      frame = JSON.parse(text) as GatewayFrame;
+    } catch {
+      return;
+    }
+    if (frame.id !== undefined) {
+      const pending = this.pending.get(frame.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(frame.id);
+      if (frame.error) pending.reject(new Error(frame.error.message || "Hermes gateway request failed"));
+      else pending.resolve(frame.result);
+      return;
+    }
+    if (frame.method !== "event" || !frame.params?.type) return;
+    const event = frame.params;
+    const turn = this.activeTurn;
+    if (!turn || event.session_id !== turn.sessionId) return;
+    const payload = event.payload ?? {};
+    if (event.type === "message.delta") {
+      turn.sawDelta = true;
+      turn.queue.push(String(payload.text ?? ""));
+    } else if (event.type === "message.complete") {
+      const status = String(payload.status ?? "complete");
+      if (status === "error") turn.queue.end(new Error(String(payload.text ?? "Hermes turn failed")));
+      else if (status === "interrupted") turn.queue.end(new Error("Hermes turn was interrupted"));
+      else {
+        if (!turn.sawDelta) turn.queue.push(String(payload.text ?? ""));
+        turn.queue.end();
+      }
+    } else if (event.type === "error") {
+      turn.queue.end(new Error(String(payload.message ?? "Hermes gateway turn failed")));
+    } else if (event.type === "approval.request") {
+      void this.request("approval.respond", {
+        session_id: turn.sessionId,
+        choice: this.autoApproveTools ? "once" : "deny",
+      }).catch((error) => turn.queue.end(asError(error)));
+    } else if (event.type === "clarify.request" || event.type === "sudo.request" || event.type === "secret.request") {
+      turn.queue.end(new Error(`Hermes requested interactive input (${event.type}) that Cicero cannot collect in-band`));
+      void this.interrupt();
+    }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private async interrupt(): Promise<void> {
+    if (!this.sessionId || !this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    await this.request("session.interrupt", { session_id: this.sessionId }).catch(() => undefined);
+  }
+
+  private async reserveTurn(signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) throw abortError();
+    if (!this.turnHeld) {
+      this.turnHeld = true;
+      return this.turnRelease();
+    }
+    return new Promise<() => void>((resolve, reject) => {
+      const waiter: TurnWaiter = { resolve, reject, signal };
+      if (signal) {
+        waiter.onAbort = () => {
+          const index = this.turnWaiters.indexOf(waiter);
+          if (index >= 0) this.turnWaiters.splice(index, 1);
+          reject(abortError());
+        };
+        signal.addEventListener("abort", waiter.onAbort, { once: true });
+      }
+      this.turnWaiters.push(waiter);
+    });
+  }
+
+  private turnRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      while (this.turnWaiters.length > 0) {
+        const waiter = this.turnWaiters.shift()!;
+        if (waiter.onAbort) waiter.signal?.removeEventListener("abort", waiter.onAbort);
+        if (waiter.signal?.aborted) {
+          waiter.reject(abortError());
+          continue;
+        }
+        waiter.resolve(this.turnRelease());
+        return;
+      }
+      this.turnHeld = false;
+    };
+  }
+
+  private rejectTurnWaiters(error: Error): void {
+    for (const waiter of this.turnWaiters.splice(0)) {
+      if (waiter.onAbort) waiter.signal?.removeEventListener("abort", waiter.onAbort);
+      waiter.reject(error);
+    }
+  }
+}

--- a/src/brain/index.ts
+++ b/src/brain/index.ts
@@ -8,6 +8,7 @@ import { OllamaBrain } from "./ollama";
 import { OpenAiCompatibleBrain } from "./openai-compatible";
 import { TabInjectBrain } from "./tab-inject";
 import { AcpBrain } from "./acp";
+import { HermesGatewayBrain } from "./hermes-gateway";
 import { FallbackBrain } from "./fallback";
 import { RoutingBrain } from "./routing";
 import { SwitchboardBrain, type LaneDef } from "./switchboard";
@@ -86,7 +87,7 @@ export function createBrain(config: RuntimeConfig, terminal?: TerminalAdapter, h
 }
 
 function buildBrain(config: RuntimeConfig, terminal?: TerminalAdapter, hooks: BrainHooks = {}): Brain {
-  const { backend, mode, target_tab, auto_approve_tools, confirm_tools, confirm_retry, max_queue_bytes, max_response_bytes, max_pending_turns, binary, binary_args, ollama_port, ollama_model, base_url, model, api_key, api_key_env, max_tokens, timeout_ms, unset_env, headers, session_header } = config.brain;
+  const { backend, mode, target_tab, auto_approve_tools, confirm_tools, confirm_retry, max_queue_bytes, max_response_bytes, max_pending_turns, binary, binary_args, ollama_port, ollama_model, base_url, model, api_key, api_key_env, max_tokens, timeout_ms, unset_env, headers, session_header, gateway_url, gateway_url_env, session } = config.brain;
   const onConfirmationPending = config.notify?.telegram
     ? async (summary: string, nonce: string): Promise<void> => {
         try {
@@ -207,6 +208,24 @@ function buildBrain(config: RuntimeConfig, terminal?: TerminalAdapter, hooks: Br
       return new SwitchboardBrain(front, lanes, summarizerClassifier(config.raw.web_voice?.tldr));
     }
     return front;
+  }
+
+  if (backend === "hermes-gateway") {
+    const url = gateway_url ?? (gateway_url_env ? process.env[gateway_url_env] : undefined);
+    if (!url) {
+      throw new Error(
+        gateway_url_env
+          ? `brain.gateway_url_env points to unset environment variable '${gateway_url_env}'`
+          : "brain.gateway_url or brain.gateway_url_env is required for hermes-gateway",
+      );
+    }
+    return new HermesGatewayBrain({
+      url,
+      session: session ?? "",
+      autoApproveTools: auto_approve_tools,
+      turnTimeoutMs: timeout_ms,
+      maxResponseBytes: max_response_bytes,
+    });
   }
 
   switch (backend) {

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -334,6 +334,7 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
       "binary", "binary_args", "ollama_port", "ollama_model",
       "base_url", "model", "api_key", "api_key_env", "max_tokens", "timeout_ms", "turn_timeout_ms",
       "headers", "session_header", "narrate_progress", "unset_env", "agent_first", "thinking_filler",
+      "gateway_url", "gateway_url_env", "session",
     ], issues);
     checkString(config.brain.backend, "brain.backend", issues);
     if (config.brain.mode !== "subprocess" && config.brain.mode !== "tab-inject") {
@@ -379,6 +380,35 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     }
     checkOptionalInteger(config.brain, "max_tokens", "brain", issues, { min: 1 });
     if (config.brain.headers !== undefined) checkStringRecord(config.brain.headers, "brain.headers", issues);
+    for (const key of ["gateway_url_env", "session"] as const) {
+      if (config.brain[key] !== undefined) checkString(config.brain[key], `brain.${key}`, issues);
+    }
+    if (config.brain.gateway_url !== undefined) {
+      if (typeof config.brain.gateway_url !== "string") {
+        issues.push("brain.gateway_url must be a valid WebSocket URL");
+      } else {
+        try {
+          const url = new URL(config.brain.gateway_url);
+          if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+            issues.push("brain.gateway_url must use ws:// or wss://");
+          }
+          const loopback = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+          if (url.protocol === "ws:" && !loopback.has(url.hostname)) {
+            issues.push("brain.gateway_url must use wss:// outside the local machine");
+          }
+        } catch {
+          issues.push("brain.gateway_url must be a valid WebSocket URL");
+        }
+      }
+    }
+    if (config.brain.backend === "hermes-gateway") {
+      if (config.brain.gateway_url === undefined && config.brain.gateway_url_env === undefined) {
+        issues.push("brain.gateway_url or brain.gateway_url_env is required for hermes-gateway");
+      }
+      if (config.brain.session === undefined) {
+        issues.push("brain.session is required for hermes-gateway");
+      }
+    }
 
     const validateAgent = (value: unknown, path: string, allowMetadata: boolean): void => {
       if (!checkRecord(value, path, issues)) return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -534,7 +534,7 @@ export function loadConfig(flags: CLIFlags = {}, opts: { home?: string } = {}): 
   if (flags.tts !== undefined) config.tts_enabled = flags.tts;
   if (flags.wakeWord !== undefined) config.wake_word_enabled = flags.wakeWord;
   if (flags.brain) {
-    const VALID_BRAINS = ["claude-code", "codex", "gemini", "qwen", "ollama", "acp"] as const;
+    const VALID_BRAINS = ["claude-code", "codex", "gemini", "qwen", "ollama", "acp", "hermes-gateway"] as const;
     if (!(VALID_BRAINS as readonly string[]).includes(flags.brain)) {
       throw new Error(`Invalid --brain value '${flags.brain}'. Valid: ${VALID_BRAINS.join(", ")}`);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,7 +243,7 @@ export interface BrainConfig {
   // CLI agents run tools/edit files; "ollama" and "openai-compatible" (plus any
   // OpenAI preset like "openrouter") answer with a model only. `(string & {})`
   // keeps literal autocomplete while allowing preset names.
-  backend: "claude-code" | "codex" | "gemini" | "qwen" | "ollama" | "openai-compatible" | "acp" | (string & {});
+  backend: "claude-code" | "codex" | "gemini" | "qwen" | "ollama" | "openai-compatible" | "acp" | "hermes-gateway" | (string & {});
   mode: "subprocess" | "tab-inject"; // subprocess = claude --print, tab-inject = inject into existing tab
   target_tab?: string; // tab title to inject into (for tab-inject mode)
   auto_approve_tools?: boolean; // tab-inject: true bypasses checks; false uses Claude's auto permission mode
@@ -298,6 +298,12 @@ export interface BrainConfig {
   // Header name under which to send a per-session id (generated once at startup) so a
   // stateful agent keeps memory across turns — Hermes uses "X-Hermes-Session-Id".
   session_header?: string;
+  // Hermes TUI Gateway: attach to an existing live TUI/desktop session instead
+  // of spawning a separate ACP agent. Prefer gateway_url_env when the URL
+  // contains a dashboard token.
+  gateway_url?: string;
+  gateway_url_env?: string;
+  session?: string; // exact live title, durable session key, or gateway-local live id
   // When the brain supports it (e.g. codex, claude-code), speak a running summary
   // of what the agent is doing (commands, steps, final answer), not just the answer.
   narrate_progress?: boolean; // default true

--- a/tests/brain-factory.test.ts
+++ b/tests/brain-factory.test.ts
@@ -12,6 +12,7 @@ import { TabInjectBrain } from "../src/brain/tab-inject";
 import { KittyAdapter } from "../src/terminal/kitty";
 import { NullTerminalAdapter } from "../src/terminal/null";
 import { SwitchboardBrain } from "../src/brain/switchboard";
+import { HermesGatewayBrain } from "../src/brain/hermes-gateway";
 
 function cfg(
   backend: CiceroConfig["brain"]["backend"],
@@ -52,6 +53,12 @@ test("factory returns OpenAiCompatibleBrain for openai-compatible (local / Herme
 });
 test("factory returns OpenAiCompatibleBrain for an OpenAI preset (openrouter)", () => {
   expect(createBrain(cfg("openrouter", { model: "z-ai/glm-4.6", api_key: "k" }))).toBeInstanceOf(OpenAiCompatibleBrain);
+});
+test("factory returns HermesGatewayBrain for an existing live Hermes session", () => {
+  expect(createBrain(cfg("hermes-gateway", {
+    gateway_url: "ws://127.0.0.1:9119/api/ws?token=test",
+    session: "main",
+  }))).toBeInstanceOf(HermesGatewayBrain);
 });
 test("factory passes binary_args + unset_env to claude-code", () => {
   const brain = createBrain(cfg("claude-code", { binary_args: ["--dangerously-skip-permissions"], unset_env: ["ANTHROPIC_API_KEY"] }));

--- a/tests/brain/hermes-gateway.test.ts
+++ b/tests/brain/hermes-gateway.test.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "bun:test";
+import { HermesGatewayBrain } from "../../src/brain/hermes-gateway";
+
+type RequestFrame = {
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+};
+
+class FakeGatewaySocket extends EventTarget {
+  readyState = WebSocket.CONNECTING;
+  readonly requests: RequestFrame[] = [];
+
+  constructor(
+    private readonly onRequest: (request: RequestFrame, socket: FakeGatewaySocket) => void,
+    autoOpen = true,
+  ) {
+    super();
+    if (autoOpen) {
+      queueMicrotask(() => {
+        this.readyState = WebSocket.OPEN;
+        this.dispatchEvent(new Event("open"));
+      });
+    }
+  }
+
+  send(raw: string): void {
+    const request = JSON.parse(raw) as RequestFrame;
+    this.requests.push(request);
+    this.onRequest(request, this);
+  }
+
+  close(): void {
+    if (this.readyState === WebSocket.CLOSED) return;
+    this.readyState = WebSocket.CLOSED;
+    this.dispatchEvent(new CloseEvent("close"));
+  }
+
+  respond(request: RequestFrame, result: unknown): void {
+    this.frame({ jsonrpc: "2.0", id: request.id, result });
+  }
+
+  event(type: string, sessionId: string, payload: Record<string, unknown> = {}): void {
+    this.frame({
+      jsonrpc: "2.0",
+      method: "event",
+      params: { type, session_id: sessionId, payload },
+    });
+  }
+
+  private frame(frame: unknown): void {
+    queueMicrotask(() => this.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(frame) })));
+  }
+}
+
+function liveSession() {
+  return { id: "live-1", session_key: "20260715_main", title: "main", status: "idle" };
+}
+
+test("attaches to the named live Hermes session and streams its real agent reply", async () => {
+  let prompt = "";
+  let activeLists = 0;
+  let socket!: FakeGatewaySocket;
+  socket = new FakeGatewaySocket((request, peer) => {
+    if (request.method === "session.active_list") {
+      activeLists++;
+      peer.respond(request, {
+        sessions: [{ ...liveSession(), title: activeLists === 1 ? "main" : "auto-generated title" }],
+      });
+    } else if (request.method === "session.activate") peer.respond(request, { session_id: "live-1" });
+    else if (request.method === "prompt.submit") {
+      prompt = String(request.params.text);
+      peer.respond(request, { status: "streaming" });
+      peer.event("message.delta", "live-1", { text: "same " });
+      peer.event("message.delta", "live-1", { text: "agent" });
+      peer.event("message.complete", "live-1", { text: "same agent", status: "complete" });
+    }
+  });
+  const brain = new HermesGatewayBrain({
+    url: "ws://127.0.0.1:9119/api/ws?token=secret",
+    session: "main",
+    socketFactory: () => socket as unknown as WebSocket,
+  });
+
+  await brain.start();
+  brain.injectContext("The voice user is looking at the deploy screen.");
+  expect(await brain.send("what changed?")).toBe("same agent");
+  expect(prompt).toContain("The voice user is looking at the deploy screen.");
+  expect(prompt).toContain("what changed?");
+  expect(socket.requests.filter((request) => request.method === "session.create")).toHaveLength(0);
+  expect(socket.requests.filter((request) => request.method === "session.activate")).toHaveLength(1);
+  expect(socket.requests.find((request) => request.method === "prompt.submit")?.params.session_id).toBe("live-1");
+});
+
+test("fails closed instead of creating a standalone session when the selector misses", async () => {
+  const socket = new FakeGatewaySocket((request, peer) => {
+    if (request.method === "session.active_list") peer.respond(request, { sessions: [liveSession()] });
+  });
+  const brain = new HermesGatewayBrain({
+    url: "ws://127.0.0.1:9119/api/ws?token=secret",
+    session: "other",
+    socketFactory: () => socket as unknown as WebSocket,
+  });
+
+  await expect(brain.start()).rejects.toThrow(/live Hermes session 'other' was not found.*main/);
+  expect(socket.requests.some((request) => request.method === "session.create")).toBe(false);
+});
+
+test("fails immediately when the gateway closes during startup", async () => {
+  const socket = new FakeGatewaySocket(() => undefined, false);
+  queueMicrotask(() => socket.close());
+  const brain = new HermesGatewayBrain({
+    url: "ws://127.0.0.1:9119/api/ws?token=secret",
+    session: "main",
+    connectTimeoutMs: 1_000,
+    socketFactory: () => socket as unknown as WebSocket,
+  });
+
+  await expect(brain.start()).rejects.toThrow("Hermes gateway connection closed during startup");
+});
+
+test("resolves Hermes approval requests on the attached session", async () => {
+  const socket = new FakeGatewaySocket((request, peer) => {
+    if (request.method === "session.active_list") peer.respond(request, { sessions: [liveSession()] });
+    else if (request.method === "session.activate") peer.respond(request, {});
+    else if (request.method === "prompt.submit") {
+      peer.respond(request, { status: "streaming" });
+      peer.event("approval.request", "live-1", { command: "git status" });
+    } else if (request.method === "approval.respond") {
+      peer.respond(request, { resolved: true });
+      peer.event("message.complete", "live-1", { text: "done", status: "complete" });
+    }
+  });
+  const brain = new HermesGatewayBrain({
+    url: "ws://127.0.0.1:9119/api/ws?token=secret",
+    session: "main",
+    autoApproveTools: true,
+    socketFactory: () => socket as unknown as WebSocket,
+  });
+
+  await brain.start();
+  expect(await brain.send("check it")).toBe("done");
+  expect(socket.requests.find((request) => request.method === "approval.respond")?.params).toEqual({
+    session_id: "live-1",
+    choice: "once",
+  });
+});
+
+test("does not interrupt or queue behind a TUI turn that is already running", async () => {
+  const socket = new FakeGatewaySocket((request, peer) => {
+    if (request.method === "session.active_list") {
+      peer.respond(request, { sessions: [{ ...liveSession(), status: "working" }] });
+    } else if (request.method === "session.activate") peer.respond(request, {});
+  });
+  const brain = new HermesGatewayBrain({
+    url: "ws://127.0.0.1:9119/api/ws?token=secret",
+    session: "main",
+    socketFactory: () => socket as unknown as WebSocket,
+  });
+
+  await brain.start();
+  await expect(brain.send("voice turn")).rejects.toThrow(/session 'main' is working/);
+  expect(socket.requests.some((request) => request.method === "prompt.submit")).toBe(false);
+  expect(socket.requests.some((request) => request.method === "session.interrupt")).toBe(false);
+});
+
+test("interrupts only the attached Hermes turn when cancelled", async () => {
+  const socket = new FakeGatewaySocket((request, peer) => {
+    if (request.method === "session.active_list") peer.respond(request, { sessions: [liveSession()] });
+    else if (request.method === "session.activate") peer.respond(request, {});
+    else if (request.method === "prompt.submit") peer.respond(request, { status: "streaming" });
+    else if (request.method === "session.interrupt") peer.respond(request, { status: "interrupted" });
+  });
+  const brain = new HermesGatewayBrain({
+    url: "ws://127.0.0.1:9119/api/ws?token=secret",
+    session: "main",
+    socketFactory: () => socket as unknown as WebSocket,
+  });
+  await brain.start();
+  const controller = new AbortController();
+  const turn = brain.send("keep going", { signal: controller.signal });
+  await Bun.sleep(0);
+  controller.abort();
+
+  await expect(turn).rejects.toThrow(/Aborted/);
+  await Bun.sleep(0);
+  expect(socket.requests.find((request) => request.method === "session.interrupt")?.params.session_id).toBe("live-1");
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -51,9 +51,10 @@ describe("Config — default values", () => {
     expect(config.terminal).toBe("auto");
   });
 
-  test("CLI --brain flag accepts qwen and ollama", () => {
+  test("CLI --brain flag accepts qwen, ollama, and hermes-gateway", () => {
     expect(loadConfig({ brain: "qwen" }).brain.backend).toBe("qwen");
     expect(loadConfig({ brain: "ollama" }).brain.backend).toBe("ollama");
+    expect(() => loadConfig({ brain: "hermes-gateway" })).toThrow(/brain\.gateway_url or brain\.gateway_url_env is required/);
   });
 
   test("CLI --brain flag rejects invalid backends", () => {
@@ -465,6 +466,29 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))).toThrow(
       /brain\.max_queue_bytes must be an integer[\s\S]*brain\.max_response_bytes must be an integer[\s\S]*brain\.max_pending_turns must be an integer/,
     );
+  });
+
+  test("requires an explicit live session and gateway endpoint for hermes-gateway", () => {
+    expect(loadYaml("brain:\n  backend: hermes-gateway\n")).toThrow(
+      /brain\.gateway_url or brain\.gateway_url_env is required[\s\S]*brain\.session is required/,
+    );
+  });
+
+  test("accepts a loopback Hermes gateway URL and rejects plaintext remote credentials", () => {
+    expect(loadYaml([
+      "brain:",
+      "  backend: hermes-gateway",
+      "  gateway_url: ws://127.0.0.1:9119/api/ws?token=test",
+      "  session: main",
+      "",
+    ].join("\n"))().brain.backend).toBe("hermes-gateway");
+    expect(loadYaml([
+      "brain:",
+      "  backend: hermes-gateway",
+      "  gateway_url: ws://hermes.example.com/api/ws?token=test",
+      "  session: main",
+      "",
+    ].join("\n"))).toThrow(/brain\.gateway_url must use wss:\/\/ outside the local machine/);
   });
 
   test("rejects a non-string inline provider API key before doctor can inspect it", () => {


### PR DESCRIPTION
## Summary

- add a `hermes-gateway` brain that selects and activates an existing Hermes TUI Gateway session instead of spawning an isolated ACP agent
- stream replies from that exact live agent while preserving cancellation, bounded queues/frames, busy-session protection, and explicit approval handling
- add configuration validation, factory wiring, focused regressions, and operator documentation

The adapter deliberately never calls `session.create`: a missing or ambiguous selector fails closed.

## Verification

- `bunx bun@1.3.14 test tests/brain/hermes-gateway.test.ts tests/brain-factory.test.ts tests/config.test.ts`
- `bunx bun@1.3.14 run typecheck`
- `bunx bun@1.3.14 test` — 1,847 passed, 5 skipped, 0 failed
- `git diff --check`
- live loopback attach smoke against a temporary `hermes serve` backend (disposable session, no model turn)

## Integration note

Cicero and the Hermes terminal TUI must connect to the same long-lived `hermes serve` backend. Current Hermes releases expose that TUI attach path through `HERMES_TUI_GATEWAY_URL`, but Hermes documents it as internal wiring today; making that a first-class Hermes CLI option is a sensible companion upstream change. Hermes also routes a session stream to the client that most recently activates/submits it, so a voice turn is persisted to shared history but the terminal TUI may need a session redraw afterward.