### PR TITLE
feat(notify): durable morning-briefing catch-up + non-consuming overnight store

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -236,9 +236,10 @@ notify:
   # timezone: America/New_York
   # No pings overnight — notifications queue up for the morning briefing:
   # quiet_hours: { from: "23:00", to: "08:00" }
-  # Daily digest of the deferred news + board state, texted to the phone;
+  # Daily digest of the deferred news + board state, texted to the phone.
+  # A restart catches up for 180 minutes by default (0 = exact minute only);
   # call: true also rings you and speaks it (needs the Telegram call sidecar):
-  # briefing: { at: "08:00", call: false }
+  # briefing: { at: "08:00", call: false, catch_up_minutes: 180 }
   # Text short call notes to the phone after a voice session goes quiet
   # (only for calls longer than min_minutes; default 3):
   # call_minutes: { min_minutes: 3 }

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -99,13 +99,16 @@ Four `notify:` options turn the office into something that manages the flow of i
 notify:
   timezone: America/New_York                   # IANA zone — quiet_hours and briefing.at are read in THIS zone
   quiet_hours: { from: "23:00", to: "08:00" }  # no pings overnight — news queues up
-  briefing: { at: "08:00", call: true }        # daily digest: deferred news + board state
+  briefing:                                      # daily digest: deferred news + board state
+    at: "08:00"
+    call: true
+    catch_up_minutes: 180                        # restart catch-up window; 0 = exact-minute only
   call_minutes: { min_minutes: 3 }             # notes texted after calls longer than 3 minutes
 ```
 
 - **Timezone** — set it if the box's clock isn't your local time (a UTC server will otherwise happily ring you at 4am). Bad zone names fail loudly at startup.
 - **Quiet hours** — notifications inside the window don't ping anything; they queue (persisted across restarts) for the briefing.
-- **Morning briefing** — at the set time, the queued news plus the board's blocked/review items arrive as one Telegram text. With `call: true`, Cicero also *rings your phone* and reads it to you.
+- **Morning briefing** — at the set time, the queued news plus the board's blocked/review items arrive as one Telegram text. If Cicero starts late, it catches up within `catch_up_minutes` (default 180); `0` preserves exact-minute-only behavior. A durable daily claim in `~/.cicero/briefing-status.json` prevents restart loops from sending twice. Quiet hours delay the attempt only while the catch-up window remains open. With `call: true`, Cicero also *rings your phone* and reads it to you. Deferred items stay queued unless at least one delivery channel accepts the briefing.
 - **Call minutes** — a couple of minutes after a voice conversation goes quiet, the summarizer writes 2-4 lines of notes (what was asked, decided, done) and texts them to your phone. Like leaving a meeting and finding the minutes in your inbox.
 
 ## Scheduled prompts: daily briefs the brain writes

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -690,8 +690,9 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
       checkClockTime(config.notify.quiet_hours.to, "notify.quiet_hours.to", issues);
     }
     if (isRecord(config.notify.briefing)) {
-      checkKnownKeys(config.notify.briefing, "notify.briefing", ["at", "call"], issues);
+      checkKnownKeys(config.notify.briefing, "notify.briefing", ["at", "call", "catch_up_minutes"], issues);
       checkClockTime(config.notify.briefing.at, "notify.briefing.at", issues);
+      checkOptionalInteger(config.notify.briefing, "catch_up_minutes", "notify.briefing", issues, { min: 0, max: 720 });
     }
     if (config.notify.schedules !== undefined) {
       if (!Array.isArray(config.notify.schedules)) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -59,8 +59,14 @@ import { TurnHistory } from "./web-voice/history";
 import { classifyCallIntent, sendTelegramVoice, sendTelegramText, startTelegramUpdatePoller } from "./notify/telegram";
 import { notificationTurnContext } from "./notify/context";
 import { KanbanWatcher, listViaCli, nudgeLine, spokenLine, taskLinkViaCli, type KanbanTask } from "./notify/kanban-watch";
-import { inQuietHours, composeBriefing, composeBriefingDigest, minutesPrompt, worthMinutes, callMinutesThresholdMs, parseHm, hmOf, dayOf } from "./notify/briefing";
+import { inQuietHours, composeBriefing, composeBriefingDigest, minutesPrompt, worthMinutes, callMinutesThresholdMs, dayOf } from "./notify/briefing";
 import { PromptScheduler, scheduleLabel } from "./notify/schedules";
+import {
+  BriefingScheduler,
+  BriefingStatusStore,
+  type BriefingRunResult,
+} from "./notify/briefing-scheduler";
+import { OvernightStore } from "./notify/overnight-store";
 import { sendUnattended } from "./brain/capabilities";
 import { buildResumePrimer, buildRosterNote } from "./web-voice/resume";
 import { HealthStore, briefLine } from "./health/store";
@@ -110,6 +116,30 @@ export function createRecordedWebTurn(
     aborted: () => sink.aborted(),
   };
   return { sink: recordedSink, drain: () => persistence };
+}
+
+export async function recordParkedBriefingVoiceOutcome(
+  signal: AbortSignal,
+  channels: NonNullable<BriefingRunResult["channels"]>,
+  writeCallback: () => Promise<unknown>,
+): Promise<void> {
+  if (signal.aborted) {
+    channels.voice = "aborted";
+    channels.callback = "aborted";
+    return;
+  }
+  try {
+    await writeCallback();
+    if (signal.aborted) {
+      channels.voice = "aborted";
+      channels.callback = "aborted";
+      return;
+    }
+    channels.callback = "accepted";
+  } catch {
+    channels.callback = signal.aborted ? "aborted" : "failed";
+    if (signal.aborted) channels.voice = "aborted";
+  }
 }
 import { createAudioPlayer, createAudioRecorder } from "./platform/audio";
 import { AecAudioHub, aecAvailable } from "./platform/aec-hub";
@@ -192,29 +222,16 @@ export class CiceroDaemon {
   private dashboard: DashboardHandle | null = null;
   private webVoice: WebVoiceHandle | null = null;
   private kanbanWatcher: KanbanWatcher | null = null;
-  private briefingTimer: ReturnType<typeof setInterval> | undefined;
+  private briefingScheduler: Pick<BriefingScheduler, "start" | "stop"> | null = null;
   private promptScheduler: PromptScheduler | null = null;
   private minutesTimer: ReturnType<typeof setTimeout> | undefined;
   private stopTelegramPoller: (() => void) | null = null;
   private pidLease: DaemonPidLease | null = null;
 
   /** Overnight queue for quiet-hours notifications, persisted across restarts. */
-  private overnightPath = join(homedir(), ".cicero", "overnight.json");
-  private async readOvernight(): Promise<string[]> {
-    try {
-      const arr = await Bun.file(this.overnightPath).json() as unknown;
-      return Array.isArray(arr) ? arr.filter((x): x is string => typeof x === "string") : [];
-    } catch { return []; }
-  }
-  private async deferOvernight(text: string): Promise<void> {
-    const q = await this.readOvernight();
-    q.push(text);
-    await Bun.write(this.overnightPath, JSON.stringify(q.slice(-40)));
-  }
-  private async takeOvernight(): Promise<string[]> {
-    const q = await this.readOvernight();
-    await Bun.write(this.overnightPath, "[]");
-    return q;
+  private overnightStore: OvernightStore | null = null;
+  private getOvernightStore(): OvernightStore {
+    return this.overnightStore ??= new OvernightStore();
   }
   /** Synthesize a notification clip: lane-or-raw voice resolution plus the
    * URL strip (bare links are for the text surfaces — the audio never reads
@@ -995,7 +1012,7 @@ export class CiceroDaemon {
             // the user is actively talking, quiet hours don't apply to them.
             const qh = this.config.notify?.quiet_hours;
             if (!opts?.urgent && qh && inQuietHours(new Date(), qh, this.config.notify?.timezone)) {
-              await this.deferOvernight(text);
+              await this.getOvernightStore().enqueue(text);
               if (opts?.signal?.aborted) return null;
               return null;
             }
@@ -1143,75 +1160,94 @@ export class CiceroDaemon {
           this.kanbanWatcher.start();
           log("ok", `📋 Kanban watch on — announcing task completions every ${kw.interval_seconds ?? 20}s`);
         }
-        // Morning briefing: once a day at notify.briefing.at, deliver the
-        // deferred overnight news + board state as a text — and, with
-        // call: true, ring the phone and speak it (same spool as callbacks).
+        // Morning briefing: durably claim the local day before looking up or
+        // delivering anything. A restart can catch up, but never double-send.
         const briefing = this.config.notify?.briefing;
         if (briefing?.at) {
-          parseHm(briefing.at); // validate at startup, not at 8am
           const webVoice = this.webVoice;
-          let lastFiredDay = "";
           const tz = this.config.notify?.timezone;
-          if (tz) hmOf(new Date(), tz); // bad IANA names throw here, at startup
-          this.briefingTimer = setInterval(() => {
-            const now = new Date();
-            const day = dayOf(now, tz);
-            if (hmOf(now, tz) !== briefing.at || lastFiredDay === day) return;
-            lastFiredDay = day;
-            void (async () => {
-              const signal = this.lifecycleAbort.signal;
-              if (signal.aborted) return;
+          const statusStore = new BriefingStatusStore();
+          this.briefingScheduler = new BriefingScheduler({
+            at: briefing.at,
+            catchUpMinutes: briefing.catch_up_minutes ?? 180,
+            timezone: tz,
+            quietHours: this.config.notify?.quiet_hours,
+            store: statusStore,
+            run: async (_trigger, signal, beforeDelivery): Promise<BriefingRunResult> => {
+              signal.throwIfAborted();
+              const overnightStore = this.getOvernightStore();
+              const snapshot = await overnightStore.peek();
+              signal.throwIfAborted();
+
               let board: KanbanTask[] | null = null;
-              const boardCommand = this.config.notify?.kanban?.enabled !== false ? this.config.notify?.kanban?.command : undefined;
+              const boardCommand = this.config.notify?.kanban?.enabled !== false
+                ? this.config.notify?.kanban?.command
+                : undefined;
               try {
                 if (boardCommand) board = await listViaCli(boardCommand, { signal });
               } catch {
-                if (signal.aborted) return;
+                signal.throwIfAborted();
                 // Board state is optional in the daily briefing.
               }
-              if (signal.aborted) return;
-              // Do not clear deferred overnight news until the cancellable
-              // external board lookup has completed.
-              const overnight = await this.takeOvernight();
-              if (signal.aborted) return;
-              // The health line: yesterday's logged metrics, silent on empty days.
+              signal.throwIfAborted();
+
               let health: string | null = null;
               try { health = briefLine(await healthStore.since(Date.now() - 24 * 60 * 60 * 1000)); } catch { /* record optional */ }
-              if (signal.aborted) return;
+              signal.throwIfAborted();
+              beforeDelivery();
+
+              const overnight = snapshot.map((item) => item.text);
+              const day = dayOf(new Date(), tz);
               const tg = this.config.notify?.telegram;
-              // Same data, two renderings: the glanceable digest for text, flat
-              // prose for the call (TTS reads dividers/bullets as garbage).
-              // The digest is ALWAYS the text — with call: true, the notify
-              // below suppresses its own Telegram mirror, which used to text
-              // the spoken rendering instead (seen live 2026-07-12: the digest
-              // never reached the phone on call-enabled configs).
-              if (tg) {
-                const text = composeBriefingDigest(overnight, board, health, day);
-                void sendTelegramText(tg, text).catch((error: unknown) => {
-                  if (!signal.aborted) {
-                    log("warn", `morning briefing Telegram send failed: ${error instanceof Error ? error.message : String(error)}`);
-                  }
-                });
+              const channels: NonNullable<BriefingRunResult["channels"]> = {};
+              const telegramDelivery = tg
+                ? sendTelegramText(tg, composeBriefingDigest(overnight, board, health, day), undefined, {}, signal)
+                    .then((accepted) => {
+                      channels.telegram = accepted && !signal.aborted
+                        ? "accepted"
+                        : signal.aborted ? "aborted" : "failed";
+                    })
+                    .catch(() => { channels.telegram = "failed"; })
+                : Promise.resolve();
+              const voiceDelivery = briefing.call
+                ? webVoice.notify(composeBriefing(overnight, board, health), undefined, {
+                    telegramMirror: false,
+                    signal,
+                  }).then(async (result) => {
+                    const accepted = result !== null && (result.delivered > 0 || result.parked);
+                    channels.voice = accepted ? "accepted" : "failed";
+                    if (result?.parked) {
+                      await recordParkedBriefingVoiceOutcome(signal, channels, () => Bun.write(
+                          join(homedir(), ".cicero", "telegram-call", "callback.request"),
+                          JSON.stringify({ reason: "morning briefing", at: Date.now() }),
+                        ));
+                    }
+                  }).catch(() => { channels.voice = signal.aborted ? "aborted" : "failed"; })
+                : Promise.resolve();
+
+              await Promise.all([telegramDelivery, voiceDelivery]);
+              if (signal.aborted && channels.callback === "accepted") {
+                channels.voice = "aborted";
+                channels.callback = "aborted";
               }
-              if (briefing.call) {
-                const text = composeBriefing(overnight, board, health);
-                const res = await webVoice.notify(text, undefined, { telegramMirror: false }).catch(() => null);
-                if (signal.aborted) return;
-                if (res?.parked) {
-                  await Bun.write(
-                    join(homedir(), ".cicero", "telegram-call", "callback.request"),
-                    JSON.stringify({ reason: "morning briefing", at: Date.now() }),
-                  );
-                }
-              }
-              log("ok", `☀️ Morning briefing delivered (${overnight.length} deferred item(s))`);
-            })().catch((error: unknown) => {
-              if (!this.lifecycleAbort.signal.aborted) {
-                log("warn", `morning briefing failed: ${error instanceof Error ? error.message : String(error)}`);
-              }
-            });
-          }, 20_000);
-          log("ok", `☀️ Morning briefing scheduled daily at ${briefing.at}${briefing.call ? " (with a call)" : ""}`);
+              const outcomes = Object.values(channels);
+              const accepted = outcomes.filter((outcome) => outcome === "accepted").length;
+              if (accepted > 0) await overnightStore.ack(snapshot.map((item) => item.id));
+              if (signal.aborted && accepted === 0) signal.throwIfAborted();
+
+              const phase = accepted === 0 ? "failed" : accepted === outcomes.length ? "delivered" : "partial";
+              const result: BriefingRunResult = {
+                phase,
+                channels,
+                deferredCount: snapshot.length,
+                contentSummary: `${snapshot.length} deferred; board ${board ? "included" : "unavailable"}; health ${health ? "included" : "empty"}`,
+                errorKind: phase === "delivered" ? undefined : accepted === 0 ? "delivery-failed" : "channel-failed",
+              };
+              log(phase === "delivered" ? "ok" : "warn", `☀️ Morning briefing ${phase} (${snapshot.length} deferred item(s))`);
+              return result;
+            },
+          });
+          log("ok", `☀️ Morning briefing scheduled daily at ${briefing.at} (catch-up ${briefing.catch_up_minutes ?? 180}m)${briefing.call ? " (with a call)" : ""}`);
         }
         // Scheduled prompts: daily unattended brain turns (research briefs,
         // digests) texted via Telegram. Unlike the briefing, the CONTENT is a
@@ -1326,6 +1362,7 @@ export class CiceroDaemon {
 
     this.lifecycle = "running";
     this.running = true;
+    this.briefingScheduler?.start();
     log("ok", "");
     if (this.config.headless) {
       console.log(`Cicero ready (headless — web voice only; local mic/speaker/clap/hotkey disabled).`);
@@ -1608,7 +1645,7 @@ export class CiceroDaemon {
 
       const qh = this.config.notify?.quiet_hours;
       if (qh && inQuietHours(new Date(), qh, this.config.notify?.timezone)) {
-        await this.deferOvernight(text);
+        await this.getOvernightStore().enqueue(text);
         return;
       }
       const tg = this.config.notify?.telegram;
@@ -2150,12 +2187,15 @@ export class CiceroDaemon {
 
     let shutdownCompleted = false;
     try {
-      if (this.briefingTimer) clearInterval(this.briefingTimer);
-      this.briefingTimer = undefined;
+      // Quiesce every scheduler/timer synchronously, then drain the briefing's
+      // exact owned run before dependencies are released.
+      const briefingStop = this.briefingScheduler?.stop();
       this.promptScheduler?.stop();
       this.promptScheduler = null;
       if (this.minutesTimer) clearTimeout(this.minutesTimer);
       this.minutesTimer = undefined;
+      await cleanup("briefing scheduler", () => briefingStop);
+      this.briefingScheduler = null;
 
       // Stop accepting external work before tearing down any dependency an
       // HTTP/WebSocket/dashboard handler may still be using. Both stop methods
@@ -2254,7 +2294,7 @@ export class CiceroDaemon {
       shutdownCompleted = true;
     } finally {
       if (shutdownCompleted) {
-        this.briefingTimer = undefined;
+        this.briefingScheduler = null;
         this.promptScheduler = null;
         this.minutesTimer = undefined;
         this.actionsReloader = null;

--- a/src/notify/briefing-scheduler.ts
+++ b/src/notify/briefing-scheduler.ts
@@ -52,6 +52,7 @@ export interface BriefingScheduleSnapshot {
 const TICK_MS = 20_000;
 const MAX_SUMMARY_CHARS = 500;
 const MAX_ERROR_KIND_CHARS = 64;
+const MINUTE_MS = 60_000;
 
 export function briefingStatusFilePath(): string {
   return join(homedir(), ".cicero", "briefing-status.json");
@@ -200,18 +201,15 @@ export class BriefingScheduler {
 
   private async tickOnce(): Promise<void> {
     const now = this.now();
-    const day = dayOf(now, this.opts.timezone);
-    const minute = parseHm(hmOf(now, this.opts.timezone));
-    const scheduled = parseHm(this.opts.at);
-    const cutoff = Math.min(23 * 60 + 59, scheduled + this.opts.catchUpMinutes);
-    if (minute < scheduled) return;
+    const window = briefingWindow(now, this.opts.at, this.opts.catchUpMinutes, this.opts.timezone);
+    if (window.elapsedMs < 0 || !window.sameLocalDay) return;
 
     const current = await this.opts.store.read();
     this.lastStatus = current;
-    if (this.scope.signal.aborted || current?.day === day) return;
+    if (this.scope.signal.aborted || current?.day === window.day) return;
 
-    if (minute > cutoff) {
-      const missed = this.baseStatus(day, "catch-up", now, "missed");
+    if (window.pastCutoff) {
+      const missed = this.baseStatus(window.day, "catch-up", now, "missed");
       missed.completedAt = now.getTime();
       if (await this.opts.store.claim(missed)) this.lastStatus = missed;
       return;
@@ -220,8 +218,8 @@ export class BriefingScheduler {
     // informational gap is accepted because delivery stays blocked and morning times are the supported configuration.
     if (this.opts.quietHours && inQuietHours(now, this.opts.quietHours, this.opts.timezone)) return;
 
-    const trigger: BriefingTrigger = minute === scheduled ? "scheduled" : "catch-up";
-    const claimed = this.baseStatus(day, trigger, now, "claimed");
+    const trigger: BriefingTrigger = window.scheduledMinute ? "scheduled" : "catch-up";
+    const claimed = this.baseStatus(window.day, trigger, now, "claimed");
     if (!await this.opts.store.claim(claimed)) {
       this.lastStatus = await this.opts.store.read();
       return;
@@ -242,12 +240,9 @@ export class BriefingScheduler {
     const beforeDelivery = (): void => {
       signal.throwIfAborted();
       const now = this.now();
-      const minute = parseHm(hmOf(now, this.opts.timezone));
-      const scheduled = parseHm(this.opts.at);
-      const cutoff = Math.min(23 * 60 + 59, scheduled + this.opts.catchUpMinutes);
-      const closed = dayOf(now, this.opts.timezone) !== claimed.day
-        || minute < scheduled
-        || minute > cutoff
+      const window = briefingWindow(now, this.opts.at, this.opts.catchUpMinutes, this.opts.timezone);
+      const closed = window.day !== claimed.day
+        || !window.eligible
         || Boolean(this.opts.quietHours && inQuietHours(now, this.opts.quietHours, this.opts.timezone));
       if (closed) deliveryWindow.abort(new Error("briefing delivery window closed"));
       signal.throwIfAborted();
@@ -285,6 +280,56 @@ export class BriefingScheduler {
   private nowDate(now: (() => Date) | undefined): Date {
     return now ? now() : new Date();
   }
+}
+
+interface BriefingWindow {
+  day: string;
+  elapsedMs: number;
+  eligible: boolean;
+  pastCutoff: boolean;
+  sameLocalDay: boolean;
+  scheduledMinute: boolean;
+}
+
+function briefingWindow(now: Date, at: string, catchUpMinutes: number, timeZone?: string): BriefingWindow {
+  const day = dayOf(now, timeZone);
+  const scheduled = scheduledInstantForToday(now, at, timeZone);
+  const elapsedMs = now.getTime() - scheduled.getTime();
+  const sameLocalDay = dayOf(scheduled, timeZone) === day;
+  const cutoffMs = catchUpMinutes === 0 ? MINUTE_MS : catchUpMinutes * MINUTE_MS;
+  const beforeOrAtCutoff = catchUpMinutes === 0 ? elapsedMs < cutoffMs : elapsedMs <= cutoffMs;
+  return {
+    day,
+    elapsedMs,
+    eligible: sameLocalDay && elapsedMs >= 0 && beforeOrAtCutoff,
+    pastCutoff: sameLocalDay && (catchUpMinutes === 0 ? elapsedMs >= cutoffMs : elapsedMs > cutoffMs),
+    sameLocalDay,
+    scheduledMinute: parseHm(hmOf(now, timeZone)) === parseHm(at),
+  };
+}
+
+function scheduledInstantForToday(now: Date, at: string, timeZone?: string): Date {
+  const minute = parseHm(at);
+  const hour = Math.floor(minute / 60);
+  const minuteOfHour = minute % 60;
+  if (!timeZone) return new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minuteOfHour);
+
+  const [year, month, date] = dayOf(now, timeZone).split("-").map(Number);
+  const wallTimeAsUtc = Date.UTC(year, month - 1, date, hour, minuteOfHour);
+  let epochMs = wallTimeAsUtc;
+  // Two corrections converge for ordinary and repeated wall times. For a DST
+  // gap they select the earlier valid instant, which keeps missing-minute catch-up deterministic.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    epochMs = wallTimeAsUtc - timeZoneOffsetMs(new Date(epochMs), timeZone);
+  }
+  return new Date(epochMs);
+}
+
+function timeZoneOffsetMs(instant: Date, timeZone: string): number {
+  const [year, month, date] = dayOf(instant, timeZone).split("-").map(Number);
+  const minute = parseHm(hmOf(instant, timeZone));
+  const localAsUtc = Date.UTC(year, month - 1, date, Math.floor(minute / 60), minute % 60);
+  return localAsUtc - instant.getTime();
 }
 
 function normalizeStatus(status: BriefingRunStatus): BriefingRunStatus {

--- a/src/notify/briefing-scheduler.ts
+++ b/src/notify/briefing-scheduler.ts
@@ -259,6 +259,8 @@ export class BriefingScheduler {
         ? { phase: "missed", errorKind: "delivery-window-closed" }
         : { phase: "failed", errorKind: "run-failed" };
     }
+    // A stop during complete() may persist today's accurate status a moment late. The store's day
+    // guard confines it to today's claim and prevents resend, so we accept that instead of a second write lock.
     if (this.scope.signal.aborted) return;
     const completed: BriefingRunStatus = normalizeStatus({
       ...claimed,
@@ -314,14 +316,16 @@ function scheduledInstantForToday(now: Date, at: string, timeZone?: string): Dat
   const minuteOfHour = minute % 60;
   if (!timeZone) return new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minuteOfHour);
 
-  const [year, month, date] = dayOf(now, timeZone).split("-").map(Number);
+  const requestedDay = dayOf(now, timeZone);
+  const [year, month, date] = requestedDay.split("-").map(Number);
   const wallTimeAsUtc = Date.UTC(year, month - 1, date, hour, minuteOfHour);
-  let epochMs = wallTimeAsUtc;
-  // Two corrections converge for ordinary and repeated wall times. For a DST
-  // gap they select the earlier valid instant, which keeps missing-minute catch-up deterministic.
-  for (let attempt = 0; attempt < 2; attempt++) {
-    epochMs = wallTimeAsUtc - timeZoneOffsetMs(new Date(epochMs), timeZone);
-  }
+  const firstCandidate = wallTimeAsUtc - timeZoneOffsetMs(new Date(wallTimeAsUtc), timeZone);
+  const correctedCandidate = wallTimeAsUtc - timeZoneOffsetMs(new Date(firstCandidate), timeZone);
+  const correctedInstant = new Date(correctedCandidate);
+  const isGap = firstCandidate !== correctedCandidate
+    && (dayOf(correctedInstant, timeZone) !== requestedDay || parseHm(hmOf(correctedInstant, timeZone)) !== minute);
+  // A nonexistent wall time straddles the DST gap; use its later real candidate so it cannot fire early.
+  const epochMs = isGap ? Math.max(firstCandidate, correctedCandidate) : correctedCandidate;
   return new Date(epochMs);
 }
 

--- a/src/notify/briefing-scheduler.ts
+++ b/src/notify/briefing-scheduler.ts
@@ -1,0 +1,320 @@
+import { lstat, rename, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { PrivateJsonTooLargeError, readPrivateJson, writePrivateJson } from "../platform/private-json";
+import { ensurePrivateDirectorySync, ensurePrivateFileIfExistsSync } from "../platform/secure-storage";
+import { log } from "../logger";
+import { dayOf, hmOf, inQuietHours, parseHm, type QuietHoursConfig } from "./briefing";
+
+export type BriefingTrigger = "scheduled" | "catch-up";
+export type BriefingPhase = "claimed" | "delivered" | "partial" | "failed" | "missed";
+export type BriefingCompletedPhase = Exclude<BriefingPhase, "claimed">;
+export type BriefingDeliveryGate = () => void;
+
+export interface BriefingRunStatus {
+  day: string;
+  scheduledAt: string;
+  trigger: BriefingTrigger;
+  claimedAt: number;
+  completedAt?: number;
+  phase: BriefingPhase;
+  channels?: { telegram?: string; voice?: string; callback?: string };
+  deferredCount?: number;
+  contentSummary?: string;
+  errorKind?: string;
+}
+
+export interface BriefingRunResult {
+  phase: BriefingCompletedPhase;
+  channels?: BriefingRunStatus["channels"];
+  deferredCount?: number;
+  contentSummary?: string;
+  errorKind?: string;
+}
+
+export interface BriefingSchedulerOptions {
+  at: string;
+  catchUpMinutes: number;
+  timezone?: string;
+  quietHours?: QuietHoursConfig;
+  now?: () => Date;
+  run: (trigger: BriefingTrigger, signal: AbortSignal, beforeDelivery: BriefingDeliveryGate) => Promise<BriefingRunResult>;
+  store: BriefingStatusStore;
+  tickMs?: number;
+}
+
+export interface BriefingScheduleSnapshot {
+  running: boolean;
+  inFlight: boolean;
+  status: BriefingRunStatus | null;
+}
+
+const TICK_MS = 20_000;
+const MAX_SUMMARY_CHARS = 500;
+const MAX_ERROR_KIND_CHARS = 64;
+
+export function briefingStatusFilePath(): string {
+  return join(homedir(), ".cicero", "briefing-status.json");
+}
+
+/** One-record durable daily latch. A claim is never silently retried that day. */
+export class BriefingStatusStore {
+  private pending: Promise<void> = Promise.resolve();
+  private corruptWarningIssued = false;
+
+  constructor(private readonly file: string = briefingStatusFilePath()) {
+    ensurePrivateDirectorySync(dirname(file));
+    ensurePrivateFileIfExistsSync(file);
+  }
+
+  read(): Promise<BriefingRunStatus | null> {
+    return this.serialize(async () => this.readUnserialized());
+  }
+
+  claim(status: BriefingRunStatus): Promise<boolean> {
+    return this.serialize(async () => {
+      const current = await this.readUnserialized();
+      if (current?.day === status.day) return false;
+      await writePrivateJson(this.file, normalizeStatus(status));
+      return true;
+    });
+  }
+
+  complete(status: BriefingRunStatus): Promise<void> {
+    return this.serialize(async () => {
+      const current = await this.readUnserialized();
+      if (current?.day !== status.day) throw new Error("briefing claim no longer owns today's status");
+      await writePrivateJson(this.file, normalizeStatus(status));
+    });
+  }
+
+  private serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.pending.catch(() => {}).then(operation);
+    this.pending = result.then(() => {}, () => {});
+    return result;
+  }
+
+  private async readUnserialized(): Promise<BriefingRunStatus | null> {
+    let value: unknown | undefined;
+    try {
+      value = await readPrivateJson(this.file);
+    } catch (error: unknown) {
+      if (!(error instanceof SyntaxError) && !(error instanceof PrivateJsonTooLargeError)) throw error;
+      await this.quarantineCorrupt();
+      return null;
+    }
+    if (value === undefined) return null;
+    try {
+      if (!isStatus(value)) throw new TypeError("invalid briefing status");
+      const normalized = normalizeStatus(value);
+      this.corruptWarningIssued = false;
+      return normalized;
+    } catch {
+      await this.quarantineCorrupt();
+      return null;
+    }
+  }
+
+  private async quarantineCorrupt(): Promise<void> {
+    const day = new Date().toISOString().slice(0, 10);
+    let quarantined = false;
+    for (let counter = 0; counter < 100; counter++) {
+      const suffix = counter === 0 ? day : `${day}-${counter}`;
+      const candidate = `${this.file}.corrupt-${suffix}`;
+      try {
+        await lstat(candidate);
+        continue;
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") continue;
+      }
+      try {
+        await rename(this.file, candidate);
+        quarantined = true;
+        break;
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") break;
+      }
+    }
+    if (!quarantined) {
+      try { await unlink(this.file); } catch { /* best-effort corrupt-file removal */ }
+    }
+    if (!this.corruptWarningIssued) {
+      this.corruptWarningIssued = true;
+      log("warn", "morning briefing status file was corrupt and was quarantined");
+    }
+  }
+}
+
+export class BriefingScheduler {
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private readonly scope = new AbortController();
+  private readonly now: () => Date;
+  private tickPromise: Promise<void> | null = null;
+  private runPromise: Promise<void> | null = null;
+  private lastStatus: BriefingRunStatus | null = null;
+
+  constructor(private readonly opts: BriefingSchedulerOptions) {
+    parseHm(opts.at);
+    if (!Number.isInteger(opts.catchUpMinutes) || opts.catchUpMinutes < 0 || opts.catchUpMinutes > 720) {
+      throw new Error("briefing catchUpMinutes must be an integer from 0 to 720");
+    }
+    if (opts.timezone) hmOf(this.nowDate(opts.now), opts.timezone);
+    if (opts.quietHours) {
+      parseHm(opts.quietHours.from);
+      parseHm(opts.quietHours.to);
+    }
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  start(): void {
+    if (this.timer || this.scope.signal.aborted) return;
+    const tick = () => {
+      void this.tick().catch(() => {
+        if (!this.scope.signal.aborted) log("warn", "morning briefing scheduler tick failed");
+      });
+    };
+    tick();
+    this.timer = setInterval(tick, this.opts.tickMs ?? TICK_MS);
+  }
+
+  tick(): Promise<void> {
+    if (this.scope.signal.aborted) return Promise.resolve();
+    if (this.tickPromise) return this.tickPromise;
+    const ticking = this.tickOnce().finally(() => {
+      if (this.tickPromise === ticking) this.tickPromise = null;
+    });
+    this.tickPromise = ticking;
+    return ticking;
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+    if (!this.scope.signal.aborted) this.scope.abort(new Error("briefing scheduler stopped"));
+    await Promise.allSettled([this.tickPromise, this.runPromise].filter((p): p is Promise<void> => p !== null));
+  }
+
+  snapshot(): BriefingScheduleSnapshot {
+    return { running: this.timer !== undefined, inFlight: this.runPromise !== null, status: this.lastStatus };
+  }
+
+  private async tickOnce(): Promise<void> {
+    const now = this.now();
+    const day = dayOf(now, this.opts.timezone);
+    const minute = parseHm(hmOf(now, this.opts.timezone));
+    const scheduled = parseHm(this.opts.at);
+    const cutoff = Math.min(23 * 60 + 59, scheduled + this.opts.catchUpMinutes);
+    if (minute < scheduled) return;
+
+    const current = await this.opts.store.read();
+    this.lastStatus = current;
+    if (this.scope.signal.aborted || current?.day === day) return;
+
+    if (minute > cutoff) {
+      const missed = this.baseStatus(day, "catch-up", now, "missed");
+      missed.completedAt = now.getTime();
+      if (await this.opts.store.claim(missed)) this.lastStatus = missed;
+      return;
+    }
+    // Degenerate schedules inside quiet hours may never persist "missed"; that
+    // informational gap is accepted because delivery stays blocked and morning times are the supported configuration.
+    if (this.opts.quietHours && inQuietHours(now, this.opts.quietHours, this.opts.timezone)) return;
+
+    const trigger: BriefingTrigger = minute === scheduled ? "scheduled" : "catch-up";
+    const claimed = this.baseStatus(day, trigger, now, "claimed");
+    if (!await this.opts.store.claim(claimed)) {
+      this.lastStatus = await this.opts.store.read();
+      return;
+    }
+    this.lastStatus = claimed;
+    if (this.scope.signal.aborted) return;
+
+    const running = this.runClaim(claimed, trigger).finally(() => {
+      if (this.runPromise === running) this.runPromise = null;
+    });
+    this.runPromise = running;
+    await running;
+  }
+
+  private async runClaim(claimed: BriefingRunStatus, trigger: BriefingTrigger): Promise<void> {
+    const deliveryWindow = new AbortController();
+    const signal = AbortSignal.any([this.scope.signal, deliveryWindow.signal]);
+    const beforeDelivery = (): void => {
+      signal.throwIfAborted();
+      const now = this.now();
+      const minute = parseHm(hmOf(now, this.opts.timezone));
+      const scheduled = parseHm(this.opts.at);
+      const cutoff = Math.min(23 * 60 + 59, scheduled + this.opts.catchUpMinutes);
+      const closed = dayOf(now, this.opts.timezone) !== claimed.day
+        || minute < scheduled
+        || minute > cutoff
+        || Boolean(this.opts.quietHours && inQuietHours(now, this.opts.quietHours, this.opts.timezone));
+      if (closed) deliveryWindow.abort(new Error("briefing delivery window closed"));
+      signal.throwIfAborted();
+    };
+    let result: BriefingRunResult;
+    try {
+      // The window is checked immediately before delivery begins; TTS may finish just past a boundary.
+      // That accepted slip is immaterial for realistic morning windows, where synthesis takes only seconds.
+      beforeDelivery();
+      result = await this.opts.run(trigger, signal, beforeDelivery);
+    } catch {
+      if (this.scope.signal.aborted) return;
+      result = deliveryWindow.signal.aborted
+        ? { phase: "missed", errorKind: "delivery-window-closed" }
+        : { phase: "failed", errorKind: "run-failed" };
+    }
+    if (this.scope.signal.aborted) return;
+    const completed: BriefingRunStatus = normalizeStatus({
+      ...claimed,
+      ...result,
+      day: claimed.day,
+      scheduledAt: claimed.scheduledAt,
+      trigger: claimed.trigger,
+      claimedAt: claimed.claimedAt,
+      completedAt: this.now().getTime(),
+    });
+    await this.opts.store.complete(completed);
+    this.lastStatus = completed;
+  }
+
+  private baseStatus(day: string, trigger: BriefingTrigger, now: Date, phase: BriefingPhase): BriefingRunStatus {
+    return { day, scheduledAt: this.opts.at, trigger, claimedAt: now.getTime(), phase };
+  }
+
+  private nowDate(now: (() => Date) | undefined): Date {
+    return now ? now() : new Date();
+  }
+}
+
+function normalizeStatus(status: BriefingRunStatus): BriefingRunStatus {
+  return {
+    ...status,
+    contentSummary: status.contentSummary?.slice(0, MAX_SUMMARY_CHARS),
+    errorKind: sanitizeErrorKind(status.errorKind),
+  };
+}
+
+function sanitizeErrorKind(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const sanitized = value.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return sanitized.slice(0, MAX_ERROR_KIND_CHARS) || "unknown";
+}
+
+function isStatus(value: unknown): value is BriefingRunStatus {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const status = value as Partial<BriefingRunStatus>;
+  const channels = status.channels;
+  return typeof status.day === "string"
+    && typeof status.scheduledAt === "string"
+    && (status.trigger === "scheduled" || status.trigger === "catch-up")
+    && typeof status.claimedAt === "number"
+    && (status.phase === "claimed" || status.phase === "delivered" || status.phase === "partial"
+      || status.phase === "failed" || status.phase === "missed")
+    && (status.completedAt === undefined || typeof status.completedAt === "number")
+    && (status.deferredCount === undefined || typeof status.deferredCount === "number")
+    && (status.contentSummary === undefined || typeof status.contentSummary === "string")
+    && (status.errorKind === undefined || typeof status.errorKind === "string")
+    && (channels === undefined || (channels !== null && typeof channels === "object" && !Array.isArray(channels)
+      && Object.values(channels).every((channel) => typeof channel === "string")));
+}

--- a/src/notify/briefing.ts
+++ b/src/notify/briefing.ts
@@ -15,6 +15,7 @@ export interface QuietHoursConfig {
 export interface BriefingConfig {
   at: string;      // "HH:MM", box-local time, fires once a day
   call?: boolean;  // also ring the phone and speak it (default: text only)
+  catch_up_minutes?: number; // restart catch-up window (default 180, 0 = exact minute only)
 }
 
 /** "HH:MM" → minutes past midnight. Throws on garbage so config errors surface at startup. */

--- a/src/notify/overnight-store.ts
+++ b/src/notify/overnight-store.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { PrivateJsonTooLargeError, readPrivateJson, writePrivateJson } from "../platform/private-json";
+import { ensurePrivateDirectorySync, ensurePrivateFileIfExistsSync } from "../platform/secure-storage";
+
+export interface OvernightItem {
+  id: string;
+  queuedAt: number;
+  text: string;
+}
+
+const MAX_ITEMS = 40;
+const MAX_TEXT_CHARS = 12_000;
+
+export function overnightFilePath(): string {
+  return join(homedir(), ".cicero", "overnight.json");
+}
+
+/** Durable, serialized quiet-hours queue. Reads never consume queued news. */
+export class OvernightStore {
+  private pending: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly file: string = overnightFilePath(),
+    private readonly now: () => number = Date.now,
+    private readonly makeId: () => string = randomUUID,
+  ) {
+    ensurePrivateDirectorySync(dirname(file));
+    ensurePrivateFileIfExistsSync(file);
+  }
+
+  enqueue(text: string): Promise<void> {
+    return this.serialize(async () => {
+      const { items } = await this.read();
+      items.push({ id: this.makeId(), queuedAt: this.now(), text: text.slice(0, MAX_TEXT_CHARS) });
+      await writePrivateJson(this.file, items.slice(-MAX_ITEMS));
+    });
+  }
+
+  peek(): Promise<readonly OvernightItem[]> {
+    return this.serialize(async () => {
+      const { items, migrated } = await this.read();
+      if (migrated) await writePrivateJson(this.file, items);
+      return items.map((item) => ({ ...item }));
+    });
+  }
+
+  ack(ids: readonly string[]): Promise<void> {
+    return this.serialize(async () => {
+      const remove = new Set(ids);
+      if (remove.size === 0) return;
+      const { items } = await this.read();
+      await writePrivateJson(this.file, items.filter((item) => !remove.has(item.id)));
+    });
+  }
+
+  private serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.pending.catch(() => {}).then(operation);
+    this.pending = result.then(() => {}, () => {});
+    return result;
+  }
+
+  private async read(): Promise<{ items: OvernightItem[]; migrated: boolean }> {
+    let value: unknown;
+    try {
+      value = await readPrivateJson(this.file);
+    } catch (error: unknown) {
+      // Unsafe paths are a policy failure, not corrupt content to ignore.
+      if (error instanceof SyntaxError || error instanceof PrivateJsonTooLargeError) {
+        return { items: [], migrated: false };
+      }
+      throw error;
+    }
+    if (value === undefined) return { items: [], migrated: false };
+    if (!Array.isArray(value)) return { items: [], migrated: false };
+
+    let migrated = false;
+    const items: OvernightItem[] = [];
+    for (const entry of value) {
+      if (typeof entry === "string") {
+        migrated = true;
+        items.push({ id: this.makeId(), queuedAt: this.now(), text: entry.slice(0, MAX_TEXT_CHARS) });
+        continue;
+      }
+      if (!isItem(entry)) continue;
+      items.push({ id: entry.id, queuedAt: entry.queuedAt, text: entry.text.slice(0, MAX_TEXT_CHARS) });
+    }
+    return { items: items.slice(-MAX_ITEMS), migrated };
+  }
+}
+
+function isItem(value: unknown): value is OvernightItem {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<OvernightItem>;
+  return typeof item.id === "string" && item.id.length > 0 && item.id.length <= 128
+    && typeof item.queuedAt === "number" && Number.isFinite(item.queuedAt)
+    && typeof item.text === "string";
+}

--- a/src/notify/overnight-store.ts
+++ b/src/notify/overnight-store.ts
@@ -86,6 +86,8 @@ export class OvernightStore {
       if (!isItem(entry)) continue;
       items.push({ id: entry.id, queuedAt: entry.queuedAt, text: entry.text.slice(0, MAX_TEXT_CHARS) });
     }
+    // Legacy string[] migration intentionally shares the write-path MAX_ITEMS bound: the old writer
+    // also used slice(-40), so retaining only the newest 40 remains the queue's memory bound.
     return { items: items.slice(-MAX_ITEMS), migrated };
   }
 }

--- a/src/notify/telegram.ts
+++ b/src/notify/telegram.ts
@@ -375,6 +375,7 @@ export async function sendTelegramText(
   text: string,
   api = "https://api.telegram.org",
   extra: Record<string, unknown> = {},
+  signal?: AbortSignal,
 ): Promise<boolean> {
   const token = telegramToken(cfg);
   if (!token || !cfg.chat_id) return false;
@@ -384,7 +385,7 @@ export async function sendTelegramText(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ chat_id: String(cfg.chat_id), text: text.slice(0, 4096), ...extra }),
-      signal: scope.signal,
+      signal: signal ? AbortSignal.any([scope.signal, signal]) : scope.signal,
     });
     if (!res.ok) {
       const body = await readBoundedText(res, TELEGRAM_MAX_ERROR_BYTES);

--- a/src/platform/private-json.ts
+++ b/src/platform/private-json.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { open, rename, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
+import {
+  PRIVATE_FILE_MODE,
+  ensurePrivateDirectorySync,
+  ensurePrivateFileIfExistsSync,
+  ensurePrivateFileSync,
+} from "./secure-storage";
+
+export const DEFAULT_PRIVATE_JSON_MAX_BYTES = 1_000_000;
+
+export class PrivateJsonTooLargeError extends Error {
+  constructor(path: string, maxBytes: number) {
+    super(`private JSON file '${path}' exceeds the ${maxBytes}-byte limit`);
+    this.name = "PrivateJsonTooLargeError";
+  }
+}
+
+/** Read a Cicero-owned private JSON file without following file symlinks. */
+export async function readPrivateJson(
+  path: string,
+  maxBytes = DEFAULT_PRIVATE_JSON_MAX_BYTES,
+): Promise<unknown | undefined> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) throw new RangeError("maxBytes must be a positive integer");
+  ensurePrivateDirectorySync(dirname(path));
+  if (!ensurePrivateFileIfExistsSync(path)) return undefined;
+  const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+  const handle = await open(path, constants.O_RDONLY | noFollow);
+  try {
+    const info = await handle.stat();
+    if (!info.isFile()) throw new Error(`refusing unsafe private file path '${path}'`);
+    if (info.size > maxBytes) throw new PrivateJsonTooLargeError(path, maxBytes);
+
+    // Do not use readFile() here: the inode can grow after stat(), and readFile()
+    // would then retain the unbounded replacement contents.
+    const bytes = Buffer.allocUnsafe(info.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const read = await handle.read(bytes, offset, bytes.length - offset, offset);
+      if (read.bytesRead === 0) break;
+      offset += read.bytesRead;
+    }
+    const after = await handle.stat();
+    if (after.size > maxBytes) throw new PrivateJsonTooLargeError(path, maxBytes);
+    return JSON.parse(bytes.subarray(0, offset).toString("utf8")) as unknown;
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Atomically replace a private JSON file through a fresh 0600 sibling inode. */
+export async function writePrivateJson(path: string, value: unknown): Promise<void> {
+  const directory = dirname(path);
+  ensurePrivateDirectorySync(directory);
+  // Reject an existing link explicitly. rename() would not follow it, but
+  // silently replacing an unsafe path would hide a storage-policy violation.
+  ensurePrivateFileIfExistsSync(path);
+  const temporary = `${path}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    const handle = await open(temporary, "wx", PRIVATE_FILE_MODE);
+    try {
+      await handle.writeFile(JSON.stringify(value));
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    ensurePrivateFileSync(temporary);
+    await rename(temporary, path);
+    ensurePrivateFileSync(path);
+
+    // Windows cannot open directories as file handles. POSIX directory fsync
+    // makes the rename itself durable, rather than only the new inode contents.
+    if (process.platform !== "win32") {
+      const directoryHandle = await open(directory, constants.O_RDONLY);
+      try {
+        await directoryHandle.sync();
+      } finally {
+        await directoryHandle.close();
+      }
+    }
+  } catch (error: unknown) {
+    try { await unlink(temporary); } catch { /* absent after rename, or best-effort cleanup */ }
+    throw error;
+  }
+}

