### PR TITLE
ci(dependabot): only bump pip floors when the range excludes the release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # The manifests use floor+cap ranges (>=X,<MAJOR) precisely so fresh
+    # installs pick up new releases without a manifest edit. Raising a floor
+    # the range already satisfies changes nothing for real installs, and can
+    # even break a documented support target (scipy>=1.18 dropped Python
+    # 3.11 — closed PR #29). Only PR when the range genuinely excludes the
+    # newest release; security updates are unaffected by this setting.
+    versioning-strategy: increase-if-necessary
     # torch and torchaudio are a tested lockstep pair (ser.txt pins both);
     # bumping one without the other is unresolvable, so group the family
     # into a single PR.


### PR DESCRIPTION
Weekly pip sweeps were producing cosmetic floor-raise PRs (#29–#32): the manifests use floor+cap ranges precisely so fresh installs pick up new releases without a manifest edit, so raising a floor the range already satisfies changes nothing — and can break a documented support target (scipy>=1.18 requires Python ≥3.12; #29 closed for that).

`versioning-strategy: increase-if-necessary` makes dependabot PR only when the newest release falls outside the current range (so real pins like the torch group still bump, and security updates are unaffected by this setting per GitHub docs).

Config-only; YAML validated.