### PR TITLE
feat(web-voice): daemon-owned reachability tunnel (tailscale/cloudflared)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -33,6 +33,11 @@ web_voice:
   # tls: { cert_file: /etc/cicero/cert.pem, key_file: /etc/cicero/key.pem }
   # `tls: { enabled: false }` explicitly permits plaintext HTTP; never use it
   # on an untrusted network.
+  # Optional daemon-owned public tunnel. `auto` prefers tailscale, then
+  # cloudflared, and startup errors if neither binary is installed. An explicit
+  # provider never falls back to the other one. Tunnel startup failures after
+  # launch leave this local/LAN web-voice listener running.
+  # tunnel: { provider: auto } # auto | tailscale | cloudflared
   # TLDR speech gate is on by default: long replies speak the first N sentences
   # plus a generic coda; say "details" to hear the rest. Add an optional local
   # OpenAI-compatible summarizer for a model-written coda. Set enabled: false to

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -554,7 +554,7 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
   }
   if (isRecord(config.web_voice)) {
     checkKnownKeys(config.web_voice, "web_voice", [
-      "enabled", "host", "port", "token", "tls", "resume_turns", "speech_gate", "tldr", "speculative", "long_turn",
+      "enabled", "host", "port", "token", "tls", "tunnel", "resume_turns", "speech_gate", "tldr", "speculative", "long_turn",
     ], issues);
   }
   if (isRecord(config.turn)) {
@@ -589,10 +589,10 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
         issues.push(`web_voice.token ${problem}; ${WEB_VOICE_TOKEN_GENERATION_HINT}`);
       }
     }