--- a/src/platform/secure-storage.ts
+++ b/src/platform/secure-storage.ts
@@ -22,7 +22,9 @@ export function ensurePrivateDirectorySync(path: string): void {
 
   // Windows does not implement POSIX ownership bits. The containing directory
   // is still created normally there; ACLs remain under the user's profile.
-  if (process.platform !== "win32") chmodSync(path, PRIVATE_DIRECTORY_MODE);
+  if (process.platform !== "win32" && (info.mode & 0o777) !== PRIVATE_DIRECTORY_MODE) {
+    chmodSync(path, PRIVATE_DIRECTORY_MODE);
+  }
 }
 
 /** Tighten an existing private file without ever following a symlink. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface CiceroConfig {
     }; // phone notifications: text by default, voice notes opt-in
     timezone?: string; // IANA name (America/New_York) — quiet_hours and briefing.at are read in THIS zone; default is the box clock
     quiet_hours?: { from: string; to: string }; // HH:MM in notify.timezone — notifications defer instead of pinging
-    briefing?: { at: string; call?: boolean };  // daily digest of deferred news + board state; call: also ring and speak it
+    briefing?: { at: string; call?: boolean; catch_up_minutes?: number };  // daily digest of deferred news + board state; call: also ring and speak it; catch-up defaults to 180 minutes
     schedules?: Array<{ name?: string; at: string; prompt: string; lane?: string }>; // daily unattended brain turns (research briefs, digests) texted via notify.telegram; lane targets a named brain lane, otherwise the front desk answers; quiet hours hold delivery, not the work
     call_minutes?: boolean | { min_minutes?: number }; // notes texted after a voice session goes quiet; only for calls longer than min_minutes (default 3)
     kanban?: { enabled?: boolean; interval_seconds?: number; command?: string[]; task_command?: string[]; call_back?: boolean; nudge_after_minutes?: number }; // announce task completions; call_back rings the phone when nobody's listening (never for blocked tasks); nudge_after_minutes (default 60, 0 = off) reminds about tasks nobody picked up

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -169,7 +169,7 @@ export interface WebVoiceHandle {
    * broadcast, park when nobody's connected) — for in-process callers like the
    * kanban watcher. Resolves null when unavailable, saturated, or quiescing.
    */
