### PR TITLE
ci(dependabot): group torch-family pip bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # torch and torchaudio are a tested lockstep pair (ser.txt pins both);
+    # bumping one without the other is unresolvable, so group the family
+    # into a single PR.
+    groups:
+      torch:
+        patterns:
+          - "torch*"


### PR DESCRIPTION
Dependabot's torch-only bump in #26 left `torchaudio==2.10.0` behind, making `requirements/ser.txt` unresolvable (the pair is pinned in lockstep — the python-portability check caught it). This groups `torch*` pip updates so the family always arrives as a single coherent PR.

Config-only change; YAML validated. Supersedes the approach in #26 (closed).