### PR TITLE
docs: task-oriented documentation map (docs/README.md)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+# Cicero documentation
+
+Start from what you're trying to do. Every guide below is current unless it
+says otherwise; the [historical records](#history-dated-records) at the bottom
+are provenance, not guidance.
+
+## Understand it
+
+| Read | For |
+|---|---|
+| [Project README](../README.md) | What Cicero is, what it feels like, and what you need |
+| [Architecture](architecture.md) | The three runtime shapes and how a spoken turn flows through them |
+| [Why not full-duplex](duplex.md) | The core design decision: honest turn-taking with fast barge-in |
+| [The office](office.md) | Lanes: several agents with their own voices behind one call |
+
+## Have your first conversation
+
+| Read | For |
+|---|---|
+| [Setup](setup.md) | The canonical install path — prerequisites to first spoken reply, per platform |
+| [Choosing a brain](brains.md) | Which agent to plug in (Claude Code, Codex, Gemini, ACP, any OpenAI-compatible endpoint) and how |
+| [Configuration](configuration.md) | Deployment tiers, the config schema, quick intents, custom voice actions — with [`config.yaml.example`](../config.yaml.example) as the annotated reference |
+
+## Operate it
+
+| Read | For |
+|---|---|
+| [Web voice](web-voice.md) | The browser/PWA surface: controls, identity, limits |
+| [Daemon mode & local mic](daemon-mode.md) | Lifecycle, activation, echo cancellation, computer use on the local machine |
+| [Voice activation](voice-activation.md) | Hands-free start, claps, VAD tuning, earcons |
+| [Turn detection](turn-detection.md) | Semantic end-of-turn (Smart-Turn): what it fixes and how to enable it |
+| [Voice cloning](voice-cloning.md) | Giving Cicero (or a lane) any voice from one reference clip |
+| [Notifications](notifications.md) | Cicero speaking up on its own: Telegram, briefings, schedules, quiet hours |
+| [Telegram calls](../sidecars/telegram-call/README.md) | The phone-call sidecar: talk to your agent from anywhere |
+| [Security](security.md) | Threat model, authentication, egress rules — read before exposing anything beyond localhost |
+
+## Extend it
+
+| Read | For |
+|---|---|
+| [Choosing a brain → custom drivers](brains.md) | The three tiers of adding an agent, from zero-code to a small adapter |
+| [Configuration → quick intents](configuration.md#quick-intents--your-own-zero-latency-phrases) | Your own zero-latency phrases and voice actions, pure YAML |
+| [Python model servers](../requirements/README.md) | How the speech sidecars are provisioned |
+
+## History (dated records)
+
+Point-in-time snapshots kept for provenance. Claims inside describe their date,
+not the current product.
+
+- [Lessons learned](lessons-learned.md) — the first three days (March 2026)
+- [Performance & portability evaluation](performance-portability-evaluation.md) — June 2026 audit
+- [Evaluation follow-up](evaluation-follow-up-2026-07.md) — the July 2026 hardening series
+- `superpowers/plans/`, `superpowers/specs/` — historical design records, not the backlog

--- a/docs/turn-detection.md
+++ b/docs/turn-detection.md
@@ -119,9 +119,15 @@ turn:
   timeout_ms: 10000      # absolute /predict deadline, including response body
 ```
 
-**Tuning tip:** turn detection composes with a *shorter* `silence_duration`.
-Lower it (e.g. `"0.5"`) for snappy turn-taking — the grace loop catches the
-mid-thought cutoffs that a short timer would otherwise cause.
+**Tuning tip (local-mic conversational mode):** turn detection composes with a
+*shorter* quiet window. On the local mic's default path that window is the
+streaming VAD's `vad.hangover_ms` — lower it (e.g. `300`) for snappy
+turn-taking; `silence_duration` only governs when `vad.enabled: false`, where
+`"0.5"` is the equivalent move. Either way the grace loop catches the
+mid-thought cutoffs a short window would otherwise cause. These knobs do not
+apply to the browser path: the web-voice page runs its own client-side VAD
+with a fixed hangover, and Smart-Turn rides on top of whatever the client
+sends.
 
 This touches the load-bearing listen loop, so it stays gated behind
 verify-before-stacking — confirm the conversational voice path on hardware first.


### PR DESCRIPTION
Item 3 of the docs plan.

New `docs/README.md` — a router organized by reader intent (**understand / first conversation / operate / extend / history**) rather than a flat file list. Dated records get their own fenced-off section so their claims aren't mistaken for current guidance.

All links verified against files on this branch. The main README's Docs section will point here in the upcoming README-restructure PR; nothing else changes in this one. Docs-only, `git diff --check` clean.