### PR TITLE
build: restore the vendor/audio.cpp submodule pin lost in the public squash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ __pycache__/
 # audio, never shippable (see: voice add moves them to ~/.cicero/voices).
 /*.wav
 /*.mp3
-vendor/


### PR DESCRIPTION
## What

- Removes the blanket `vendor/` line appended to `.gitignore` on Jul 14 — it overrode the earlier `vendor/*` + `!vendor/audio.cpp` pattern and hid the submodule path from git entirely.
- Restores the `vendor/audio.cpp` submodule gitlink, pinned to current upstream main `b81ea93` (includes the merged Citrinet tokenizer fix #49 and the PocketTTS Mimi decoder allocation hardening). The mirror at the `.gitmodules` URL is synced to the same commit.

## Why

The public-release squash (41348a5) kept `.gitmodules`, `scripts/provision-audiocpp.sh`, and the ignore pattern, but dropped the gitlink itself. Since then, on a fresh clone, `scripts/provision-audiocpp.sh` dies at `git submodule update --init` with `pathspec 'vendor/audio.cpp' did not match any file(s) known to git` — the documented audiocpp provisioning path cannot work anywhere but the original dev box.

## Verification

- `bun run typecheck` — clean
- `bun test` — 2008 pass / 2 fail; both failures are pre-existing on `main` in this environment (ANSI color codes leaking into an error-message assertion in `tests/terminal-send-errors.test.ts`), reproduced on an untouched `main` checkout, untouched by this diff
- `git diff --check` — clean
- `git clone --recurse-submodules` fetchability: pinned SHA verified present at the `.gitmodules` URL