### PR TITLE
fix(notify): briefing chunks instead of silent truncation; digest reaches brain context

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -60,9 +60,9 @@ import { makeSpeculator } from "./web-voice/speculative";
 import { MAX_TURN_AUDIO_BYTES } from "./web-voice/protocol";
 import { TurnHistory } from "./web-voice/history";
 import { classifyCallIntent, sendTelegramVoice, sendTelegramText, startTelegramUpdatePoller, telegramToken } from "./notify/telegram";
-import { notificationTurnContext } from "./notify/context";
+import { briefingTurnContext, notificationTurnContext } from "./notify/context";
 import { KanbanWatcher, listViaCli, nudgeLine, spokenLine, taskLinkViaCli, type KanbanTask } from "./notify/kanban-watch";
-import { inQuietHours, composeBriefing, composeBriefingDigest, minutesPrompt, worthMinutes, callMinutesThresholdMs, dayOf } from "./notify/briefing";
+import { inQuietHours, composeBriefing, composeBriefingDigest, chunkBriefingDigest, minutesPrompt, worthMinutes, callMinutesThresholdMs, dayOf } from "./notify/briefing";
 import { PromptScheduler, scheduleLabel } from "./notify/schedules";
 import {
   BriefingScheduler,
@@ -84,6 +84,35 @@ import { healthLog } from "./cli/health";
 export interface RecordedWebTurn {
   sink: WebReplySink;
   drain: () => Promise<void>;
+}
+
+export type BriefingTelegramDeliveryOutcome = "accepted" | "failed" | "aborted";
+
+/** Send every digest chunk in order and expose one scheduler-facing outcome. */
+export async function deliverBriefingTelegramChunks(
+  digest: string,
+  send: (chunk: string) => Promise<boolean>,
+  signal?: AbortSignal,
+): Promise<BriefingTelegramDeliveryOutcome> {
+  for (const chunk of chunkBriefingDigest(digest)) {
+    if (signal?.aborted) return "aborted";
+    try {
+      if (!await send(chunk)) return signal?.aborted ? "aborted" : "failed";
+    } catch {
+      return signal?.aborted ? "aborted" : "failed";
+    }
+  }
+  return signal?.aborted ? "aborted" : "accepted";
+}
+
+/** Mirror a delivered briefing into the brain's one-shot turn context. */
+export function injectDeliveredBriefingContext(
+  injectContext: (context: string) => void,
+  digest: string,
+  delivered: boolean,
+  at: Date,
+): void {
+  if (delivered) injectContext(briefingTurnContext(digest, at));
 }
 
 export interface OperatorChatTurnDeps {
@@ -1454,15 +1483,16 @@ export class CiceroDaemon {
 
               const overnight = snapshot.map((item) => item.text);
               const day = dayOf(new Date(), tz);
+              const digest = composeBriefingDigest(overnight, board, health, day);
               const tg = this.config.notify?.telegram;
               const channels: NonNullable<BriefingRunResult["channels"]> = {};
               const telegramDelivery = tg
-                ? sendTelegramText(tg, composeBriefingDigest(overnight, board, health, day), undefined, {}, signal)
-                    .then((accepted) => {
-                      channels.telegram = accepted && !signal.aborted
-                        ? "accepted"
-                        : signal.aborted ? "aborted" : "failed";
-                    })
+                ? deliverBriefingTelegramChunks(
+                    digest,
+                    (chunk) => sendTelegramText(tg, chunk, undefined, {}, signal),
+                    signal,
+                  )
+                    .then((outcome) => { channels.telegram = outcome; })
                     .catch(() => { channels.telegram = "failed"; })
                 : Promise.resolve();
               const voiceDelivery = briefing.call
@@ -1491,7 +1521,15 @@ export class CiceroDaemon {
               }
               const outcomes = Object.values(channels);
               const accepted = outcomes.filter((outcome) => outcome === "accepted").length;
-              if (accepted > 0) await overnightStore.ack(snapshot.map((item) => item.id));
+              if (accepted > 0) {
+                injectDeliveredBriefingContext(
+                  (context) => this.brain.injectContext(context),
+                  digest,
+                  true,
+                  new Date(),
+                );
+                await overnightStore.ack(snapshot.map((item) => item.id));
+              }
               if (signal.aborted && accepted === 0) signal.throwIfAborted();
 
               const phase = accepted === 0 ? "failed" : accepted === outcomes.length ? "delivered" : "partial";

--- a/src/notify/briefing.ts
+++ b/src/notify/briefing.ts
@@ -1,5 +1,10 @@
 import type { KanbanTask } from "./kanban-watch";
 
+/** Telegram's maximum plain-text sendMessage payload, measured like String.slice(). */
+export const TELEGRAM_TEXT_MAX_CHARS = 4_096;
+
+const BRIEFING_CONTINUATION_HEADER = "☀️ Morning briefing";
+
 /**
  * The chief-of-staff pair: quiet hours park notifications overnight instead of
  * pinging, and the morning briefing delivers them in one digest — "while you
@@ -121,6 +126,99 @@ export function composeBriefingDigest(
     return `${header}\n\n${quiet}`;
   }
   return `${header}\n\n${sections.join("\n\n")}`;
+}
+
+/**
+ * Split a composed digest into Telegram-safe messages. Whole sections are kept
+ * together when possible; only an oversized section falls back to line/item
+ * boundaries, and only a single over-limit line is hard-split.
+ */
+export function chunkBriefingDigest(digest: string): string[] {
+  if (!digest) return [];
+  if (digest.length <= TELEGRAM_TEXT_MAX_CHARS) return [digest];
+
+  // Continuation-header length depends on the final denominator. Starting at
+  // two and repacking converges monotonically whenever another digit is needed.
+  let total = 2;
+  for (;;) {
+    const chunks = packBriefingChunks(digest, total);
+    if (chunks.length === total) return chunks;
+    total = chunks.length;
+  }
+}
+
+function packBriefingChunks(digest: string, total: number): string[] {
+  const blocks = digest.split("\n\n");
+  const chunks: string[] = [];
+  let content = "";
+
+  const prefix = (index: number): string => index === 0
+    ? ""
+    : `${BRIEFING_CONTINUATION_HEADER} (${index + 1}/${total})\n\n`;
+  const contentLimit = (): number => TELEGRAM_TEXT_MAX_CHARS - prefix(chunks.length).length;
+  const flush = (): void => {
+    if (!content) return;
+    chunks.push(`${prefix(chunks.length)}${content}`);
+    content = "";
+  };
+
+  const appendHardSplitLine = (line: string, initialSeparator: string): void => {
+    let remaining = line;
+    let separator = initialSeparator;
+    while (remaining.length > 0) {
+      const available = contentLimit() - content.length - separator.length;
+      if (remaining.length <= available) {
+        content += separator + remaining;
+        return;
+      }
+      if (available <= 1) {
+        flush();
+        separator = "";
+        continue;
+      }
+      // The ellipsis makes the otherwise destructive hard split visible.
+      content += separator + remaining.slice(0, available - 1) + "…";
+      remaining = remaining.slice(available - 1);
+      flush();
+      separator = "";
+    }
+  };
+
+  blocks.forEach((block, blockIndex) => {
+    const separator = content ? "\n\n" : "";
+    if (content.length + separator.length + block.length <= contentLimit()) {
+      content += separator + block;
+      return;
+    }
+
+    // Prefer a clean section boundary. The first digest header stays attached
+    // to at least part of an oversized first section instead of standing alone.
+    const currentIsOnlyDigestHeader = blockIndex === 1 && chunks.length === 0;
+    if (content && !currentIsOnlyDigestHeader) flush();
+
+    const freshSeparator = content ? "\n\n" : "";
+    if (content.length + freshSeparator.length + block.length <= contentLimit()) {
+      content += freshSeparator + block;
+      return;
+    }
+
+    const lines = block.split("\n");
+    lines.forEach((line, lineIndex) => {
+      const lineSeparator = content
+        ? (lineIndex === 0 ? "\n\n" : "\n")
+        : "";
+      if (content.length + lineSeparator.length + line.length <= contentLimit()) {
+        content += lineSeparator + line;
+        return;
+      }
+      const keepDigestHeader = blockIndex === 1 && lineIndex === 0 && chunks.length === 0;
+      if (content && !keepDigestHeader) flush();
+      appendHardSplitLine(line, keepDigestHeader ? lineSeparator : "");
+    });
+  });
+
+  flush();
+  return chunks;
 }
 
 /** Prompt for the call-minutes summarizer — turns a transcript into short notes. */

--- a/src/notify/context.ts
+++ b/src/notify/context.ts
@@ -14,3 +14,18 @@ export function notificationTurnContext(text: string, at: Date): string {
     "If the user follows up without naming a topic, assume they mean the most recent notification."
   );
 }
+
+/** BrainTurnContext's per-entry bound; keep briefing wrappers within it. */
+export const MAX_TURN_CONTEXT_ENTRY_CHARS = 8_000;
+
+/** One-shot brain context for a delivered morning briefing. */
+export function briefingTurnContext(text: string, at: Date): string {
+  const prefix = `[Morning briefing delivered at ${at.toISOString()}] `;
+  const suffix = "\nIf the user follows up without naming a topic, assume they mean the most recent morning briefing.";
+  const full = `${prefix}${text}${suffix}`;
+  if (full.length <= MAX_TURN_CONTEXT_ENTRY_CHARS) return full;
+
+  const marker = "[earlier briefing content truncated for brain context]\n";
+  const available = MAX_TURN_CONTEXT_ENTRY_CHARS - prefix.length - marker.length - suffix.length;
+  return `${prefix}${marker}${text.slice(-Math.max(0, available))}${suffix}`;
+}

--- a/src/notify/telegram.ts
+++ b/src/notify/telegram.ts
@@ -4,6 +4,7 @@ export { classifyCallIntent } from "../call-intent";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { log } from "../logger";
+import { TELEGRAM_TEXT_MAX_CHARS } from "./briefing";
 import { confirmationDecision, isConfirmationNonce } from "../brain/approval";
 import type { Brain } from "../types";
 import { snapshotSynthesizedWav } from "../platform/wav";
@@ -379,12 +380,19 @@ export async function sendTelegramText(
 ): Promise<boolean> {
   const token = telegramToken(cfg);
   if (!token || !cfg.chat_id) return false;
+  const guardedText = text.slice(0, TELEGRAM_TEXT_MAX_CHARS);
+  if (guardedText.length < text.length) {
+    log(
+      "warn",
+      `telegram text transport guard truncated a message from ${text.length} to ${guardedText.length} characters`,
+    );
+  }
   const scope = boundedRequestScope(TELEGRAM_HTTP_TIMEOUT_MS);
   try {
     const res = await fetch(botUrl(api, token, "sendMessage"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ chat_id: String(cfg.chat_id), text: text.slice(0, 4096), ...extra }),
+      body: JSON.stringify({ chat_id: String(cfg.chat_id), text: guardedText, ...extra }),
       signal: signal ? AbortSignal.any([scope.signal, signal]) : scope.signal,
     });
     if (!res.ok) {

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -3,7 +3,14 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig } from "../src/config";
-import { CiceroDaemon, createRecordedWebTurn, recordParkedBriefingVoiceOutcome } from "../src/daemon";
+import {
+  CiceroDaemon,
+  createRecordedWebTurn,
+  deliverBriefingTelegramChunks,
+  injectDeliveredBriefingContext,
+  recordParkedBriefingVoiceOutcome,
+} from "../src/daemon";
+import { TELEGRAM_TEXT_MAX_CHARS } from "../src/notify/briefing";
 import { OvernightStore } from "../src/notify/overnight-store";
 import type { WebReplySink } from "../src/web-voice/turn";
 import type { HistoryTurn } from "../src/web-voice/history";
@@ -19,6 +26,42 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): 
 }
 
 describe("CiceroDaemon lifecycle", () => {
+  test("briefing Telegram delivery accepts only after every chunk is accepted", async () => {
+    const digest = `☀️ Morning briefing\n\n${"item line\n".repeat(1_000)}`;
+    const sent: string[] = [];
+    const outcome = await deliverBriefingTelegramChunks(digest, async (chunk) => {
+      sent.push(chunk);
+      return true;
+    });
+
+    expect(outcome).toBe("accepted");
+    expect(sent.length).toBeGreaterThan(1);
+    expect(sent.every((chunk) => chunk.length <= TELEGRAM_TEXT_MAX_CHARS)).toBe(true);
+  });
+
+  test("briefing Telegram delivery stops on a partial chunk failure and reports failed", async () => {
+    const digest = `☀️ Morning briefing\n\n${"item line\n".repeat(1_500)}`;
+    let attempts = 0;
+    const outcome = await deliverBriefingTelegramChunks(digest, async () => {
+      attempts++;
+      return attempts !== 2;
+    });
+
+    expect(outcome).toBe("failed");
+    expect(attempts).toBe(2);
+  });
+
+  test("briefing context is injected after accepted delivery, but not failed delivery", () => {
+    const contexts: string[] = [];
+    const at = new Date("2026-07-18T12:30:00.000Z");
+    injectDeliveredBriefingContext((context) => contexts.push(context), "☀️ Morning briefing\n\n• PR ready", true, at);
+    injectDeliveredBriefingContext((context) => contexts.push(context), "failed digest", false, at);
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]).toContain("PR ready");
+    expect(contexts[0]).toContain("Morning briefing delivered at 2026-07-18T12:30:00.000Z");
+  });
+
   test("aborting during a parked briefing callback write leaves the overnight snapshot unacked", async () => {
     const root = mkdtempSync(join(tmpdir(), "cicero-daemon-briefing-callback-abort-"));
     const store = new OvernightStore(join(root, "overnight.json"), () => 1_700_000_000_000, () => "item-1");

--- a/tests/notify/briefing.test.ts
+++ b/tests/notify/briefing.test.ts
@@ -1,5 +1,17 @@
 import { test, expect } from "bun:test";
-import { parseHm, inQuietHours, hmOf, dayOf, composeBriefing, composeBriefingDigest, minutesPrompt, worthMinutes, callMinutesThresholdMs } from "../../src/notify/briefing";
+import {
+  TELEGRAM_TEXT_MAX_CHARS,
+  callMinutesThresholdMs,
+  chunkBriefingDigest,
+  composeBriefing,
+  composeBriefingDigest,
+  dayOf,
+  hmOf,
+  inQuietHours,
+  minutesPrompt,
+  parseHm,
+  worthMinutes,
+} from "../../src/notify/briefing";
 
 const at = (h: number, m: number) => new Date(2026, 6, 7, h, m);
 
@@ -101,6 +113,68 @@ test("digest briefing: health-only mornings intentionally omit the quiet framing
   expect(composeBriefing([], [], "Health log: weight 82.4 kg.")).toContain(
     "All quiet overnight, and the board is clean.",
   );
+});
+
+test("digest chunking: empty, one-chunk, and exact-cap inputs", () => {
+  expect(chunkBriefingDigest("")).toEqual([]);
+  expect(chunkBriefingDigest("☀️ Morning briefing\n\nAll quiet overnight.")).toEqual([
+    "☀️ Morning briefing\n\nAll quiet overnight.",
+  ]);
+  const exact = "x".repeat(TELEGRAM_TEXT_MAX_CHARS);
+  expect(chunkBriefingDigest(exact)).toEqual([exact]);
+});
+
+test("digest chunking prefers section boundaries before line boundaries", () => {
+  const firstSection = `━━━━━ while you were away ━━━━━\n• ${"A".repeat(2_000)}`;
+  const secondSection = `━━━━━ needs your input ━━━━━\n• ${"B".repeat(2_000)}`;
+  const digest = `☀️ Morning briefing — 2026-07-18\n\n${firstSection}\n\n${secondSection}`;
+
+  const chunks = chunkBriefingDigest(digest);
+
+  expect(chunks).toHaveLength(2);
+  expect(chunks[0]).toBe(`☀️ Morning briefing — 2026-07-18\n\n${firstSection}`);
+  expect(chunks[1]).toBe(`☀️ Morning briefing (2/2)\n\n${secondSection}`);
+  expect(chunks.every((chunk) => chunk.length <= TELEGRAM_TEXT_MAX_CHARS)).toBe(true);
+});
+
+test("digest chunking splits an oversized section on item lines", () => {
+  const items = Array.from({ length: 6 }, (_, index) => `• item-${index + 1} ${String(index + 1).repeat(850)}`);
+  const digest = `☀️ Morning briefing\n\n━━━━━ while you were away ━━━━━\n${items.join("\n")}`;
+
+  const chunks = chunkBriefingDigest(digest);
+
+  expect(chunks.length).toBeGreaterThan(1);
+  expect(chunks.slice(1).every((chunk, index) => chunk.startsWith(`☀️ Morning briefing (${index + 2}/${chunks.length})\n\n`))).toBe(true);
+  for (const item of items) expect(chunks.some((chunk) => chunk.includes(item))).toBe(true);
+  expect(chunks.every((chunk) => chunk.length <= TELEGRAM_TEXT_MAX_CHARS)).toBe(true);
+});
+
+test("digest chunking hard-splits an oversized single line with an ellipsis", () => {
+  const digest = `☀️ Morning briefing\n\n${"Z".repeat(TELEGRAM_TEXT_MAX_CHARS * 2)}`;
+
+  const chunks = chunkBriefingDigest(digest);
+
+  expect(chunks.length).toBeGreaterThan(2);
+  expect(chunks[0].endsWith("…")).toBe(true);
+  expect(chunks.slice(1, -1).every((chunk) => chunk.endsWith("…"))).toBe(true);
+  expect(chunks.every((chunk) => chunk.length <= TELEGRAM_TEXT_MAX_CHARS)).toBe(true);
+});
+
+test("18 realistic overnight items survive a multi-chunk digest verbatim", () => {
+  const items = Array.from({ length: 18 }, (_, index) => (
+    `GitHub PR #${1_200 + index} announced: ${["parser", "scheduler", "dashboard", "voice transport"][index % 4]} ` +
+    `work is ready for review after the overnight CI matrix completed successfully; ` +
+    `the change includes focused regressions, operator notes, and a safe rollback path. ` +
+    `Reviewers can inspect the bounded failure handling, cancellation ownership, and release checklist (${index + 1}/18).`
+  ));
+  const digest = composeBriefingDigest(items, [], null, "2026-07-18");
+
+  const chunks = chunkBriefingDigest(digest);
+  const delivered = chunks.join("\n");
+
+  expect(chunks.length).toBeGreaterThan(1);
+  expect(chunks.every((chunk) => chunk.length <= TELEGRAM_TEXT_MAX_CHARS)).toBe(true);
+  for (const item of items) expect(delivered).toContain(item);
 });
 
 test("minutes need a call longer than the duration gate", () => {

--- a/tests/notify/context.test.ts
+++ b/tests/notify/context.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { notificationTurnContext } from "../../src/notify/context";
+import {
+  MAX_TURN_CONTEXT_ENTRY_CHARS,
+  briefingTurnContext,
+  notificationTurnContext,
+} from "../../src/notify/context";
+import { BrainTurnContext } from "../../src/brain/turn-context";
 
 describe("notificationTurnContext", () => {
   test("carries the delivered text, the timestamp, and the follow-up hint", () => {
@@ -10,5 +15,27 @@ describe("notificationTurnContext", () => {
     expect(ctx).toContain("most recent notification");
     // One-shot context rides a prompt: it must stay a compact block, not grow prose.
     expect(ctx.split("\n").length).toBe(2);
+  });
+});
+
+describe("briefingTurnContext", () => {
+  test("labels a delivered morning briefing for follow-up", () => {
+    const ctx = briefingTurnContext("☀️ Morning briefing\n\n• PR #123 is ready.", new Date("2026-07-18T12:30:00.000Z"));
+    expect(ctx).toContain("[Morning briefing delivered at 2026-07-18T12:30:00.000Z]");
+    expect(ctx).toContain("PR #123 is ready.");
+    expect(ctx).toContain("most recent morning briefing");
+  });
+
+  test("honestly bounds the injected digest copy to one turn-context entry", () => {
+    const headMarker = "HEAD-OF-FULL-TELEGRAM-DIGEST";
+    const tailMarker = "TAIL-OF-FULL-TELEGRAM-DIGEST";
+    const ctx = briefingTurnContext(`${headMarker}${"x".repeat(12_000)}${tailMarker}`, new Date(0));
+    const turnContext = new BrainTurnContext();
+    turnContext.inject(ctx);
+    expect(ctx.length).toBeLessThanOrEqual(MAX_TURN_CONTEXT_ENTRY_CHARS);
+    expect(ctx).toContain("[earlier briefing content truncated for brain context]");
+    expect(ctx).not.toContain(headMarker);
+    expect(ctx).toContain(tailMarker);
+    expect(turnContext.takePending()).toBe(ctx);
   });
 });

--- a/tests/notify/telegram.test.ts
+++ b/tests/notify/telegram.test.ts
@@ -10,6 +10,7 @@ import {
   telegramToken,
   wavToOggOpus,
 } from "../../src/notify/telegram";
+import { TELEGRAM_TEXT_MAX_CHARS } from "../../src/notify/briefing";
 import type { Brain } from "../../src/types";
 
 const hasFfmpeg = Bun.which("ffmpeg") !== null;
@@ -238,6 +239,31 @@ test("sendTelegramText posts a plain message, no ffmpeg involved", async () => {
 test("sendTelegramText without token or chat_id is a quiet no-op", async () => {
   expect(await sendTelegramText({ chat_id: 42 }, "x")).toBe(false);
   expect(await sendTelegramText({ token: "tok" }, "x")).toBe(false);
+});
+
+test("sendTelegramText warns with lengths, not content, when its transport guard truncates", async () => {
+  const secretMarker = "DO-NOT-LOG-THIS-MESSAGE-CONTENT";
+  const text = `${secretMarker}${"x".repeat(TELEGRAM_TEXT_MAX_CHARS)}`;
+  const output: string[] = [];
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  let sentText = "";
+  globalThis.fetch = async (_input, init) => {
+    sentText = String(jsonObject(JSON.parse(String(init?.body))).text);
+    return Response.json({ ok: true });
+  };
+  console.log = (...values: unknown[]): void => { output.push(values.map(String).join(" ")); };
+  try {
+    expect(await sendTelegramText({ token: "tok", chat_id: 42 }, text, "http://telegram.test")).toBe(true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.log = originalLog;
+  }
+  const logs = output.join("\n");
+  const warning = output.find((line) => line.includes("transport guard truncated")) ?? "";
+  expect(sentText).toHaveLength(TELEGRAM_TEXT_MAX_CHARS);
+  expect(logs).toContain(`from ${text.length} to ${TELEGRAM_TEXT_MAX_CHARS} characters`);
+  expect(warning).not.toContain(secretMarker);
 });
 
 test("sendTelegramText combines an external abort with its request deadline", async () => {


### PR DESCRIPTION
Fixes this morning's live incident: the 12:30 briefing packed 18 overnight items, `composeBriefingDigest` has no length bounding, and `sendTelegramText` silently sliced the message at Telegram's 4096-char cap — the tail (last night's PR announcements) was lost while the scheduler logged full delivery. Separately, the briefing path never injected the digest into brain context, so the voice brain couldn't answer "what were those PRs?" on the 13:09 call.

- **Chunked delivery**: digest splits on section boundaries (lines only within an oversized section; a visible `…` hard-split only for a single over-limit line), continuation headers `(n/total)` with a converging repack for header digits, order preserved. Telegram channel reports `accepted` only when **all** chunks send; a failed chunk stops the sequence and reports `failed` — the scheduler's existing retry semantics take over, nothing is acked as delivered that wasn't.
- **Transport guard**: `sendTelegramText`'s 4096 slice stays as last-resort but now logs a warning when it actually truncates (lengths only, no content).
- **Brain context**: a delivered digest is injected one-shot via new `briefingTurnContext`, bounded to `BrainTurnContext`'s real 8000-char entry cap (verified at `src/brain/turn-context.ts:30`), keeping the tail.
- **Incident reproduced in test**: 18 realistic-length items produce a multi-chunk delivery whose concatenation contains every item verbatim.

Verified by execution here: full `bun test` **1980 pass / 0 fail** (11 new tests), typecheck clean, `git diff --check` clean.

Implementation by Codex (gpt-5.6-sol) against a fixed contract; independently reviewed (chunker, delivery outcome mapping, context bound) and the 8000-char claim checked against code.