### PR TITLE
feat(web-voice): approval cards — the confirmation gate's third surface

### DIFF
--- a/src/brain/index.ts
+++ b/src/brain/index.ts
@@ -26,6 +26,8 @@ import {
 
 export interface BrainHooks {
   onNudgeReply?: (text: string) => void;
+  /** Transport fan-out for an exact brain-owned confirmation capability. */
+  onConfirmationPending?: (summary: string, nonce: string) => void | Promise<void>;
   /** Daemon runtime only: install the backend-independent spoken dial-back control. */
   dialBackControl?: boolean;
 }
@@ -87,13 +89,22 @@ export function createBrain(config: RuntimeConfig, terminal?: TerminalAdapter, h
 
 function buildBrain(config: RuntimeConfig, terminal?: TerminalAdapter, hooks: BrainHooks = {}): Brain {
   const { backend, mode, target_tab, auto_approve_tools, confirm_tools, confirm_retry, max_queue_bytes, max_response_bytes, max_pending_turns, binary, binary_args, ollama_port, ollama_model, base_url, model, api_key, api_key_env, max_tokens, timeout_ms, unset_env, headers, session_header } = config.brain;
-  const onConfirmationPending = config.notify?.telegram
+  const telegram = config.notify?.telegram;
+  const onConfirmationPending = telegram || hooks.onConfirmationPending
     ? async (summary: string, nonce: string): Promise<void> => {
+        if (hooks.onConfirmationPending) {
+          try {
+            await hooks.onConfirmationPending(summary, nonce);
+          } catch (err: unknown) {
+            log("warn", `approval prompt hook delivery failed for nonce=${nonce}: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+        if (!telegram) return;
         try {
-          const sent = await sendTelegramConfirmation(config.notify!.telegram!, `Allow ${summary}?`, nonce);
-          if (!sent) log("warn", `approval prompt was not delivered for: ${summary}`);
+          const sent = await sendTelegramConfirmation(telegram, `Allow ${summary}?`, nonce);
+          if (!sent) log("warn", `Telegram approval prompt was not delivered for nonce=${nonce}`);
         } catch (err: unknown) {
-          log("warn", `approval prompt delivery failed: ${err instanceof Error ? err.message : String(err)}`);
+          log("warn", `Telegram approval prompt delivery failed for nonce=${nonce}: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     : undefined;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -682,6 +682,9 @@ export class CiceroDaemon {
     this.router = createRouter(this.config, this.providers.llm);
     this.brain = createBrain(this.config, this.terminal, {
       onNudgeReply: (text) => { void this.deliverProactiveReply(text); },
+      onConfirmationPending: (summary, nonce) => {
+        this.webVoice?.confirmPending(summary, nonce);
+      },
       dialBackControl: true,
     });
     this.speaker = createSpeaker(this.config, this.providers.tts, audioPlayer);
@@ -1212,6 +1215,7 @@ export class CiceroDaemon {
         readiness: () => this.running
           ? { ready: true }
           : { ready: false, reason: "daemon startup or shutdown in progress" },
+        confirmations: this.brain,
         onHealth: async (rows, options) => {
           try {
             options?.signal?.throwIfAborted();

--- a/src/web-voice/page.ts
+++ b/src/web-voice/page.ts
@@ -66,6 +66,14 @@ export const PAGE = `<!doctype html>
   #notice.show { display:flex; }
   #notice a { color:#7dd3fc; font-weight:600; word-break:break-all; }
   #notice button { flex:none; background:none; border:0; color:#4b5f70; font-size:16px; cursor:pointer; padding:0 2px; line-height:1; }
+  #confirmations { display:flex; flex-direction:column; gap:8px; width:min(86vw,560px); max-height:30vh; overflow:auto; }
+  .confirm-card { display:flex; flex-direction:column; gap:10px; background:#0e2230; border:1px solid #1f4a5e; border-radius:10px; padding:12px; font-size:13px; color:#a5c8dc; line-height:1.45; }
+  .confirm-summary { white-space:pre-wrap; overflow-wrap:anywhere; }
+  .confirm-actions { display:flex; justify-content:flex-end; gap:8px; }
+  .confirm-actions button { border-radius:8px; padding:7px 12px; font-family:inherit; font-size:13px; font-weight:600; cursor:pointer; }
+  .confirm-actions button:disabled { cursor:default; opacity:.5; }
+  .confirm-deny { border:1px solid #6e3030; background:#2b1518; color:#ffb4ae; }
+  .confirm-approve { border:1px solid #2ea043; background:#13351c; color:#a7e3b1; }
 </style>
 </head>
 <body class="pre">
@@ -105,6 +113,7 @@ export const PAGE = `<!doctype html>
   <div id="status"><span class="dot" id="dot"></span><span id="statusText">tap start to enable the mic…</span></div>
   <div id="debug"></div>
   <div class="hint" id="hint">Push-to-talk: hold <b>SPACE</b> (or press &amp; hold the orb) to talk — release to send.</div>
+  <div id="confirmations" aria-live="polite"></div>
   <div id="notice"><span id="noticeText"></span><button id="noticeClose" aria-label="dismiss">&times;</button></div>
 <script>
 // Token: the URL param wins and is remembered, so an installed PWA (whose
@@ -616,6 +625,50 @@ function handleNotify(msg) {
   enqueueAudio(buf);
 }
 
+const confirmationEl = document.getElementById("confirmations");
+const confirmationCards = new Map();
+function removeConfirmation(nonce) {
+  const card = confirmationCards.get(nonce);
+  if (!card) return;
+  card.remove();
+  confirmationCards.delete(nonce);
+}
+function clearConfirmations() {
+  confirmationCards.forEach((card) => card.remove());
+  confirmationCards.clear();
+}
+function showConfirmation(msg) {
+  if (typeof msg.nonce !== "string" || typeof msg.summary !== "string") return;
+  removeConfirmation(msg.nonce);
+  const card = document.createElement("div");
+  card.className = "confirm-card";
+  card.dataset.nonce = msg.nonce;
+  const summary = document.createElement("div");
+  summary.className = "confirm-summary";
+  summary.textContent = msg.summary;
+  const actions = document.createElement("div");
+  actions.className = "confirm-actions";
+  function decisionButton(label, approved, className) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = className;
+    button.textContent = label;
+    button.onclick = function () {
+      Array.from(actions.querySelectorAll("button")).forEach((item) => { item.disabled = true; });
+      try {
+        ws.send(JSON.stringify({ type: "confirm", sessionId: wsSessionId, nonce: msg.nonce, approved: approved }));
+      } catch (e) { removeConfirmation(msg.nonce); }
+    };
+    return button;
+  }
+  actions.appendChild(decisionButton("Deny", false, "confirm-deny"));
+  actions.appendChild(decisionButton("Approve", true, "confirm-approve"));
+  card.appendChild(summary);
+  card.appendChild(actions);
+  confirmationCards.set(msg.nonce, card);
+  confirmationEl.appendChild(card);
+}
+
 function handleVolumeControl(msg) {
   if (typeof msg.volume === "number") voiceGain = Math.max(0.2, Math.min(2.0, msg.volume));
   else voiceGain = Math.max(0.2, Math.min(2.0, voiceGain + (Number(msg.delta) || 0)));
@@ -640,6 +693,8 @@ function onWsMessage(e) {
     return;
   }
   if (!wsSessionId || msg.sessionId !== wsSessionId) return;
+  if (msg.type === "confirm_request") { showConfirmation(msg); return; }
+  if (msg.type === "confirm_result" || msg.type === "confirm_resolved") { removeConfirmation(msg.nonce); return; }
   if (msg.type === "notify") { handleNotify(msg); return; } // arrives any time, not just mid-turn
   if (msg.type === "history") { return; } // server replay ignored: each page load starts a fresh chat
   if (msg.type === "probe_on") { probeOn = true; return; } // server has an end-of-turn model
@@ -705,6 +760,7 @@ function connectWs() {
     setDot(false);
     if (ws !== sock) return;          // superseded by a newer socket — not ours to handle
     wsSessionId = ""; activeTurnId = null; captureTurnId = null;
+    clearConfirmations();
     if (state === "thinking" || state === "speaking") { stopPlayback(); setState("listening"); }
     if (convOn) scheduleReconnect(); else setStatus("disconnected");
   };
@@ -769,6 +825,7 @@ function stopConversation() {
   convOn = false; toggleLabel.textContent = "Start conversation"; toggle.classList.remove("on"); setDot(false);
   holding = false;
   notifyQueue = [];
+  clearConfirmations();
   releaseWakeLock();
   if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
   reconnectAttempt = 0;

--- a/src/web-voice/protocol.ts
+++ b/src/web-voice/protocol.ts
@@ -11,6 +11,8 @@ export const MAX_CHAT_JSON_BYTES = 64 * 1024;
 export const MAX_HEALTH_JSON_BYTES = 256 * 1024;
 export const MAX_NOTIFY_TEXT_CHARS = 4_096;
 export const MAX_CHAT_TEXT_CHARS = 16_384;
+/** Tool summaries are untrusted brain/provider text displayed in approval cards. */
+export const MAX_CONFIRM_SUMMARY_CHARS = 2_000;
 export const MAX_HEALTH_ROWS = 100;
 
 /**

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -1,4 +1,6 @@
 import { log } from "../logger";
+import { isConfirmationNonce } from "../brain/approval";
+import type { Brain } from "../types";
 import { presentedToken, tokenMatches } from "../http-auth";
 import { PAGE } from "./page";
 import { MANIFEST, ICON_SVG } from "./pwa";
@@ -28,6 +30,7 @@ import {
   MAX_HEALTH_JSON_BYTES,
   MAX_NOTIFY_TEXT_CHARS,
   MAX_CHAT_TEXT_CHARS,
+  MAX_CONFIRM_SUMMARY_CHARS,
   MAX_HEALTH_ROWS,
   decodeTurnAudioFrame,
   encodeTurnAudioFrame,
@@ -131,6 +134,12 @@ export interface WebVoiceServerOptions {
    */
   onHistory?: (options?: { signal?: AbortSignal }) => Promise<Array<{ t: number; user: string; reply: string }>>;
   /**
+   * The brain-owned confirmation gate. The server reads this capability for
+   * late joins and routes exact nonce decisions back through it; it never
+   * retains a parallel pending-confirmation store.
+   */
+  confirmations?: Pick<Brain, "hasPendingConfirmation" | "pendingConfirmations" | "resolvePendingConfirmation">;
+  /**
    * Health-record ingest (the phone bridge's door): rows are appended to
    * the health record. Returns how many were logged. Absent = 501.
    */
@@ -170,6 +179,8 @@ export interface WebVoiceHandle {
    * kanban watcher. Resolves null when unavailable, saturated, or quiescing.
    */
   notify: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal }) => Promise<{ delivered: number; parked: boolean } | null>;
+  /** Broadcast a newly pending brain-owned confirmation to live clients. */
+  confirmPending: (summary: string, nonce: string) => number;
   /** Quiesce ingress, cancel owned work, close sockets, and drain handlers. */
   stop: () => Promise<void>;
 }
@@ -308,7 +319,7 @@ function requestedId(req: Request, url: URL, header: string, query: string): str
  * because a headless box is driven from another machine's browser.
  */
 export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle | null {
-  const { host = "0.0.0.0", port, token, tls, onTurn, onStreamTurn, onTextTurn, onNotify, onNotifyRender, onNotified, onSay, onChat, onHistory, onHealth, onTurnProbe, onSpeculate, readiness } = opts;
+  const { host = "0.0.0.0", port, token, tls, onTurn, onStreamTurn, onTextTurn, onNotify, onNotifyRender, onNotified, onSay, onChat, onHistory, onHealth, onTurnProbe, onSpeculate, readiness, confirmations } = opts;
   const scheme: "http" | "https" = tls ? "https" : "http";
   const configuredDrainTimeout = opts.shutdownDrainTimeoutMs;
   const shutdownDrainTimeoutMs = typeof configuredDrainTimeout === "number" && Number.isFinite(configuredDrainTimeout) && configuredDrainTimeout >= 1
@@ -319,6 +330,67 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
   let stopPromise: Promise<void> | null = null;
   // Live voice clients — notify broadcasts go to every open socket.
   const clients = new Set<import("bun").ServerWebSocket<WsData>>();
+  const debugConfirmation = (reason: string, nonce?: string, approved?: boolean): void => {
+    // The project logger intentionally has no debug level. Keep rejected
+    // controls out of the operator event stream while retaining a debug trace.
+    console.debug(
+      `web-voice confirmation ${reason}`
+      + (nonce ? ` nonce=${nonce}` : "")
+      + (approved === undefined ? "" : ` approved=${approved}`),
+    );
+  };
+  const boundedConfirmation = (nonce: string, summary: string): { type: "confirm_request"; nonce: string; summary: string } | null => {
+    if (!isConfirmationNonce(nonce) || typeof summary !== "string") return null;
+    return { type: "confirm_request", nonce, summary: summary.slice(0, MAX_CONFIRM_SUMMARY_CHARS) };
+  };
+  const pendingConfirmation = (nonce: string): { nonce: string; summary: string } | null => {
+    if (!confirmations?.pendingConfirmations || !isConfirmationNonce(nonce)) return null;
+    try {
+      const matches = confirmations.pendingConfirmations().filter((item) => item.nonce === nonce);
+      return matches.length === 1 ? matches[0]! : null;
+    } catch {
+      debugConfirmation("pending lookup failed", nonce);
+      return null;
+    }
+  };
+  const confirmPending = (summary: string, nonce: string): number => {
+    if (!accepting) return 0;
+    const pending = pendingConfirmation(nonce);
+    if (!pending) return 0;
+    // The callback and capability normally carry the same title. If they ever
+    // diverge, prefer the current brain snapshot over potentially stale text.
+    const request = boundedConfirmation(nonce, summary === pending.summary ? summary : pending.summary);
+    if (!request) return 0;
+    let delivered = 0;
+    for (const ws of clients) {
+      try {
+        ws.send(JSON.stringify(withSession(ws, request)));
+        delivered += 1;
+      } catch { /* socket closed */ }
+    }
+    return delivered;
+  };
+  const sendPendingConfirmations = (ws: import("bun").ServerWebSocket<WsData>): void => {
+    if (!confirmations?.pendingConfirmations) return;
+    let pending: readonly { nonce: string; summary: string }[];
+    try {
+      pending = confirmations.pendingConfirmations();
+    } catch {
+      debugConfirmation("late-join lookup failed");
+      return;
+    }
+    for (const item of pending) {
+      // Re-read at the point of send: pendingConfirmations() also expires ACP
+      // gates, so a stale item from the first snapshot is skipped.
+      const current = pendingConfirmation(item.nonce);
+      if (!current) continue;
+      const request = boundedConfirmation(current.nonce, current.summary);
+      if (request) sendJson(ws, withSession(ws, request));
+    }
+  };
+  const broadcastConfirmationResolved = (nonce: string): void => {
+    for (const client of clients) sendJson(client, withSession(client, { type: "confirm_resolved", nonce }));
+  };
   const liveSpecs = new Set<SpeculativeTurn>();
   const specAbortTasks = new Map<SpeculativeTurn, Promise<void>>();
   const uncertainSpecs = new Set<SpeculativeTurn>();
@@ -1221,6 +1293,9 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           // Tell the client whether mid-pause turn probes are worth sending —
           // without a detector they'd be dead weight on every pause.
           if (onTurnProbe) sendJson(ws, withSession(ws, { type: "probe_on" }));
+          // The brain is the authoritative pending store. A reconnect drains a
+          // fresh snapshot so resolved or expired confirmations never reappear.
+          sendPendingConfirmations(ws);
           // History first, then any parked notifications — so missed news
           // reads (and speaks) after the old chat log, in arrival order.
           if (onHistory && acquireJob()) {
@@ -1259,12 +1334,58 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               protocolError(ws, "control frame too large");
               return;
             }
-            let msg: { type?: string; text?: string; sessionId?: unknown; turnId?: unknown };
+            let msg: {
+              type?: string;
+              text?: string;
+              sessionId?: unknown;
+              turnId?: unknown;
+              nonce?: unknown;
+              approved?: unknown;
+            };
             try {
               msg = JSON.parse(message) as typeof msg;
             } catch {
               if (ws.data.protocol === 2) protocolError(ws, "malformed control frame");
               // Protocol v1 historically ignored malformed controls.
+              return;
+            }
+            if (msg.type === "confirm") {
+              const replyNonce = typeof msg.nonce === "string"
+                ? msg.nonce.slice(0, 128)
+                : "";
+              const approved = typeof msg.approved === "boolean" ? msg.approved : null;
+              const malformed =
+                !isConfirmationNonce(replyNonce)
+                || approved === null
+                || (ws.data.protocol === 2 && msg.sessionId !== ws.data.sessionId);
+              if (malformed || !confirmations?.resolvePendingConfirmation) {
+                debugConfirmation(
+                  malformed ? "malformed control rejected" : "capability unavailable",
+                  replyNonce || undefined,
+                  approved ?? undefined,
+                );
+                sendJson(ws, withSession(ws, { type: "confirm_result", nonce: replyNonce, ok: false }));
+                return;
+              }
+              let resolved = false;
+              try {
+                resolved = confirmations.resolvePendingConfirmation(approved!, replyNonce);
+              } catch {
+                debugConfirmation("resolution threw", replyNonce, approved!);
+              }
+              if (!resolved) {
+                debugConfirmation("resolution rejected", replyNonce, approved!);
+                sendJson(ws, withSession(ws, { type: "confirm_result", nonce: replyNonce, ok: false }));
+                return;
+              }
+              sendJson(ws, withSession(ws, {
+                type: "confirm_result",
+                nonce: replyNonce,
+                ok: true,
+                approved,
+              }));
+              log("info", `web-voice confirmation resolved nonce=${replyNonce} approved=${approved}`);
+              broadcastConfirmationResolved(replyNonce);
               return;
             }
             if (ws.data.protocol === 2 && msg.sessionId !== ws.data.sessionId) {
@@ -1514,6 +1635,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       port: server.port ?? port,
       clientCount: () => clients.size,
       notify,
+      confirmPending,
       stop,
     };
   } catch (err: unknown) {

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_TURN_AUDIO_MS,
   MAX_NOTIFY_JSON_BYTES,
   MAX_CHAT_TEXT_CHARS,
+  MAX_CONFIRM_SUMMARY_CHARS,
   MAX_HEALTH_ROWS,
   MAX_CONCURRENT_WEB_JOBS,
   MAX_WEB_VOICE_CLIENTS,
@@ -88,6 +89,7 @@ function start(opts: {
   onTurnProbe?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onTurnProbe"]>;
   onSpeculate?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onSpeculate"]>;
   readiness?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["readiness"]>;
+  confirmations?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["confirmations"]>;
   shutdownDrainTimeoutMs?: number;
   vadDir?: string;
 } = {}): string {
@@ -109,6 +111,7 @@ function start(opts: {
     onTurnProbe: opts.onTurnProbe,
     onSpeculate: opts.onSpeculate,
     readiness: opts.readiness,
+    confirmations: opts.confirmations,
     shutdownDrainTimeoutMs: opts.shutdownDrainTimeoutMs,
     vadDir: opts.vadDir,
   });
@@ -140,6 +143,180 @@ function connect(base: string): Promise<WebSocket> {
     ws.onerror = () => { clearTimeout(timer); reject(new Error("socket open failed")); };
   });
 }
+
+function nextJson(
+  ws: WebSocket,
+  predicate: (message: Record<string, unknown>) => boolean = () => true,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (event: MessageEvent): void => {
+      if (typeof event.data !== "string") return;
+      const message = JSON.parse(event.data) as Record<string, unknown>;
+      if (!predicate(message)) return;
+      clearTimeout(timer);
+      ws.removeEventListener("message", onMessage);
+      resolve(message);
+    };
+    const timer = setTimeout(() => {
+      ws.removeEventListener("message", onMessage);
+      reject(new Error("websocket JSON timeout"));
+    }, 3_000);
+    ws.addEventListener("message", onMessage);
+  });
+}
+
+test("web confirmations: pending prompts broadcast with bounded summaries", async () => {
+  const nonce = "11111111-1111-4111-8111-111111111111";
+  const summary = "x".repeat(MAX_CONFIRM_SUMMARY_CHARS + 500);
+  const pending = [{ nonce, summary }];
+  const base = start({
+    confirmations: {
+      pendingConfirmations: () => pending,
+      resolvePendingConfirmation: () => false,
+    },
+  });
+  const ws = await connect(base);
+  try {
+    const request = nextJson(ws, (message) => message.type === "confirm_request");
+    expect(handle?.confirmPending(summary, nonce)).toBe(1);
+    expect(await request).toEqual({
+      type: "confirm_request",
+      nonce,
+      summary: summary.slice(0, MAX_CONFIRM_SUMMARY_CHARS),
+    });
+  } finally {
+    ws.close();
+  }
+});
+
+test("web confirmations: late join drains only confirmations still pending", async () => {
+  const expiredNonce = "22222222-2222-4222-8222-222222222222";
+  const liveNonce = "33333333-3333-4333-8333-333333333333";
+  let pending = [{ nonce: expiredNonce, summary: "expired" }];
+  pending = pending.filter((item) => item.nonce !== expiredNonce);
+  pending.push({ nonce: liveNonce, summary: "delete the live branch" });
+  const base = start({
+    confirmations: {
+      pendingConfirmations: () => pending,
+      resolvePendingConfirmation: () => false,
+    },
+  });
+  const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+  try {
+    expect(await nextJson(ws, (message) => message.type === "confirm_request")).toEqual({
+      type: "confirm_request",
+      nonce: liveNonce,
+      summary: "delete the live branch",
+    });
+  } finally {
+    ws.close();
+  }
+});
+
+for (const approved of [true, false]) {
+  test(`web confirmations: confirm frame resolves ${approved ? "approve" : "deny"} and clears every client`, async () => {
+    const nonce = approved
+      ? "44444444-4444-4444-8444-444444444444"
+      : "55555555-5555-4555-8555-555555555555";
+    let pending = [{ nonce, summary: "guarded operation" }];
+    const resolutions: Array<{ approved: boolean; nonce: string }> = [];
+    const base = start({
+      confirmations: {
+        pendingConfirmations: () => pending,
+        resolvePendingConfirmation: (decision, suppliedNonce) => {
+          resolutions.push({ approved: decision, nonce: suppliedNonce });
+          if (suppliedNonce !== nonce || pending.length === 0) return false;
+          pending = [];
+          return true;
+        },
+      },
+    });
+    const first = await connectV2(base);
+    const second = await connectV2(base);
+    try {
+      const result = nextJson(first.ws, (message) => message.type === "confirm_result");
+      const firstCleared = nextJson(first.ws, (message) => message.type === "confirm_resolved");
+      const secondCleared = nextJson(second.ws, (message) => message.type === "confirm_resolved");
+      first.ws.send(JSON.stringify({ type: "confirm", sessionId: first.sessionId, nonce, approved }));
+      expect(await result).toEqual({
+        type: "confirm_result",
+        nonce,
+        ok: true,
+        approved,
+        sessionId: first.sessionId,
+        turnId: null,
+      });
+      expect(await Promise.all([firstCleared, secondCleared])).toEqual([
+        { type: "confirm_resolved", nonce, sessionId: first.sessionId, turnId: null },
+        { type: "confirm_resolved", nonce, sessionId: second.sessionId, turnId: null },
+      ]);
+      expect(resolutions).toEqual([{ approved, nonce }]);
+    } finally {
+      first.ws.close();
+      second.ws.close();
+    }
+  });
+}
+
+test("web confirmations: unknown nonce fails closed without throwing", async () => {
+  const liveNonce = "66666666-6666-4666-8666-666666666666";
+  const unknownNonce = "77777777-7777-4777-8777-777777777777";
+  const calls: string[] = [];
+  const base = start({
+    confirmations: {
+      pendingConfirmations: () => [{ nonce: liveNonce, summary: "guarded operation" }],
+      resolvePendingConfirmation: (_approved, nonce) => {
+        calls.push(nonce);
+        return false;
+      },
+    },
+  });
+  const ws = await connect(base);
+  try {
+    const result = nextJson(ws, (message) => message.type === "confirm_result");
+    ws.send(JSON.stringify({ type: "confirm", nonce: unknownNonce, approved: true }));
+    expect(await result).toEqual({ type: "confirm_result", nonce: unknownNonce, ok: false });
+    expect(calls).toEqual([unknownNonce]);
+  } finally {
+    ws.close();
+  }
+});
+
+test("web confirmations: malformed frames are rejected without invoking the brain", async () => {
+  const nonce = "88888888-8888-4888-8888-888888888888";
+  let calls = 0;
+  const base = start({
+    confirmations: {
+      pendingConfirmations: () => [{ nonce, summary: "guarded operation" }],
+      resolvePendingConfirmation: () => {
+        calls += 1;
+        return true;
+      },
+    },
+  });
+  const ws = await connect(base);
+  try {
+    const malformed = nextJson(ws, (message) => message.type === "confirm_result");
+    ws.send(JSON.stringify({ type: "confirm", nonce, approved: "yes" }));
+    expect(await malformed).toEqual({ type: "confirm_result", nonce, ok: false });
+    expect(calls).toBe(0);
+  } finally {
+    ws.close();
+  }
+});
+
+test("web confirmations: missing capability replies ok false", async () => {
+  const nonce = "99999999-9999-4999-8999-999999999999";
+  const base = start();
+  const ws = await connect(base);
+  try {
+    const unavailable = nextJson(ws, (message) => message.type === "confirm_result");
+    ws.send(JSON.stringify({ type: "confirm", nonce, approved: false }));
+    expect(await unavailable).toEqual({ type: "confirm_result", nonce, ok: false });
+  } finally {
+    ws.close();
+  }
+});
 
 test("/health needs no token", async () => {
   const base = start();
@@ -178,7 +355,11 @@ test("the page is served with a valid ?token", async () => {
   const base = start();
   const res = await fetch(base + "/?token=" + TOKEN);
   expect(res.status).toBe(200);
-  expect(await res.text()).toContain("Start conversation");
+  const page = await res.text();
+  expect(page).toContain("Start conversation");
+  expect(page).toContain('type: "confirm"');
+  expect(page).toContain('decisionButton("Approve", true');
+  expect(page).toContain('decisionButton("Deny", false');
   expect(res.headers.get("cache-control")).toBe("no-store");
   expect(res.headers.get("referrer-policy")).toBe("no-referrer");
   expect(res.headers.get("x-frame-options")).toBe("DENY");


### PR DESCRIPTION
Cicero already holds destructive tool calls behind the `confirm_tools` gate, resolvable by spoken yes/no and Telegram tap. This adds the third surface: a connected web client shows an approval card with Approve/Deny.

Design constraints honored:
- **No second pending store** — the brain's capability trio stays authoritative; the server drains a fresh snapshot on late join (re-read at send time, so expired ACP gates never render) and routes taps through `resolvePendingConfirmation`.
- **Fail closed** — unknown/expired nonce, malformed frame, wrong session id, or missing capability → `confirm_result ok:false`, never a throw, never a guess.
- **Untrusted text bounded** — summaries capped at 2000 chars (`MAX_CONFIRM_SUMMARY_CHARS`), rendered with `textContent`; resolution logs carry nonce + decision, not content.
- **Multi-client coherence** — resolution broadcasts `confirm_resolved` so a card approved on the phone disappears on the laptop. Honest limitation (in-code): a voice/Telegram resolution doesn't push a clear; the card self-corrects on tap (ok:false) or reconnect drain — there is no cheap hook without touching the approval spine, which this PR deliberately doesn't.
- No new config: gate configured + web voice enabled ⇒ cards work.

Verified by execution here: 7 new server tests (broadcast, late-join drain freshness, approve/deny routing, unknown-nonce fail-closed, malformed frames, summary bounding) — full `bun test` 1976 pass / 0 fail, typecheck clean, `git diff --check` clean. Codex's sandbox couldn't bind sockets, so the suite ran out here.

Implementation by Codex (gpt-5.6-sol) against a fixed contract; independently reviewed line-by-line (server routing, card DOM, wiring fan-out).