### PR TITLE
chore(deps): stop Dependabot from proposing torch bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,12 @@ updates:
       torch:
         patterns:
           - "torch*"
+    # torch is additionally pin-guarded: scripts/check-python-manifests.ts
+    # requires the manifests to resolve to its hardcoded torch/torchaudio
+    # pins, so a Dependabot PR that only edits requirements files can never
+    # pass CI (closed PR #28, which also paired torch 2.13.0 with a
+    # non-matching torchaudio 2.11.0). Moving torch is a coordinated,
+    # hardware-smoked change; security ALERTS for torch still surface on
+    # the repo's Dependabot alerts page regardless of this rule.
+    ignore:
+      - dependency-name: "torch*"


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for the `torch*` family in the pip ecosystem.

## Why

`scripts/check-python-manifests.ts` deliberately pin-guards `torch`/`torchaudio` (the manifests must resolve to its hardcoded pins), so a Dependabot bump that only touches `requirements/*.txt` can never go green — see #28, which additionally paired torch 2.13.0 with a non-matching torchaudio 2.11.0. Torch upgrades here are coordinated changes: requirements + the check script's `expectedPins` + a live sidecar smoke (other sidecars borrow torch's bundled CUDA/cuDNN libraries at runtime).

Security **alerts** for torch still appear on the repo's Dependabot alerts page; this only suppresses the automated version-bump PRs.

## Verification

- `git diff --check` clean; YAML is config-only (no runtime code, no tests to add)
- Rule follows the documented `ignore` schema (`dependency-name` glob)