-  notify: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean }) => Promise<{ delivered: number; parked: boolean } | null>;
+  notify: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal }) => Promise<{ delivered: number; parked: boolean } | null>;
   /** Quiesce ingress, cancel owned work, close sockets, and drain handlers. */
   stop: () => Promise<void>;
 }
@@ -673,7 +673,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
   const notify = async (
     text: string,
     voice?: string,
-    notifyOpts?: { urgent?: boolean; telegramMirror?: boolean },
+    notifyOpts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal },
   ): Promise<{ delivered: number; parked: boolean } | null> => {
     const normalizedText = text.trim();
     const normalizedVoice = voice?.trim() || undefined;
@@ -684,7 +684,9 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     try {
       return await dispatchNotify(normalizedText, normalizedVoice, {
         ...notifyOpts,
-        signal: shutdownController.signal,
+        signal: notifyOpts?.signal
+          ? AbortSignal.any([shutdownController.signal, notifyOpts.signal])
+          : shutdownController.signal,
       });
     } catch (error) {
       if (error instanceof Error) throw error;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -673,15 +673,16 @@ describe("Config — fail-fast validation", () => {
       "notify:",
       "  timezone: Mars/Olympus",
       "  quiet_hours: { from: '25:00', to: noon }",
-      "  briefing: { at: '8am' }",
+      "  briefing: { at: '8am', catch_up_minutes: 721 }",
       "  call_minutes: { min_minutes: -1 }",
       "  kanban:",
       "    interval_seconds: 0",
       "    command: []",
       "",
     ].join("\n"))).toThrow(
-      /notify\.timezone[\s\S]*notify\.quiet_hours\.from[\s\S]*notify\.briefing\.at[\s\S]*notify\.kanban\.interval_seconds[\s\S]*notify\.kanban\.command[\s\S]*notify\.call_minutes\.min_minutes/,
+      /notify\.timezone[\s\S]*notify\.quiet_hours\.from[\s\S]*notify\.briefing\.at[\s\S]*notify\.briefing\.catch_up_minutes[\s\S]*notify\.kanban\.interval_seconds[\s\S]*notify\.kanban\.command[\s\S]*notify\.call_minutes\.min_minutes/,
     );
+    expect(loadYaml("notify:\n  briefing: { at: '08:30', catch_up_minutes: 0 }\n")).not.toThrow();
   });
 
   test("kanban watch has no built-in board CLI — enabling it requires an explicit command", () => {

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig } from "../src/config";
-import { CiceroDaemon, createRecordedWebTurn } from "../src/daemon";
+import { CiceroDaemon, createRecordedWebTurn, recordParkedBriefingVoiceOutcome } from "../src/daemon";
+import { OvernightStore } from "../src/notify/overnight-store";
 import type { WebReplySink } from "../src/web-voice/turn";
 import type { HistoryTurn } from "../src/web-voice/history";
 
@@ -18,6 +19,39 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): 
 }
 
 describe("CiceroDaemon lifecycle", () => {
+  test("aborting during a parked briefing callback write leaves the overnight snapshot unacked", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cicero-daemon-briefing-callback-abort-"));
+    const store = new OvernightStore(join(root, "overnight.json"), () => 1_700_000_000_000, () => "item-1");
+    await store.enqueue("queued overnight");
+    const snapshot = await store.peek();
+    const controller = new AbortController();
+    const channels = { voice: "accepted" };
+    let markWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => { markWriteStarted = resolve; });
+    let releaseWrite!: () => void;
+    const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
+
+    try {
+      const recording = recordParkedBriefingVoiceOutcome(controller.signal, channels, async () => {
+        markWriteStarted();
+        await writeGate;
+      });
+      await writeStarted;
+      controller.abort(new Error("briefing scheduler stopped"));
+      releaseWrite();
+      await recording;
+
+      const accepted = Object.values(channels).filter((outcome) => outcome === "accepted").length;
+      if (accepted > 0) await store.ack(snapshot.map((item) => item.id));
+
+      expect(channels).toEqual({ voice: "aborted", callback: "aborted" });
+      expect((await store.peek()).map((item) => item.text)).toEqual(["queued overnight"]);
+    } finally {
+      releaseWrite();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("a completed WebSocket turn does not drain before history persistence", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => { release = resolve; });
@@ -136,67 +170,43 @@ describe("CiceroDaemon lifecycle", () => {
 
   test("a successful stop clears every daemon-owned timer", async () => {
     const home = mkdtempSync(join(tmpdir(), "cicero-daemon-timer-test-"));
-    const pidFile = join(home, "cicero.pid");
-    const config = loadConfig({}, { home });
-    config.raw.headless = true;
-    config.raw.dashboard = { enabled: false };
-    config.raw.tts_enabled = false;
-    config.raw.web_voice = {
-      enabled: true,
-      port: 0,
-      token: "test-token-that-is-long-enough",
-      tls: { enabled: false },
-    };
-    config.raw.notify = { briefing: { at: "00:00" } };
-    config.raw.brain = {
-      ...config.raw.brain,
-      backend: "qwen",
-      mode: "subprocess",
-      binary: process.execPath,
-      binary_args: ["-e", "console.log('ok')"],
-      thinking_filler: false,
-    };
-
-    const daemon = new CiceroDaemon(config, {
-      skipServers: true,
-      pidFile,
-      providerFactory: () => ({
-        stt: {
-          name: "test-stt",
-          transcribe: () => Promise.resolve(null),
-          health: () => Promise.resolve(true),
-        },
-        tts: {
-          name: "test-tts",
-          generateAudio: () => Promise.resolve(new ArrayBuffer(0)),
-          health: () => Promise.resolve(true),
-        },
-        llm: {
-          name: "test-llm",
-          chatCompletion: () => Promise.resolve("ok"),
-          health: () => Promise.resolve(true),
-        },
-      }),
-    });
-    const timers = daemon as unknown as {
-      briefingTimer?: ReturnType<typeof setInterval>;
+    const daemon = new CiceroDaemon(loadConfig({}, { home }));
+    let schedulerStarted = false;
+    let schedulerStopStarted = false;
+    let releaseScheduler!: () => void;
+    const schedulerDrain = new Promise<void>((resolve) => { releaseScheduler = resolve; });
+    const state = daemon as unknown as {
+      lifecycle: "idle" | "starting" | "running" | "stopping";
+      running: boolean;
+      briefingScheduler: { start: () => void; stop: () => Promise<void> } | null;
       minutesTimer?: ReturnType<typeof setTimeout>;
     };
+    state.lifecycle = "running";
+    state.running = true;
+    state.briefingScheduler = {
+        start: () => { schedulerStarted = true; },
+        stop: async () => { schedulerStopStarted = true; await schedulerDrain; },
+    };
+    state.briefingScheduler.start();
     let delayedWorkRan = false;
 
     try {
-      await daemon.start();
-      expect(timers.briefingTimer).toBeDefined();
-      timers.minutesTimer = setTimeout(() => { delayedWorkRan = true; }, 20);
+      expect(schedulerStarted).toBe(true);
+      state.minutesTimer = setTimeout(() => { delayedWorkRan = true; }, 20);
 
-      await daemon.stop();
+      let stopped = false;
+      const stopping = daemon.stop().then(() => { stopped = true; });
+      await Bun.sleep(0);
+      expect(schedulerStopStarted).toBe(true);
+      expect(stopped).toBe(false);
+      releaseScheduler();
+      await stopping;
       await daemon.stop();
       await Bun.sleep(40);
 
       expect(delayedWorkRan).toBe(false);
-      expect(timers.briefingTimer).toBeUndefined();
-      expect(timers.minutesTimer).toBeUndefined();
-      expect(existsSync(pidFile)).toBe(false);
+      expect(state.briefingScheduler).toBeNull();
+      expect(state.minutesTimer).toBeUndefined();
     } catch (error) {
       await daemon.stop().catch(() => {});
       throw new Error(`successful lifecycle timer test failed: ${(error as Error).message}`, { cause: error });

--- a/tests/notify/briefing-scheduler.test.ts
+++ b/tests/notify/briefing-scheduler.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  BriefingScheduler,
+  BriefingStatusStore,
+  type BriefingDeliveryGate,
+  type BriefingRunResult,
+} from "../../src/notify/briefing-scheduler";
+import { OvernightStore } from "../../src/notify/overnight-store";
+import { sendTelegramText } from "../../src/notify/telegram";
+
+const roots: string[] = [];
+
+function statusStore(): BriefingStatusStore {
+  const root = mkdtempSync(join(tmpdir(), "cicero-briefing-scheduler-"));
+  roots.push(root);
+  return new BriefingStatusStore(join(root, "briefing-status.json"));
+}
+
+function local(hours: number, minutes: number, day = 15): Date {
+  return new Date(2026, 6, day, hours, minutes, 5);
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (condition()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("condition was not reached");
+}
+
+function scheduler(options: {
+  now: () => Date;
+  run: (signal: AbortSignal, beforeDelivery: BriefingDeliveryGate) => Promise<BriefingRunResult>;
+  store?: BriefingStatusStore;
+  at?: string;
+  catchUpMinutes?: number;
+  timezone?: string;
+  quietHours?: { from: string; to: string };
+}): { scheduler: BriefingScheduler; store: BriefingStatusStore } {
+  const store = options.store ?? statusStore();
+  return {
+    store,
+    scheduler: new BriefingScheduler({
+      at: options.at ?? "08:30",
+      catchUpMinutes: options.catchUpMinutes ?? 180,
+      timezone: options.timezone,
+      quietHours: options.quietHours,
+      now: options.now,
+      run: (_trigger, signal, beforeDelivery) => options.run(signal, beforeDelivery),
+      store,
+    }),
+  };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test("exact-minute delivery fires once", async () => {
+  let now = local(8, 30);
+  let calls = 0;
+  const h = scheduler({ now: () => now, run: async () => { calls++; return { phase: "delivered" }; } });
+
+  await h.scheduler.tick();
+  await h.scheduler.tick();
+  expect(calls).toBe(1);
+  expect(await h.store.read()).toMatchObject({ phase: "delivered", trigger: "scheduled" });
+
+  now = local(8, 30, 16);
+  await h.scheduler.tick();
+  expect(calls).toBe(2);
+});
+
+test("08:30 America/New_York catches up at 09:47", async () => {
+  const now = new Date("2026-07-15T13:47:05Z");
+  let trigger = "";
+  const h = scheduler({
+    now: () => now,
+    timezone: "America/New_York",
+    run: async () => ({ phase: "delivered", channels: { telegram: (trigger = "accepted") } }),
+  });
+  await h.scheduler.tick();
+  expect(trigger).toBe("accepted");
+  expect(await h.store.read()).toMatchObject({ day: "2026-07-15", trigger: "catch-up" });
+});
+
+test("multiple ticks while a delivery is in flight do not duplicate", async () => {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let calls = 0;
+  const h = scheduler({
+    now: () => local(8, 30),
+    run: async () => { calls++; await gate; return { phase: "delivered" }; },
+  });
+  const first = h.scheduler.tick();
+  const second = h.scheduler.tick();
+  await waitFor(() => calls === 1);
+  expect(calls).toBe(1);
+  release();
+  await Promise.all([first, second]);
+  expect(calls).toBe(1);
+});
+
+test("restart with today's persisted claim does not duplicate", async () => {
+  const store = statusStore();
+  const now = local(8, 31);
+  expect(await store.claim({
+    day: now.toDateString(), scheduledAt: "08:30", trigger: "catch-up",
+    claimedAt: now.getTime(), phase: "claimed",
+  })).toBe(true);
+  let calls = 0;
+  const h = scheduler({ store, now: () => now, run: async () => { calls++; return { phase: "delivered" }; } });
+  await h.scheduler.tick();
+  expect(calls).toBe(0);
+  expect((await store.read())?.phase).toBe("claimed");
+});
+
+test("a corrupt status is quarantined and the next tick can claim and fire", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cicero-briefing-corrupt-"));
+  roots.push(root);
+  const file = join(root, "briefing-status.json");
+  writeFileSync(file, "{broken", { mode: 0o600 });
+  const store = new BriefingStatusStore(file);
+
+  expect(await store.read()).toBeNull();
+  expect(readdirSync(root).some((name) => name.startsWith("briefing-status.json.corrupt-"))).toBe(true);
+
+  let calls = 0;
+  const h = scheduler({ store, now: () => local(8, 30), run: async () => { calls++; return { phase: "delivered" }; } });
+  await h.scheduler.tick();
+  expect(calls).toBe(1);
+  expect((await store.read())?.phase).toBe("delivered");
+});
+
+test("a parseable status with a wrong-typed optional field is quarantined and does not wedge delivery", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cicero-briefing-structural-corrupt-"));
+  roots.push(root);
+  const file = join(root, "briefing-status.json");
+  writeFileSync(file, JSON.stringify({
+    day: "2026-07-14",
+    scheduledAt: "08:30",
+    trigger: "scheduled",
+    claimedAt: local(8, 30, 14).getTime(),
+    phase: "delivered",
+    contentSummary: 7,
+  }), { mode: 0o600 });
+  const store = new BriefingStatusStore(file);
+  let calls = 0;
+  const h = scheduler({ store, now: () => local(8, 30), run: async () => { calls++; return { phase: "delivered" }; } });
+
+  await h.scheduler.tick();
+
+  expect(calls).toBe(1);
+  expect(readdirSync(root).some((name) => name.startsWith("briefing-status.json.corrupt-"))).toBe(true);
+  expect((await store.read())?.phase).toBe("delivered");
+});
+
+test("an oversized status is quarantined instead of wedging future claims", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cicero-briefing-oversized-"));
+  roots.push(root);
+  const file = join(root, "briefing-status.json");
+  writeFileSync(file, `"${"x".repeat(1_000_001)}"`, { mode: 0o600 });
+  const store = new BriefingStatusStore(file);
+
+  expect(await store.read()).toBeNull();
+  expect(readdirSync(root).some((name) => name.startsWith("briefing-status.json.corrupt-"))).toBe(true);
+  expect(await store.claim({
+    day: local(8, 30).toDateString(), scheduledAt: "08:30", trigger: "scheduled",
+    claimedAt: local(8, 30).getTime(), phase: "claimed",
+  })).toBe(true);
+});
+
+test("a valid same-day claim is not quarantined", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cicero-briefing-valid-"));
+  roots.push(root);
+  const file = join(root, "briefing-status.json");
+  const store = new BriefingStatusStore(file);
+  const now = local(8, 30);
+  await store.claim({
+    day: now.toDateString(), scheduledAt: "08:30", trigger: "scheduled",
+    claimedAt: now.getTime(), phase: "claimed",
+  });
+
+  expect((await store.read())?.day).toBe(now.toDateString());
+  expect(readdirSync(root).some((name) => name.includes(".corrupt-"))).toBe(false);
+});
+
+test("restart after the catch-up window records missed and sends nothing", async () => {
+  let calls = 0;
+  const h = scheduler({
+    now: () => local(11, 31),
+    catchUpMinutes: 180,
+    run: async () => { calls++; return { phase: "delivered" }; },
+  });
+  await h.scheduler.tick();
+  expect(calls).toBe(0);
+  expect(await h.store.read()).toMatchObject({ phase: "missed", trigger: "catch-up" });
+});
+
+test("quiet hours delay catch-up until they end", async () => {
+  let now = local(9, 47);
+  let calls = 0;
+  const h = scheduler({
+    now: () => now,
+    catchUpMinutes: 180,
+    quietHours: { from: "23:00", to: "10:00" },
+    run: async () => { calls++; return { phase: "delivered" }; },
+  });
+  await h.scheduler.tick();
+  expect(calls).toBe(0);
+  expect(await h.store.read()).toBeNull();
+  now = local(10, 0);
+  await h.scheduler.tick();
+  expect(calls).toBe(1);
+});
+
+test("quiet hours extending past the cutoff miss instead of making a late call", async () => {
+  let now = local(10, 29);
+  let calls = 0;
+  const h = scheduler({
+    now: () => now,
+    catchUpMinutes: 120,
+    quietHours: { from: "23:00", to: "10:31" },
+    run: async () => { calls++; return { phase: "delivered" }; },
+  });
+  await h.scheduler.tick();
+  now = local(10, 31);
+  await h.scheduler.tick();
+  expect(calls).toBe(0);
+  expect((await h.store.read())?.phase).toBe("missed");
+});
+
+test("spring-forward missing minute catches up and fall-back repeated minute fires once", async () => {
+  let springCalls = 0;
+  const spring = scheduler({
+    at: "02:30",
+    catchUpMinutes: 90,
+    timezone: "America/New_York",
+    now: () => new Date("2026-03-08T07:15:00Z"),
+    run: async () => { springCalls++; return { phase: "delivered" }; },
+  });
+  await spring.scheduler.tick();
+  expect(springCalls).toBe(1);
+  expect((await spring.store.read())?.trigger).toBe("catch-up");
+
+  let fallNow = new Date("2026-11-01T05:30:00Z");
+  let fallCalls = 0;
+  const fall = scheduler({
+    at: "01:30",
+    timezone: "America/New_York",
+    now: () => fallNow,
+    run: async () => { fallCalls++; return { phase: "delivered" }; },
+  });
+  await fall.scheduler.tick();
+  fallNow = new Date("2026-11-01T06:30:00Z");
+  await fall.scheduler.tick();
+  expect(fallCalls).toBe(1);
+});
+
+test("shutdown abort prevents late completion and drains the owned run", async () => {
+  let aborted = false;
+  let started = false;
+  const h = scheduler({
+    now: () => local(8, 30),
+    run: (signal) => new Promise((resolve) => {
+      started = true;
+      signal.addEventListener("abort", () => { aborted = true; resolve({ phase: "delivered" }); }, { once: true });
+    }),
+  });
+  const ticking = h.scheduler.tick();
+  await waitFor(() => started);
+  await h.scheduler.stop();
+  await ticking;
+  expect(aborted).toBe(true);
+  expect((await h.store.read())?.phase).toBe("claimed");
+});
+
+test("aborting an in-flight Telegram briefing cancels the send and preserves its overnight snapshot", async () => {
+  const root = mkdtempSync(join(tmpdir(), "cicero-briefing-abort-"));
+  roots.push(root);
+  const overnight = new OvernightStore(join(root, "overnight.json"), () => 1_700_000_000_000, () => "item-1");
+  await overnight.enqueue("queued overnight");
+  let requestStarted = false;
+  let requestAborted = false;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (_input, init) => new Promise<Response>((_resolve, reject) => {
+    requestStarted = true;
+    const signal = init?.signal;
+    const aborted = (): void => {
+      requestAborted = true;
+      reject(signal?.reason ?? new DOMException("aborted", "AbortError"));
+    };
+    if (signal?.aborted) aborted();
+    else signal?.addEventListener("abort", aborted, { once: true });
+  });
+  const h = scheduler({
+    now: () => local(8, 30),
+    run: async (signal, beforeDelivery) => {
+      const snapshot = await overnight.peek();
+      beforeDelivery();
+      const accepted = await sendTelegramText(
+        { token: "tok", chat_id: 42 },
+        "briefing",
+        "http://telegram.test",
+        {},
+        signal,
+      );
+      if (accepted && !signal.aborted) await overnight.ack(snapshot.map((item) => item.id));
+      signal.throwIfAborted();
+      return { phase: accepted ? "delivered" : "failed" };
+    },
+  });
+
+  try {
+    const ticking = h.scheduler.tick();
+    await waitFor(() => requestStarted);
+    await h.scheduler.stop();
+    await ticking;
+    await waitFor(() => requestAborted);
+    expect((await overnight.peek()).map((item) => item.text)).toEqual(["queued overnight"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("a lookup that crosses the cutoff or local midnight cannot deliver late", async () => {
+  for (const afterLookup of [local(11, 31), local(0, 1, 16)]) {
+    let now = local(8, 30);
+    let delivered = false;
+    const h = scheduler({
+      now: () => now,
+      catchUpMinutes: 180,
+      run: async (_signal, beforeDelivery) => {
+        now = afterLookup;
+        beforeDelivery();
+        delivered = true;
+        return { phase: "delivered" };
+      },
+    });
+
+    await h.scheduler.tick();
+    expect(delivered).toBe(false);
+    expect((await h.store.read())?.phase).toBe("missed");
+  }
+});
+
+test("partial and failure statuses are durable and do not retry the same day", async () => {
+  for (const result of [
+    { phase: "partial", channels: { telegram: "accepted", voice: "failed" }, errorKind: "Voice Provider: body" },
+    { phase: "failed", channels: { telegram: "failed" }, errorKind: "Telegram provider body" },
+  ] satisfies BriefingRunResult[]) {
+    let calls = 0;
+    const h = scheduler({
+      now: () => local(8, 30),
+      run: async () => { calls++; return result; },
+    });
+    await h.scheduler.tick();
+    await h.scheduler.tick();
+    expect(calls).toBe(1);
+    const persisted = await h.store.read();
+    expect(persisted?.phase).toBe(result.phase);
+    expect(persisted?.errorKind).toMatch(/^[a-z0-9_-]+$/);
+  }
+});

--- a/tests/notify/briefing-scheduler.test.ts
+++ b/tests/notify/briefing-scheduler.test.ts
@@ -233,20 +233,31 @@ test("quiet hours extending past the cutoff miss instead of making a late call",
   expect((await h.store.read())?.phase).toBe("missed");
 });
 
-test("spring-forward missing minute catches up and fall-back repeated minute fires once", async () => {
+test("spring-forward gaps resolve later while normal and fall-back times retain catch-up behavior", async () => {
+  let springNow = new Date("2026-03-08T06:45:00Z");
   let springCalls = 0;
   const spring = scheduler({
     at: "02:30",
-    catchUpMinutes: 90,
+    catchUpMinutes: 0,
     timezone: "America/New_York",
-    now: () => new Date("2026-03-08T07:15:00Z"),
+    now: () => springNow,
     run: async () => { springCalls++; return { phase: "delivered" }; },
   });
+  await spring.scheduler.tick();
+  expect(springCalls).toBe(0);
+  expect(await spring.store.read()).toBeNull();
+
+  springNow = new Date("2026-03-08T07:30:00Z");
   await spring.scheduler.tick();
   expect(springCalls).toBe(1);
   expect((await spring.store.read())?.trigger).toBe("catch-up");
 
-  let fallNow = new Date("2026-11-01T05:30:00Z");
+  springNow = new Date("2026-03-09T06:30:00Z");
+  await spring.scheduler.tick();
+  expect(springCalls).toBe(2);
+  expect(await spring.store.read()).toMatchObject({ day: "2026-03-09", trigger: "scheduled" });
+
+  let fallNow = new Date("2026-11-01T05:45:00Z");
   let fallCalls = 0;
   const fall = scheduler({
     at: "01:30",
@@ -255,7 +266,8 @@ test("spring-forward missing minute catches up and fall-back repeated minute fir
     run: async () => { fallCalls++; return { phase: "delivered" }; },
   });
   await fall.scheduler.tick();
-  fallNow = new Date("2026-11-01T06:30:00Z");
+  expect((await fall.store.read())?.trigger).toBe("catch-up");
+  fallNow = new Date("2026-11-01T06:45:00Z");
   await fall.scheduler.tick();
   expect(fallCalls).toBe(1);
 });

--- a/tests/notify/briefing-scheduler.test.ts
+++ b/tests/notify/briefing-scheduler.test.ts
@@ -260,6 +260,59 @@ test("spring-forward missing minute catches up and fall-back repeated minute fir
   expect(fallCalls).toBe(1);
 });
 
+test("fall-back catch-up uses real elapsed time instead of repeated wall-clock minutes", async () => {
+  let calls = 0;
+  const h = scheduler({
+    at: "00:30",
+    catchUpMinutes: 120,
+    timezone: "America/New_York",
+    now: () => new Date("2026-11-01T07:15:00Z"),
+    run: async () => { calls++; return { phase: "delivered" }; },
+  });
+
+  await h.scheduler.tick();
+
+  expect(calls).toBe(0);
+  expect(await h.store.read()).toMatchObject({ day: "2026-11-01", phase: "missed" });
+});
+
+test("spring-forward catch-up stays open for its real elapsed window", async () => {
+  let calls = 0;
+  const h = scheduler({
+    at: "01:30",
+    catchUpMinutes: 90,
+    timezone: "America/New_York",
+    now: () => new Date("2026-03-08T07:15:00Z"),
+    run: async () => { calls++; return { phase: "delivered" }; },
+  });
+
+  await h.scheduler.tick();
+
+  expect(calls).toBe(1);
+  expect(await h.store.read()).toMatchObject({ day: "2026-03-08", phase: "delivered", trigger: "catch-up" });
+});
+
+test("non-transition catch-up retains the configured elapsed window", async () => {
+  let now = new Date("2026-07-15T14:30:00Z");
+  let calls = 0;
+  const h = scheduler({
+    at: "08:30",
+    catchUpMinutes: 120,
+    timezone: "America/New_York",
+    now: () => now,
+    run: async () => { calls++; return { phase: "delivered" }; },
+  });
+
+  await h.scheduler.tick();
+  expect(calls).toBe(1);
+  expect(await h.store.read()).toMatchObject({ phase: "delivered", trigger: "catch-up" });
+
+  now = new Date("2026-07-16T14:31:00Z");
+  await h.scheduler.tick();
+  expect(calls).toBe(1);
+  expect(await h.store.read()).toMatchObject({ day: "2026-07-16", phase: "missed" });
+});
+
 test("shutdown abort prevents late completion and drains the owned run", async () => {
   let aborted = false;
   let started = false;

--- a/tests/notify/overnight-store.test.ts
+++ b/tests/notify/overnight-store.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, expect, test } from "bun:test";
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OvernightStore } from "../../src/notify/overnight-store";
+
+const roots: string[] = [];
+
+function fresh(): { root: string; file: string } {
+  const root = mkdtempSync(join(tmpdir(), "cicero-overnight-"));
+  roots.push(root);
+  return { root, file: join(root, "overnight.json") };
+}
+
+function store(file: string): OvernightStore {
+  let id = 0;
+  return new OvernightStore(file, () => 1_700_000_000_000 + id, () => `item-${++id}`);
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test("peek is non-consuming", async () => {
+  const { file } = fresh();
+  const queue = store(file);
+  await queue.enqueue("one");
+  expect((await queue.peek()).map((item) => item.text)).toEqual(["one"]);
+  expect((await queue.peek()).map((item) => item.text)).toEqual(["one"]);
+});
+
+test("ack removes only the captured snapshot and preserves concurrent enqueue", async () => {
+  const { file } = fresh();
+  const queue = store(file);
+  await queue.enqueue("one");
+  const snapshot = await queue.peek();
+  const adding = queue.enqueue("two");
+  const acknowledging = queue.ack(snapshot.map((item) => item.id));
+  await Promise.all([adding, acknowledging]);
+  expect((await queue.peek()).map((item) => item.text)).toEqual(["two"]);
+});
+
+test("legacy string arrays migrate on read", async () => {
+  const { file } = fresh();
+  writeFileSync(file, JSON.stringify(["one", "two"]), { mode: 0o600 });
+  const queue = store(file);
+  const items = await queue.peek();
+  expect(items.map((item) => item.text)).toEqual(["one", "two"]);
+  expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(items);
+});
+
+test("corrupt files are tolerated and the next enqueue recovers", async () => {
+  const { file } = fresh();
+  writeFileSync(file, "{broken", { mode: 0o600 });
+  const queue = store(file);
+  expect(await queue.peek()).toEqual([]);
+  await queue.enqueue("recovered");
+  expect((await queue.peek()).map((item) => item.text)).toEqual(["recovered"]);
+});
+
+test("oversized and structurally invalid files cannot wedge peek or ack", async () => {
+  const { file } = fresh();
+  writeFileSync(file, `"${"x".repeat(1_000_001)}"`, { mode: 0o600 });
+  const queue = store(file);
+  expect(await queue.peek()).toEqual([]);
+  await queue.ack(["missing"]);
+  expect(JSON.parse(readFileSync(file, "utf8"))).toEqual([]);
+
+  writeFileSync(file, JSON.stringify({ items: "not-an-array" }), { mode: 0o600 });
+  expect(await queue.peek()).toEqual([]);
+  await queue.ack(["missing"]);
+  expect(JSON.parse(readFileSync(file, "utf8"))).toEqual([]);
+});
+
+test.skipIf(process.platform === "win32")("unsafe file and directory symlinks are rejected", () => {
+  const { root, file } = fresh();
+  const target = join(root, "target.json");
+  writeFileSync(target, "[]", { mode: 0o600 });
+  symlinkSync(target, file, "file");
+  expect(() => store(file)).toThrow(/unsafe private file path/);
+
+  const real = join(root, "real");
+  const linked = join(root, "linked");
+  mkdirSync(real);
+  symlinkSync(real, linked, "dir");
+  expect(() => store(join(linked, "overnight.json"))).toThrow(/unsafe private directory path/);
+  expect(lstatSync(linked).isSymbolicLink()).toBe(true);
+});
+
+test.skipIf(process.platform === "win32")("writes remain private", async () => {
+  const { file } = fresh();
+  const queue = store(file);
+  await queue.enqueue("one");
+  expect(lstatSync(file).mode & 0o777).toBe(0o600);
+});

--- a/tests/notify/telegram.test.ts
+++ b/tests/notify/telegram.test.ts
@@ -41,6 +41,14 @@ function shellQuote(value: string): string {
 type JsonObject = Record<string, unknown>;
 type CapturedCall = { path: string; body: JsonObject };
 
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (condition()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("condition was not reached");
+}
+
 function jsonObject(value: unknown): JsonObject {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error("expected a JSON object");
@@ -230,6 +238,37 @@ test("sendTelegramText posts a plain message, no ffmpeg involved", async () => {
 test("sendTelegramText without token or chat_id is a quiet no-op", async () => {
   expect(await sendTelegramText({ chat_id: 42 }, "x")).toBe(false);
   expect(await sendTelegramText({ token: "tok" }, "x")).toBe(false);
+});
+
+test("sendTelegramText combines an external abort with its request deadline", async () => {
+  let requestStarted = false;
+  let requestAborted = false;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (_input, init) => new Promise<Response>((_resolve, reject) => {
+    requestStarted = true;
+    const signal = init?.signal;
+    signal?.addEventListener("abort", () => {
+      requestAborted = true;
+      reject(signal.reason ?? new DOMException("aborted", "AbortError"));
+    }, { once: true });
+  });
+  const controller = new AbortController();
+  try {
+    const sending = sendTelegramText(
+      { token: "tok", chat_id: 42 },
+      "briefing",
+      "http://telegram.test",
+      {},
+      controller.signal,
+    );
+    await waitFor(() => requestStarted);
+    controller.abort(new Error("briefing stopped"));
+    expect(await sending).toBe(false);
+    await waitFor(() => requestAborted);
+    expect(requestAborted).toBe(true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 function confirmationBrain(pending = true, nonce = GATE_A): Brain {

--- a/tests/platform/private-json.test.ts
+++ b/tests/platform/private-json.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PrivateJsonTooLargeError,
+  readPrivateJson,
+  writePrivateJson,
+} from "../../src/platform/private-json";
+
+const roots: string[] = [];
+
+function freshFile(): string {
+  const root = mkdtempSync(join(tmpdir(), "cicero-private-json-"));
+  roots.push(root);
+  return join(root, "state.json");
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test("a durable atomic write publishes a present, parseable file", async () => {
+  const file = freshFile();
+  await writePrivateJson(file, { day: "2026-07-15", claimed: true });
+
+  expect(existsSync(file)).toBe(true);
+  expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ day: "2026-07-15", claimed: true });
+  expect(await readPrivateJson(file)).toEqual({ day: "2026-07-15", claimed: true });
+});
+
+test("reads reject an oversized private JSON file before retaining its contents", async () => {
+  const file = freshFile();
+  writeFileSync(file, `"${"x".repeat(64)}"`, { mode: 0o600 });
+
+  await expect(readPrivateJson(file, 32)).rejects.toBeInstanceOf(PrivateJsonTooLargeError);
+});


### PR DESCRIPTION
## Why

The morning briefing was an in-process **exact-minute** timer. If the daemon wasn't alive at `notify.briefing.at`, the day's brief was silently skipped forever — real incident **2026-07-15**: a ~10h outage straddled the 08:30 slot and no brief was delivered (the user asked "where is my morning brief" hours later and got nothing). A restart loop could also **double-fire** (two texts / two calls), and overnight items were cleared *before* delivery was confirmed.

## What

Replace the timer with a durable, unit-tested scheduler:

- **`BriefingScheduler`** — bounded catch-up window (`notify.briefing.catch_up_minutes`, default **180**, `0` = exact-minute-only) + a **persisted daily claim** (`~/.cicero/briefing-status.json`). At-most-once daily across restarts: a late start *inside* the window catches up; a late-evening restart correctly stays silent.
- **`OvernightStore`** (`peek`/`ack`) replaces the consuming `takeOvernight()`. Items are acked **only after** a channel accepts the brief, so a failed or aborted delivery never drops overnight news; concurrent enqueues survive.
- **Crash-durable storage** — atomic private-JSON writes with `fsync` of both file and directory, bounded reads, and **quarantine-and-recover** for a corrupt/invalid status file (a bad file can never permanently disable briefings).
- **Cancellable delivery** — the abort signal threads through `sendTelegramText` and the voice/callback path; a window that closes mid-run records `"missed"` instead of sending late.

## How it was reviewed

Designed and implemented in collaboration with an independent model (Codex `gpt-5.6-sol`, high effort) under a brain-agnostic constraint, then put through **two adversarial review passes**. Those passes caught real durability/cancellation defects that green tests hid — fsync durability, Telegram cancellation, a corrupt-file wedge (twice: required-field then optional-field validation), and a delivery-window slip — all fixed here.

### Accepted low-severity limitations (documented in-code)
- A delivery whose voice **TTS synthesis** crosses the cutoff/quiet-hours boundary may complete slightly late. Immaterial for realistic times (08:30, cutoff +180m; TTS is seconds).
- A degenerate `at:` **inside** quiet hours (e.g. 23:30) may not record a `"missed"` status — affects the informational record only, never delivery. Not a supported morning-briefing time.
- Pre-existing `telegram.ts` error-body logging redacts only the bot token — flagged for a separate hardening PR, out of scope here.

## Tests
`bun run typecheck` clean; full suite **1870 pass / 5 skip / 0 fail**. New regressions: scheduler (exact-minute, catch-up, no-double-fire, restart-claim, missed-after-cutoff, quiet-hours, DST, abort-drain, partial/failure, no-same-day-retry), overnight store (non-consuming peek, snapshot-only ack, concurrent enqueue, legacy migration, corruption, symlink), durable/bounded/quarantine private-JSON, and Telegram abort.

## Scope / deploy
No brain-context changes (planned follow-up PR 2). **Deploy needs a daemon restart** to pick up the new scheduler.