-    for (const name of ["tls", "tldr", "speculative", "long_turn"] as const) {
+    for (const name of ["tls", "tunnel", "tldr", "speculative", "long_turn"] as const) {
       const section = config.web_voice[name];
       if (section === undefined || !checkRecord(section, `web_voice.${name}`, issues)) continue;
-      checkOptionalBoolean(section, "enabled", `web_voice.${name}`, issues);
+      if (name !== "tunnel") checkOptionalBoolean(section, "enabled", `web_voice.${name}`, issues);
     }
     if (isRecord(config.web_voice.tls)) {
       checkKnownKeys(config.web_voice.tls, "web_voice.tls", [
@@ -602,6 +602,13 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
       checkOptionalString(config.web_voice.tls, "key_file", "web_voice.tls", issues);
       if ((config.web_voice.tls.cert_file === undefined) !== (config.web_voice.tls.key_file === undefined)) {
         issues.push("web_voice.tls.cert_file and web_voice.tls.key_file must be configured together");
+      }
+    }
+    if (isRecord(config.web_voice.tunnel)) {
+      checkKnownKeys(config.web_voice.tunnel, "web_voice.tunnel", ["provider"], issues);
+      const provider = config.web_voice.tunnel.provider;
+      if (provider !== "auto" && provider !== "tailscale" && provider !== "cloudflared") {
+        issues.push("web_voice.tunnel.provider must be one of: auto, tailscale, cloudflared");
       }
     }
     if (isRecord(config.web_voice.tldr)) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -48,6 +48,10 @@ import {
 import { startDashboard, type DashboardHandle, type VoiceControlAction } from "./dashboard/server";
 import { dashBus } from "./dashboard/bus";
 import { startWebVoiceServer, type WebVoiceHandle } from "./web-voice/server";
+import {
+  startWebVoiceTunnel,
+  type WebVoiceTunnelHandle,
+} from "./web-voice/tunnel";
 import { ensureVadAssets } from "./web-voice/vad-assets";
 import { assertWebTlsPolicy, ensureTls } from "./web-voice/tls";
 import {
@@ -273,6 +277,8 @@ export class CiceroDaemon {
   private voiceInputHandoff: Promise<void> = Promise.resolve();
   private dashboard: DashboardHandle | null = null;
   private webVoice: WebVoiceHandle | null = null;
+  private webVoiceTunnelOwner: Pick<WebVoiceTunnelHandle, "stop"> | null = null;
+  private webVoiceTunnel: WebVoiceTunnelHandle | null = null;
   private kanbanWatcher: KanbanWatcher | null = null;
   private briefingScheduler: Pick<BriefingScheduler, "start" | "stop"> | null = null;
   private promptScheduler: PromptScheduler | null = null;
@@ -1401,6 +1407,17 @@ export class CiceroDaemon {
       });
       assertHeadlessWebVoiceStarted(this.config.headless, this.webVoice !== null, webHost, webPort);
       if (this.webVoice) {
+        if (wv.tunnel) {
+          this.webVoiceTunnel = await startWebVoiceTunnel({
+            config: wv.tunnel,
+            localScheme: this.webVoice.scheme,
+            localHost: webHost,
+            localPort: this.webVoice.port,
+            signal: this.lifecycleAbort.signal,
+            onOwned: (owner) => { this.webVoiceTunnelOwner = owner; },
+          });
+          this.assertStartupActive();
+        }
         if (tokenIsEphemeral) {
           // This intentionally bypasses log()/dashBus: startup stdout receives
           // the one-run credential, but the browser dashboard must never receive
@@ -1409,9 +1426,17 @@ export class CiceroDaemon {
           console.log(
             `Voice client (ephemeral token): ${this.webVoice.scheme}://<this-box-ip>:${this.webVoice.port}/?token=${token}`,
           );
+          if (this.webVoiceTunnel) {
+            console.log(
+              `Voice client via ${this.webVoiceTunnel.provider} (ephemeral token): ${this.webVoiceTunnel.publicUrl}/?token=${token}`,
+            );
+          }
           console.log("Set web_voice.token in ~/.cicero/config.yaml for a stable credential.");
         } else {
           log("ok", `🎙️  Voice client: ${this.webVoice.scheme}://<this-box-ip>:${this.webVoice.port}/?token=<redacted>`);
+          if (this.webVoiceTunnel) {
+            log("ok", `🎙️  Voice client via ${this.webVoiceTunnel.provider}: ${this.webVoiceTunnel.publicUrl}/?token=<redacted>`);
+          }
         }
         if (this.webVoice.scheme === "http") {
           log("warn", "web-voice is HTTP — the browser mic only works from localhost. Add a TLS cert for LAN access.");
@@ -1632,7 +1657,12 @@ export class CiceroDaemon {
     if (this.config.headless) {
       console.log(`Cicero ready (headless — web voice only; local mic/speaker/clap/hotkey disabled).`);
       console.log(`Brain: ${brainLabel} | TTS: ${this.config.ttsEnabled ? "on" : "off"}`);
-      if (this.webVoice) console.log(`Talk to it: ${this.webVoice.scheme}://<this-box-ip>:${this.webVoice.port}/?token=<token>`);
+      if (this.webVoice) {
+        console.log(`Talk to it: ${this.webVoice.scheme}://<this-box-ip>:${this.webVoice.port}/?token=<token>`);
+        if (this.webVoiceTunnel) {
+          console.log(`Talk to it via ${this.webVoiceTunnel.provider}: ${this.webVoiceTunnel.publicUrl}/?token=<token>`);
+        }
+      }
       else log("warn", "web_voice is disabled — nothing can reach Cicero. Set web_voice.enabled: true.");
     } else {
       console.log(`Cicero ready. Listening for commands.`);
@@ -2432,6 +2462,7 @@ export class CiceroDaemon {
     };
     return Promise.allSettled([
       invoke(this.dashboard),
+      invoke(this.webVoiceTunnelOwner),
       invoke(this.webVoice),
     ]).then((outcomes) => {
       const failures = outcomes.flatMap((outcome) =>
@@ -2592,6 +2623,8 @@ export class CiceroDaemon {
         this.startupPolicies = {};
         this.serProvider = null;
         this.dashboard = null;
+        this.webVoiceTunnelOwner = null;
+        this.webVoiceTunnel = null;
         this.webVoice = null;
         this.voiceDesiredActive = false;
         this.voiceTransition = Promise.resolve();

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,9 @@ export interface WebVoiceConfig {
   // cert is generated under ~/.cicero/web-voice/ via openssl. An exposed listener fails
   // closed if generation fails; tls.enabled:false is the explicit plaintext opt-in.
   tls?: { cert_file?: string; key_file?: string; enabled?: boolean };
+  // Optional daemon-owned public reachability process. `auto` prefers
+  // tailscale, then cloudflared; absence of the block leaves tunneling off.
+  tunnel?: WebVoiceTunnelConfig;
   // After a daemon restart, prime the fresh agent session with a recap of the
   // last N conversation turns (rides the warmup ping). 0 disables. Default 10.
   resume_turns?: number;
@@ -117,6 +120,10 @@ export interface WebVoiceConfig {
     max_background_s?: number; // give up on the detached brain after this (default 600)
     line?: string;             // override the spoken hand-back
   };
+}
+
+export interface WebVoiceTunnelConfig {
+  provider: "auto" | "tailscale" | "cloudflared";
 }
 
 // Streaming voice-activity detection for end-of-turn. Replaces the legacy sox

--- a/src/web-voice/tunnel.ts
+++ b/src/web-voice/tunnel.ts
@@ -1,0 +1,355 @@
+import { log } from "../logger";
+import {
+  spawnOwnedProcess,
+  terminateOwnedProcessTree,
+  type OwnedProcess,
+} from "../process/owned-process";
+import type { WebVoiceTunnelConfig } from "../types";
+
+export type TunnelProvider = Exclude<WebVoiceTunnelConfig["provider"], "auto">;
+
+export interface TunnelProcess extends OwnedProcess {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+}
+
+export interface TunnelRuntime {
+  which: (binary: TunnelProvider) => string | null;
+  spawn: (command: readonly string[]) => TunnelProcess;
+  terminate: (proc: TunnelProcess) => Promise<void>;
+  log: (level: "ok" | "warn", message: string) => void;
+}
+
+export interface StartWebVoiceTunnelOptions {
+  config: WebVoiceTunnelConfig;
+  localScheme: "http" | "https";
+  /** Configured listener host. Wildcard binds are reached through loopback. */
+  localHost?: string;
+  localPort: number;
+  /** Absolute budget for obtaining the provider URL. Defaults to 30 seconds. */
+  deadlineMs?: number;
+  /** Combined stdout/stderr byte limit while discovering the public URL. */
+  outputLimitBytes?: number;
+  /** Daemon lifecycle cancellation; an in-progress launch is cleaned up. */
+  signal?: AbortSignal;
+  /** Publish cleanup ownership synchronously in the same turn as spawn. */
+  onOwned?: (owner: Pick<WebVoiceTunnelHandle, "stop">) => void;
+  runtime?: TunnelRuntime;
+}
+
+export interface WebVoiceTunnelHandle {
+  provider: TunnelProvider;
+  /** Public origin only. Credentials, query strings, and paths are discarded. */
+  publicUrl: string;
+  stop: () => Promise<void>;
+}
+
+const DEFAULT_URL_DEADLINE_MS = 30_000;
+const DEFAULT_OUTPUT_LIMIT_BYTES = 64 * 1024;
+
+const defaultRuntime: TunnelRuntime = {
+  which: (binary) => Bun.which(binary),
+  spawn: (command) => spawnOwnedProcess(command, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env },
+    windowsHide: true,
+  }) as TunnelProcess,
+  terminate: (proc) => terminateOwnedProcessTree(proc),
+  log: (level, message) => log(level, message),
+};
+
+class TunnelStartupError extends Error {
+  constructor(readonly reason: "deadline" | "output-limit" | "exited" | "output-closed" | "cancelled") {
+    const detail = reason === "deadline"
+      ? "URL discovery deadline expired"
+      : reason === "output-limit"
+        ? "subprocess output limit exceeded"
+        : reason === "exited"
+          ? "provider process exited before publishing a URL"
+          : reason === "cancelled"
+            ? "tunnel startup was cancelled"
+            : "provider output closed before publishing a URL";
+    super(detail);
+    this.name = "TunnelStartupError";
+  }
+}
+
+interface OutputWatcher {
+  ready: Promise<string>;
+  cancel: () => Promise<void>;
+}
+
+/**
+ * Start one daemon-owned reachability process. Missing configured binaries are
+ * configuration/startup errors. Failures after a child is spawned are cleaned
+ * up and degrade to the local web-voice listener.
+ */
+export async function startWebVoiceTunnel(
+  options: StartWebVoiceTunnelOptions,
+): Promise<WebVoiceTunnelHandle | null> {
+  const runtime = options.runtime ?? defaultRuntime;
+  const deadlineMs = positiveInteger(options.deadlineMs ?? DEFAULT_URL_DEADLINE_MS, "deadlineMs");
+  const outputLimitBytes = positiveInteger(
+    options.outputLimitBytes ?? DEFAULT_OUTPUT_LIMIT_BYTES,
+    "outputLimitBytes",
+  );
+  const localPort = port(options.localPort);
+  options.signal?.throwIfAborted();
+  const { provider, binary } = resolveProvider(options.config.provider, runtime.which);
+  const localUrl = localTargetUrl(options.localScheme, options.localHost, localPort);
+  const command = tunnelCommand(provider, binary, localUrl, options.localScheme === "https");
+
+  let proc: TunnelProcess;
+  try {
+    proc = runtime.spawn(command);
+  } catch {
+    runtime.log("warn", `web-voice ${provider} tunnel could not start; continuing with local web voice`);
+    return null;
+  }
+
+  let watcher!: OutputWatcher;
+  let stopTask: Promise<void> | null = null;
+  let stopping = false;
+  const stop = (): Promise<void> => {
+    if (stopTask) return stopTask;
+    stopping = true;
+    const task = runtime.terminate(proc).finally(() => watcher.cancel());
+    const tracked = task.catch((error: unknown) => {
+      if (stopTask === tracked) stopTask = null;
+      throw error;
+    });
+    stopTask = tracked;
+    return tracked;
+  };
+  watcher = watchForPublicUrl({
+    proc,
+    provider,
+    deadlineMs,
+    outputLimitBytes,
+    signal: options.signal,
+  });
+  try {
+    options.onOwned?.({ stop });
+  } catch {
+    await stop();
+    throw new Error(`web-voice ${provider} tunnel ownership could not be published`);
+  }
+
+  const exitedBeforeReady = proc.exited.then(
+    () => Promise.reject(new TunnelStartupError("exited")),
+    () => Promise.reject(new TunnelStartupError("exited")),
+  );
+
+  let publicUrl: string;
+  try {
+    publicUrl = await Promise.race([watcher.ready, exitedBeforeReady]);
+  } catch (error: unknown) {
+    try {
+      await stop();
+    } catch (cleanupError: unknown) {
+      throw new Error(`web-voice ${provider} tunnel failed and its owned process cleanup was not confirmed`, {
+        cause: cleanupError,
+      });
+    }
+    const reason = error instanceof TunnelStartupError ? error.message : "provider startup failed";
+    runtime.log("warn", `web-voice ${provider} tunnel failed: ${reason}; continuing with local web voice`);
+    return null;
+  }
+
+  // Observe the long-lived child for its whole lifetime. The output watcher
+  // enforces the discovery byte cap, then drains without retaining provider
+  // output so the child cannot block on a full pipe.
+  void proc.exited.then(
+    () => {
+      if (!stopping) runtime.log("warn", `web-voice ${provider} tunnel process exited`);
+    },
+    () => {
+      if (!stopping) runtime.log("warn", `web-voice ${provider} tunnel exit observation failed`);
+    },
+  );
+  runtime.log("ok", `web-voice ${provider} tunnel ready at ${publicUrl}`);
+  return { provider, publicUrl, stop };
+}
+
+function resolveProvider(
+  configured: WebVoiceTunnelConfig["provider"],
+  which: TunnelRuntime["which"],
+): { provider: TunnelProvider; binary: string } {
+  if (configured === "auto") {
+    const tailscale = which("tailscale");
+    if (tailscale) return { provider: "tailscale", binary: tailscale };
+    const cloudflared = which("cloudflared");
+    if (cloudflared) return { provider: "cloudflared", binary: cloudflared };
+    throw new Error(
+      "web_voice.tunnel provider 'auto' found neither tailscale nor cloudflared; install one and ensure it is on PATH",
+    );
+  }
+  const binary = which(configured);
+  if (!binary) {
+    throw new Error(
+      `web_voice.tunnel provider '${configured}' was explicitly configured but ${configured} was not found; install ${configured} and ensure it is on PATH`,
+    );
+  }
+  return { provider: configured, binary };
+}
+
+function tunnelCommand(
+  provider: TunnelProvider,
+  binary: string,
+  localUrl: string,
+  insecureTlsUpstream: boolean,
+): string[] {
+  if (provider === "tailscale") {
+    const target = insecureTlsUpstream
+      ? localUrl.replace(/^https:/, "https+insecure:")
+      : localUrl;
+    return [binary, "serve", "--https=443", target];
+  }
+  const command = [binary, "tunnel", "--no-autoupdate", "--url", localUrl];
+  if (insecureTlsUpstream) command.push("--no-tls-verify");
+  return command;
+}
+
+function watchForPublicUrl(options: {
+  proc: TunnelProcess;
+  provider: TunnelProvider;
+  deadlineMs: number;
+  outputLimitBytes: number;
+  signal?: AbortSignal;
+}): OutputWatcher {
+  const readers = [options.proc.stdout.getReader(), options.proc.stderr.getReader()];
+  const retained = ["", ""];
+  let totalBytes = 0;
+  let closedReaders = 0;
+  let readySettled = false;
+  let limitHandled = false;
+  let resolveReady!: (url: string) => void;
+  let rejectReady!: (error: Error) => void;
+  const ready = new Promise<string>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const timer = setTimeout(() => {
+    if (readySettled) return;
+    readySettled = true;
+    rejectReady(new TunnelStartupError("deadline"));
+  }, options.deadlineMs);
+  const onAbort = (): void => {
+    if (readySettled) return;
+    readySettled = true;
+    clearTimeout(timer);
+    rejectReady(new TunnelStartupError("cancelled"));
+  };
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+  if (options.signal?.aborted) onAbort();
+
+  const inspect = (chunk: Uint8Array, readerIndex: number, decoder: TextDecoder): void => {
+    // Once the origin is known, drain and discard all later output so the
+    // long-lived child cannot block on a full pipe and no untrusted bytes are
+    // retained or logged.
+    if (readySettled) return;
+    if (limitHandled) return;
+    totalBytes += chunk.byteLength;
+    if (totalBytes > options.outputLimitBytes) {
+      limitHandled = true;
+      readySettled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+      rejectReady(new TunnelStartupError("output-limit"));
+      return;
+    }
+    retained[readerIndex] += decoder.decode(chunk, { stream: true });
+    const url = extractPublicOrigin(retained[readerIndex], options.provider);
+    if (!url) return;
+    readySettled = true;
+    retained[0] = "";
+    retained[1] = "";
+    clearTimeout(timer);
+    options.signal?.removeEventListener("abort", onAbort);
+    resolveReady(url);
+  };
+
+  readers.forEach((reader, readerIndex) => {
+    const decoder = new TextDecoder();
+    void (async () => {
+      try {
+        while (true) {
+          const next = await reader.read();
+          if (next.done) break;
+          inspect(next.value, readerIndex, decoder);
+          if (limitHandled) break;
+        }
+      } catch {
+        // Stream errors are represented as a controlled closed-output failure;
+        // raw provider text and stream errors are never interpolated into logs.
+      } finally {
+        closedReaders += 1;
+        if (closedReaders === readers.length && !readySettled) {
+          readySettled = true;
+          clearTimeout(timer);
+          options.signal?.removeEventListener("abort", onAbort);
+          rejectReady(new TunnelStartupError("output-closed"));
+        }
+      }
+    })();
+  });
+
+  let cancelTask: Promise<void> | null = null;
+  return {
+    ready,
+    cancel: () => cancelTask ??= Promise.allSettled(readers.map((reader) => reader.cancel())).then(() => {
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+    }),
+  };
+}
+
+function localTargetUrl(scheme: "http" | "https", configuredHost: string | undefined, localPort: number): string {
+  const rawHost = configuredHost?.trim() || "127.0.0.1";
+  const host = rawHost === "0.0.0.0"
+    ? "127.0.0.1"
+    : rawHost === "::" || rawHost === "[::]"
+      ? "[::1]"
+      : rawHost.includes(":") && !rawHost.startsWith("[")
+        ? `[${rawHost}]`
+        : rawHost;
+  try {
+    const url = new URL(`${scheme}://${host}`);
+    if (url.username || url.password || url.pathname !== "/" || url.search || url.hash) throw new Error("unsafe host");
+    url.port = String(localPort);
+    return url.origin;
+  } catch {
+    throw new Error("web_voice.host cannot be used as a tunnel upstream host");
+  }
+}
+
+function extractPublicOrigin(text: string, provider: TunnelProvider): string | null {
+  for (const match of text.matchAll(/https:\/\/[^\s<>"']+/gi)) {
+    try {
+      const url = new URL(match[0]);
+      if (url.protocol !== "https:" || url.username || url.password) continue;
+      const hostname = url.hostname.toLowerCase();
+      const valid = provider === "cloudflared"
+        ? hostname.endsWith(".trycloudflare.com")
+        : hostname.endsWith(".ts.net");
+      if (valid) return url.origin;
+    } catch {
+      // Keep scanning the bounded provider output for a valid URL.
+    }
+  }
+  return null;
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) throw new TypeError(`${name} must be a positive integer`);
+  return value;
+}
+
+function port(value: number): number {
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new TypeError("localPort must be an integer between 1 and 65535");
+  }
+  return value;
+}

--- a/tests/web-voice/tunnel.test.ts
+++ b/tests/web-voice/tunnel.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../src/config";
+import { validateRuntimeConfig } from "../../src/config-validation";
+import {
+  startWebVoiceTunnel,
+  type TunnelProcess,
+  type TunnelRuntime,
+} from "../../src/web-voice/tunnel";
+
+const PUBLIC_URL = "https://cicero-test.example.ts.net";
+const CLOUDFLARE_URL = "https://plain-bird-123.trycloudflare.com";
+
+function stream(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function pendingStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream({ start() {} });
+}
+
+function fakeProcess(output: {
+  stdout?: ReadableStream<Uint8Array>;
+  stderr?: ReadableStream<Uint8Array>;
+} = {}): TunnelProcess {
+  return {
+    pid: 4242,
+    exited: new Promise<number>(() => {}),
+    kill: () => {},
+    stdout: output.stdout ?? stream(),
+    stderr: output.stderr ?? stream(),
+  };
+}
+
+function runtime(overrides: Partial<TunnelRuntime> = {}): TunnelRuntime {
+  return {
+    which: () => "/usr/bin/tailscale",
+    spawn: () => fakeProcess({ stdout: stream(`Available at ${PUBLIC_URL}/\n`) }),
+    terminate: () => Promise.resolve(),
+    log: () => {},
+    ...overrides,
+  };
+}
+
+describe("web voice tunnel config", () => {
+  test("accepts the provider block and rejects unknown nested keys", () => {
+    const valid = structuredClone(DEFAULT_CONFIG);
+    valid.web_voice = { tunnel: { provider: "auto" } };
+    expect(() => validateRuntimeConfig(valid, "test config")).not.toThrow();
+
+    const unknown = structuredClone(DEFAULT_CONFIG) as typeof DEFAULT_CONFIG & {
+      web_voice: { tunnel: { provider: "auto"; surprise: boolean } };
+    };
+    unknown.web_voice = { tunnel: { provider: "auto", surprise: true } };
+    expect(() => validateRuntimeConfig(unknown, "test config"))
+      .toThrow(/web_voice\.tunnel\.surprise is not supported/);
+
+    const invalid = structuredClone(DEFAULT_CONFIG);
+    invalid.web_voice = { tunnel: { provider: "other" as "auto" } };
+    expect(() => validateRuntimeConfig(invalid, "test config"))
+      .toThrow(/web_voice\.tunnel\.provider/);
+  });
+});
+
+describe("startWebVoiceTunnel", () => {
+  test("auto selects tailscale first without probing cloudflared", async () => {
+    const probes: string[] = [];
+    const commands: string[][] = [];
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "auto" },
+      localScheme: "http",
+      localPort: 8090,
+      runtime: runtime({
+        which: (binary) => {
+          probes.push(binary);
+          return binary === "tailscale" ? "/opt/tailscale" : "/opt/cloudflared";
+        },
+        spawn: (command) => {
+          commands.push([...command]);
+          return fakeProcess({ stdout: stream(`Available at ${PUBLIC_URL}/\n`) });
+        },
+      }),
+    });
+
+    expect(probes).toEqual(["tailscale"]);
+    expect(commands[0]?.[0]).toBe("/opt/tailscale");
+    expect(handle?.provider).toBe("tailscale");
+    expect(handle?.publicUrl).toBe(PUBLIC_URL);
+    await handle?.stop();
+  });
+
+  test("auto falls back to cloudflared only when tailscale is absent", async () => {
+    const probes: string[] = [];
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "auto" },
+      localScheme: "http",
+      localPort: 8090,
+      runtime: runtime({
+        which: (binary) => {
+          probes.push(binary);
+          return binary === "cloudflared" ? "/opt/cloudflared" : null;
+        },
+        spawn: () => fakeProcess({ stderr: stream(`${CLOUDFLARE_URL}\n`) }),
+      }),
+    });
+
+    expect(probes).toEqual(["tailscale", "cloudflared"]);
+    expect(handle?.provider).toBe("cloudflared");
+    await handle?.stop();
+  });
+
+  test("an explicitly selected missing provider is an actionable startup error", async () => {
+    await expect(startWebVoiceTunnel({
+      config: { provider: "cloudflared" },
+      localScheme: "http",
+      localPort: 8090,
+      runtime: runtime({ which: () => null }),
+    })).rejects.toThrow(/cloudflared.*not found.*install.*PATH/i);
+  });
+
+  test("auto errors actionably when neither supported binary exists", async () => {
+    await expect(startWebVoiceTunnel({
+      config: { provider: "auto" },
+      localScheme: "http",
+      localPort: 8090,
+      runtime: runtime({ which: () => null }),
+    })).rejects.toThrow(/neither tailscale nor cloudflared.*install.*PATH/i);
+  });
+
+  test("tailscale uses the configured target and insecure HTTPS upstream mode", async () => {
+    const commands: string[][] = [];
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "tailscale" },
+      localScheme: "https",
+      localHost: "192.0.2.10",
+      localPort: 8443,
+      runtime: runtime({
+        which: () => "/opt/tailscale",
+        spawn: (command) => {
+          commands.push([...command]);
+          return fakeProcess({ stdout: stream(PUBLIC_URL) });
+        },
+      }),
+    });
+
+    expect(commands[0]).toEqual([
+      "/opt/tailscale",
+      "serve",
+      "--https=443",
+      "https+insecure://192.0.2.10:8443",
+    ]);
+    await handle?.stop();
+  });
+
+  test("parses a cloudflared quick-tunnel URL from bounded stderr", async () => {
+    const commands: string[][] = [];
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "cloudflared" },
+      localScheme: "https",
+      localPort: 8443,
+      runtime: runtime({
+        which: () => "/opt/cloudflared",
+        spawn: (command) => {
+          commands.push([...command]);
+          return fakeProcess({ stderr: stream(`noise\n${CLOUDFLARE_URL}/path?q=ignored\n`) });
+        },
+      }),
+    });
+
+    expect(handle?.publicUrl).toBe(CLOUDFLARE_URL);
+    expect(commands[0]).toContain("--no-tls-verify");
+    expect(commands[0]).toContain("https://127.0.0.1:8443");
+    await handle?.stop();
+  });
+
+  test("an output flood is capped, cleaned up, and degrades to local service", async () => {
+    let terminations = 0;
+    const logs: string[] = [];
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "cloudflared" },
+      localScheme: "http",
+      localPort: 8090,
+      outputLimitBytes: 32,
+      deadlineMs: 1_000,
+      runtime: runtime({
+        which: () => "/opt/cloudflared",
+        spawn: () => fakeProcess({ stderr: stream("x".repeat(64)) }),
+        terminate: async () => { terminations += 1; },
+        log: (_level, message) => { logs.push(message); },
+      }),
+    });
+
+    expect(handle).toBeNull();
+    expect(terminations).toBe(1);
+    expect(logs.join("\n")).toMatch(/output limit/i);
+    expect(logs.join("\n").length).toBeLessThan(500);
+  });
+
+  test("URL discovery has an absolute deadline and degrades to local service", async () => {
+    let terminations = 0;
+    const logs: string[] = [];
+    const started = performance.now();
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "cloudflared" },
+      localScheme: "http",
+      localPort: 8090,
+      deadlineMs: 20,
+      runtime: runtime({
+        which: () => "/opt/cloudflared",
+        spawn: () => fakeProcess({ stdout: pendingStream(), stderr: pendingStream() }),
+        terminate: async () => { terminations += 1; },
+        log: (_level, message) => { logs.push(message); },
+      }),
+    });
+
+    expect(handle).toBeNull();
+    expect(terminations).toBe(1);
+    expect(performance.now() - started).toBeLessThan(500);
+    expect(logs.join("\n")).toMatch(/deadline/i);
+  });
+
+  test("stop terminates the exact owned tree once", async () => {
+    let terminations = 0;
+    const proc = fakeProcess({ stderr: stream(CLOUDFLARE_URL) });
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "cloudflared" },
+      localScheme: "http",
+      localPort: 8090,
+      runtime: runtime({
+        which: () => "/opt/cloudflared",
+        spawn: () => proc,
+        terminate: async (target) => {
+          expect(target).toBe(proc);
+          terminations += 1;
+        },
+      }),
+    });
+
+    await Promise.all([handle!.stop(), handle!.stop()]);
+    await handle!.stop();
+    expect(terminations).toBe(1);
+  });
+
+  test("publishes ownership immediately and keeps a failed cleanup retryable", async () => {
+    let owner: Pick<NonNullable<Awaited<ReturnType<typeof startWebVoiceTunnel>>>, "stop"> | undefined;
+    let terminations = 0;
+    const launching = startWebVoiceTunnel({
+      config: { provider: "cloudflared" },
+      localScheme: "http",
+      localPort: 8090,
+      deadlineMs: 10,
+      onOwned: (next) => { owner = next; },
+      runtime: runtime({
+        which: () => "/opt/cloudflared",
+        spawn: () => fakeProcess({ stdout: pendingStream(), stderr: pendingStream() }),
+        terminate: async () => {
+          terminations += 1;
+          if (terminations === 1) throw new Error("synthetic reap failure");
+        },
+      }),
+    });
+
+    expect(owner).toBeDefined();
+    await expect(launching).rejects.toThrow(/cleanup was not confirmed/);
+    await owner!.stop();
+    expect(terminations).toBe(2);
+  });
+
+  test("untrusted subprocess output never reaches tunnel logs", async () => {
+    const secret = "synthetic-token-that-must-not-be-logged";
+    const logs: string[] = [];
+    const handle = await startWebVoiceTunnel({
+      config: { provider: "cloudflared" },
+      localScheme: "http",
+      localPort: 8090,
+      runtime: runtime({
+        which: () => "/opt/cloudflared",
+        spawn: () => fakeProcess({
+          stderr: stream(`token=${secret}\n${CLOUDFLARE_URL}/?token=${secret}\n`),
+        }),
+        log: (_level, message) => { logs.push(message); },
+      }),
+    });
+
+    expect(handle?.publicUrl).toBe(CLOUDFLARE_URL);
+    expect(logs.join("\n")).not.toContain(secret);
+    await handle?.stop();
+  });
+});


### PR DESCRIPTION
First of the pairing PRs: `web_voice.tunnel: { provider: auto | tailscale | cloudflared }` makes the daemon spawn and own a tunnel process exposing the local web-voice port, and print the real public pairing URL at startup (replacing only-`<this-box-ip>` guidance when a tunnel is up).

Invariants honored:
- One owner, bounded cleanup: child spawned via `spawnOwnedProcess`, ownership published synchronously, joined into the daemon's existing shutdown fan-out; cleanup failure fails closed with the unconfirmed-release error pattern.
- Absolute deadline (30s) + output cap (64KB) on URL discovery; after discovery the child's output is drained and discarded so it can never block on a full pipe, and provider bytes are never logged.
- Discovered URL is validated: https only, no credentials, hostname must match the provider (`*.ts.net` / `*.trycloudflare.com`).
- Explicitly configured provider with a missing binary = actionable startup error (no silent fallback); `auto` prefers tailscale, then cloudflared, errors if neither. Post-spawn tunnel failure degrades to local web voice, never kills the daemon.
- Self-signed local TLS handled via `https+insecure` (tailscale) / `--no-tls-verify` (cloudflared); wildcard binds tunnel through loopback.
- Ephemeral-token startup print keeps its existing intentional behavior; stable-token URLs stay `<redacted>`.

Verified by execution: 12 new injected-runtime tests (auto order, missing binaries, both provider commands, URL parse, output cap, deadline, cancellation, exactly-once cleanup, token redaction) — full `bun test` 1981 pass / 0 fail, `bun run typecheck` clean, `git diff --check` clean. No real tunnel binaries or network in tests.

Implementation by Codex (gpt-5.6-sol) against a fixed contract; independently verified here (full-suite run outside the sandbox, line-by-line review of the new module and daemon wiring).

Next PR on top: `cicero pair` (stable-token persistence, QR, doctor/status).