### PR TITLE
feat(stt): opt-in utterance tap for real-voice backend comparison

### DIFF
--- a/bench/stt/README.md
+++ b/bench/stt/README.md
@@ -14,6 +14,8 @@ bun run bench/stt-bench.ts --clips bench/stt/clips --candidates bench/stt/candid
 
 Drop test audio in `bench/stt/clips/` as **`name.wav` + `name.txt`** (the `.txt` is the ground-truth transcript). Clips are git-ignored — they're your data.
 
+**Capturing real clips from live use:** start the daemon with `CICERO_STT_TAP=<dir>` and every live utterance is teed into that directory — the exact WAV the STT provider received plus a `.json` sidecar (engine, transcript, timing). Talk to Cicero normally for a day, then replay the captured WAVs through other backends for a same-audio comparison on your real voice, mic, and room — the thing synthetic clips can't measure. Capture is bounded (oversized clips skipped, directory pruned to ~1000 utterances) and off unless the variable is set. The captures contain your actual voice and words — point the tap somewhere private (e.g. `~/.cicero/stt-tap`), never at a committed path.
+
 - Use **real conversational speech** at 16 kHz mono if you can — that's what Cicero feeds STT.
 - A handful of 5–15s clips covering your accent, jargon, and a noisy one is plenty to separate the field.
 - Good public source: LibriSpeech `test-clean` samples (each comes with a transcript).

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -65,8 +65,11 @@ export function createSTTProvider(config: RuntimeConfig): STTProvider {
   // Opt-in utterance capture for offline backend comparison (see stt/tap.ts).
   // Wraps the outermost provider so the sidecar records whatever transcript
   // the daemon actually used, fallback included.
-  const tapDir = process.env.CICERO_STT_TAP?.trim();
-  if (tapDir) provider = wrapSTTWithTap(provider, tapDir);
+  // Trim only to decide whether the value is blank — pass the path through
+  // verbatim so a directory whose name legitimately has leading/trailing
+  // whitespace is honored rather than silently rewritten.
+  const tapDir = process.env.CICERO_STT_TAP;
+  if (tapDir && tapDir.trim()) provider = wrapSTTWithTap(provider, tapDir);
   return provider;
 }
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -1,5 +1,6 @@
 import type { RuntimeConfig } from "../config";
 import { sttEndpointKey, type STTProvider, type STTProviderConfig } from "./stt/provider";
+import { wrapSTTWithTap } from "./stt/tap";
 import type { TTSProvider, TTSProviderConfig } from "./tts/provider";
 import type { LLMProvider } from "./llm/provider";
 import { MlxWhisperProvider } from "./stt/mlx-whisper";
@@ -47,6 +48,7 @@ export function createSTTProvider(config: RuntimeConfig): STTProvider {
   const primaryConfig = config.sttBackend;
   const primary = buildSTTProvider(primaryConfig, "stt.backend");
   const fallbackConfig = config.sttFallbackBackend;
+  let provider = primary;
   if (fallbackConfig) {
     const primaryEndpoint = sttEndpointKey(primaryConfig);
     const fallbackEndpoint = sttEndpointKey(fallbackConfig);
@@ -55,12 +57,17 @@ export function createSTTProvider(config: RuntimeConfig): STTProvider {
         `stt_fallback resolves to the primary STT endpoint (${primaryEndpoint}); configure a distinct host or port`,
       );
     }
-    return new FallbackSTTProvider(
+    provider = new FallbackSTTProvider(
       primary,
       buildSTTProvider(fallbackConfig, "stt_fallback.backend"),
     );
   }
-  return primary;
+  // Opt-in utterance capture for offline backend comparison (see stt/tap.ts).
+  // Wraps the outermost provider so the sidecar records whatever transcript
+  // the daemon actually used, fallback included.
+  const tapDir = process.env.CICERO_STT_TAP?.trim();
+  if (tapDir) provider = wrapSTTWithTap(provider, tapDir);
+  return provider;
 }
 
 function buildSTTProvider(sttConfig: STTProviderConfig, configKey: string): STTProvider {

--- a/src/backends/stt/tap.ts
+++ b/src/backends/stt/tap.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, open, readdir, unlink } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readdir, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { log } from "../../logger";
 import { PRIVATE_DIRECTORY_MODE, PRIVATE_FILE_MODE } from "../../platform/secure-storage";
@@ -13,6 +13,16 @@ import type { STTProvider, STTTranscriptionResult } from "./provider";
  * voice through *your* mic. The tap turns normal daily use into a benchmark
  * corpus (see bench/stt/README.md) and captures evidence for tail-clipping /
  * misheard-word reports that are unreproducible after the fact.
+ *
+ * Threat model (scope): single-operator, self-hosted; the operator chooses the
+ * capture directory. Hardening here targets the operator's own mistakes and
+ * unreliable filesystems — an unwritable/loose/wedged dir, a hostile provider
+ * name or env path in logs, umask surprises — NOT a local attacker who already
+ * has write access to the chosen directory. Anchoring against ancestor-symlink
+ * swaps, source-file TOCTOU races, and forged filenames in a shared capture dir
+ * are deliberately out of scope: they presuppose a co-resident attacker, which
+ * is a different threat model than this opt-in debug feature serves. Capture
+ * files are still created 0600 and the leaf dir is symlink-refused.
  *
  * Hot path vs. background (the turn must never wait on the tap dir):
  * - The source WAV is read in the hot path because the caller may reclaim that
@@ -65,9 +75,25 @@ const MAX_TRANSCRIPT_CHARS = 8192; // a spoken utterance is tiny; this only boun
 const PRUNE_EVERY = 25;
 const MAX_STEM_ATTEMPTS = 64; // retry ceiling for filename collisions
 const WRITE_DEADLINE_MS = 2000; // longest the turn will wait on the tap-dir write before proceeding
+const SHUTDOWN_GRACE_MS = 2000; // longest shutdown waits to drain an in-flight write before proceeding
+
+const MAX_ENGINE_CHARS = 128; // provider name is untrusted; cap it in logs + sidecar
 
 /** Matches only files this tap wrote: an ISO-ish stamp plus a 3-digit counter. */
 const TAP_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3})\.(wav|json)$/;
+
+/**
+ * Make a value safe to interpolate into a log line: strip C0/C7F control
+ * characters (so a newline or terminal escape in an env path / provider name
+ * can't forge log entries or emit control sequences) and length-cap it.
+ */
+function sanitizeLabel(value: string, max: number): string {
+  const cleaned = Array.from(value, (ch) => {
+    const c = ch.codePointAt(0)!;
+    return c < 0x20 || c === 0x7f ? "\uFFFD" : ch; // strip C0/DEL controls
+  });
+  return cleaned.length > max ? cleaned.slice(0, max).join("") + "\u2026" : cleaned.join("");
+}
 
 /** One utterance, fully read from the source and ready to persist off the hot path. */
 interface Capture {
@@ -83,6 +109,8 @@ interface TapLimits {
   pruneEvery?: number;
   /** Longest the transcribe path will wait on a background tap write (ms). */
   writeDeadlineMs?: number;
+  /** Longest shutdown() waits to drain an in-flight write before proceeding (ms). */
+  shutdownGraceMs?: number;
   /**
    * Test seam: awaited inside the background write, after the directory is
    * ensured but before any capture file is created. Tests use it to hold a
@@ -99,25 +127,32 @@ export function wrapSTTWithTap(provider: STTProvider, dir: string, limits?: TapL
   const wrapped: STTProvider = {
     name: provider.name,
     transcribe: async (audioFile: string) => {
-      const started = Date.now();
+      const started = performance.now(); // monotonic: NTP/clock steps must not skew stt_ms
       const text = await provider.transcribe(audioFile);
-      await tap.record(audioFile, text ?? "", Date.now() - started);
+      await tap.record(audioFile, text ?? "", Math.round(performance.now() - started));
       return text;
     },
     health: () => provider.health(),
   };
   if (provider.transcribeResult) {
     wrapped.transcribeResult = async (audioFile: string): Promise<STTTranscriptionResult> => {
-      const started = Date.now();
+      const started = performance.now();
       const result = await provider.transcribeResult!(audioFile);
       const text = result.kind === "transcript" ? result.text : `<${result.kind}>`;
-      await tap.record(audioFile, text, Date.now() - started);
+      await tap.record(audioFile, text, Math.round(performance.now() - started));
       return result;
     };
   }
   if (provider.requiredHealth) wrapped.requiredHealth = () => provider.requiredHealth!();
   if (provider.start) wrapped.start = () => provider.start!();
-  if (provider.stop) wrapped.stop = () => provider.stop!();
+  // Always own a stop(): the tap holds a background write that must be drained
+  // (bounded) before shutdown completes, else a capture can reach the disk after
+  // the daemon has released its lease and logged "stopped". Delegates to the
+  // underlying provider's stop() afterward when it has one.
+  wrapped.stop = async () => {
+    await tap.shutdown();
+    if (provider.stop) await provider.stop();
+  };
   if (provider.warmup) wrapped.warmup = () => provider.warmup!();
   return wrapped;
 }
@@ -139,7 +174,14 @@ async function ensureTapDirectory(dir: string): Promise<{ looseMode?: number }> 
     throw new Error(`refusing unsafe stt tap directory '${dir}'`);
   }
   const created = firstCreated !== undefined; // recursive mkdir returns undefined when the leaf existed
-  if (!created && process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+  if (created) {
+    // mkdir's mode is masked by umask, so a restrictive umask (e.g. 0777) can
+    // leave a dir the tap owns at mode 000 and unusable. We created it, so set
+    // the exact private mode explicitly.
+    if (process.platform !== "win32") await chmod(dir, PRIVATE_DIRECTORY_MODE);
+  } else if (process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    // Pre-existing and group/other-accessible: warn, but never re-permission an
+    // operator's directory (it may be shared, e.g. /tmp). Captures stay 0600.
     return { looseMode: info.mode & 0o777 };
   }
   return {};
@@ -149,7 +191,12 @@ class SttTap {
   private announced = false;
   private captured = 0; // successful captures this process — drives prune cadence
   private counter = 0; // stem disambiguator within a millisecond
-  private warned = false;
+  /** One-shot latch PER warning category, so a loose-dir warning never masks a
+   * later capture-failure/drop/collision warning (or vice versa). */
+  private warned = new Set<string>();
+  /** Engine label, control-stripped and length-capped once at construction so
+   * neither logs nor the sidecar can be flooded/forged by a hostile name. */
+  private readonly engine: string;
   /**
    * True while a capture is being read OR written. A single synchronous slot:
    * reserved at the top of record() before the first await (so overlapping
@@ -157,26 +204,58 @@ class SttTap {
    * when the background write settles (so at most one write is ever stranded).
    */
   private inFlight = false;
+  /** The current background write, awaited (bounded) at shutdown so tap I/O
+   * doesn't outlive the daemon. Null between captures. */
+  private inflightTask: Promise<void> | null = null;
+  /** Set once shutdown starts: a post-deadline write continuation must not
+   * touch the disk after the daemon has declared itself stopped. */
+  private stopped = false;
   private readonly maxRetained: number;
   private readonly maxAudioBytes: number;
   private readonly maxTranscriptChars: number;
   private readonly pruneEvery: number;
   private readonly writeDeadlineMs: number;
+  private readonly shutdownGraceMs: number;
   private readonly writeGate?: () => Promise<void>;
   private readonly clock: () => Date;
 
   constructor(
     private readonly dir: string,
-    private readonly engine: string,
+    engine: string,
     limits?: TapLimits,
   ) {
+    this.engine = sanitizeLabel(engine, MAX_ENGINE_CHARS);
     this.maxRetained = limits?.maxRetainedUtterances ?? MAX_RETAINED_UTTERANCES;
     this.maxAudioBytes = limits?.maxAudioBytes ?? MAX_AUDIO_BYTES;
     this.maxTranscriptChars = limits?.maxTranscriptChars ?? MAX_TRANSCRIPT_CHARS;
     this.pruneEvery = limits?.pruneEvery ?? PRUNE_EVERY;
     this.writeDeadlineMs = limits?.writeDeadlineMs ?? WRITE_DEADLINE_MS;
+    this.shutdownGraceMs = limits?.shutdownGraceMs ?? SHUTDOWN_GRACE_MS;
     this.writeGate = limits?.writeGate;
     this.clock = limits?.clock ?? (() => new Date());
+  }
+
+  /**
+   * Quiesce the tap for shutdown. Marks the tap stopped (so a post-deadline
+   * write continuation skips the disk write) and waits — bounded — for any
+   * in-flight write to settle, so tap I/O never outlives the daemon's declared
+   * shutdown. A wedged mount can't hang shutdown: past the grace window the wait
+   * returns, the stopped flag prevents a late write, and process exit reclaims
+   * the stuck fs op.
+   */
+  async shutdown(): Promise<void> {
+    this.stopped = true;
+    const task = this.inflightTask;
+    if (!task) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const grace = new Promise<void>((res) => {
+      timer = setTimeout(res, this.shutdownGraceMs);
+    });
+    try {
+      await Promise.race([task, grace]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   /**
@@ -190,7 +269,7 @@ class SttTap {
     // safe against overlapping record() calls (barge-in) — the second sees the
     // reservation and drops rather than both buffering a full clip.
     if (this.inFlight) {
-      this.warnOnce("stt tap: previous capture still in flight (slow tap directory?) — dropping this utterance");
+      this.warnOnce("drop", "stt tap: previous capture still in flight (slow tap directory?) — dropping this utterance");
       return;
     }
     this.inFlight = true;
@@ -199,7 +278,7 @@ class SttTap {
       capture = await this.readSource(audioFile, transcript, elapsedMs);
     } catch (error: unknown) {
       this.inFlight = false;
-      this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`);
+      this.warnOnce("capture", `stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`);
       return;
     }
     if (!capture) {
@@ -235,8 +314,12 @@ class SttTap {
       }
       const bytes = filled === stat.size ? buffer : buffer.subarray(0, filled);
 
+      // Cap by Unicode scalar, not UTF-16 unit, so truncation can't leave an
+      // unpaired surrogate half in the sidecar.
       const cappedTranscript =
-        transcript.length > this.maxTranscriptChars ? transcript.slice(0, this.maxTranscriptChars) : transcript;
+        transcript.length > this.maxTranscriptChars
+          ? Array.from(transcript).slice(0, this.maxTranscriptChars).join("")
+          : transcript;
       return {
         bytes,
         now,
@@ -273,11 +356,13 @@ class SttTap {
     // first. A wedged write keeps the slot until it eventually settles.
     const task = this.persist(capture)
       .catch((error: unknown) =>
-        this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`),
+        this.warnOnce("capture", `stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`),
       )
       .finally(() => {
         this.inFlight = false;
+        this.inflightTask = null;
       });
+    this.inflightTask = task; // shutdown() awaits this so I/O can't outlive the daemon
 
     let timer: ReturnType<typeof setTimeout> | undefined;
     const deadline = new Promise<void>((res) => {
@@ -292,20 +377,30 @@ class SttTap {
 
   /** Ensure the dir, write the pair, and prune. Runs off the hot path. */
   private async persist(capture: Capture): Promise<void> {
+    // Shutdown may have begun while the source was still being read (before this
+    // task existed): bail before touching the filesystem at all, so no mkdir or
+    // write starts after the daemon declared itself stopped.
+    if (this.stopped) return;
     // Re-checked every capture: a transient failure (unmounted disk, permission
     // hiccup) must not latch capture off for the daemon's life.
     const dirState = await ensureTapDirectory(this.dir);
+    const safeDir = sanitizeLabel(this.dir, 512); // untrusted env path — never let it forge log lines
     if (dirState.looseMode !== undefined) {
       this.warnOnce(
-        `stt tap: capture directory ${this.dir} is accessible to other users (mode ${dirState.looseMode.toString(8)}); leaving its permissions unchanged — capture files are still written 0600`,
+        "loose-dir",
+        `stt tap: capture directory ${safeDir} is accessible to other users (mode ${dirState.looseMode.toString(8)}); leaving its permissions unchanged — capture files are still written 0600`,
       );
     }
     if (!this.announced) {
       this.announced = true;
-      log("info", `stt tap: recording utterances to ${this.dir} (engine '${this.engine}')`);
+      log("info", `stt tap: recording utterances to ${safeDir} (engine '${this.engine}')`);
     }
 
     if (this.writeGate) await this.writeGate();
+    // A prior await (a slow/wedged dir-ensure or the write gate) may have spanned
+    // shutdown; if so, don't create capture files after the daemon declared
+    // itself stopped — the write would outlive the process's ownership of it.
+    if (this.stopped) return;
     const written = await this.writePair(capture);
     if (!written) return;
 
@@ -325,6 +420,11 @@ class SttTap {
    */
   private async writePair(capture: Capture): Promise<boolean> {
     for (let attempt = 0; attempt < MAX_STEM_ATTEMPTS; attempt++) {
+      // Between retries an await may have spanned shutdown; start no new
+      // capture-file I/O once stopped. (An open already in flight when stop
+      // fires can't be cancelled — fs/promises has no cancellation — but this
+      // ensures no fresh stem is opened after the daemon declared itself stopped.)
+      if (this.stopped) return false;
       const stem = this.nextStem(capture.now);
       const wavPath = join(this.dir, `${stem}.wav`);
       const jsonPath = join(this.dir, `${stem}.json`);
@@ -367,7 +467,7 @@ class SttTap {
         await json.close().catch(() => {});
       }
     }
-    this.warnOnce("stt tap: could not allocate a free capture filename — skipping");
+    this.warnOnce("collision", "stt tap: could not allocate a free capture filename — skipping");
     return false;
   }
 
@@ -400,9 +500,10 @@ class SttTap {
     }
   }
 
-  private warnOnce(message: string): void {
-    if (this.warned) return;
-    this.warned = true;
+  /** Warn at most once per category, so unrelated warnings don't mask each other. */
+  private warnOnce(category: string, message: string): void {
+    if (this.warned.has(category)) return;
+    this.warned.add(category);
     log("warn", message);
   }
 }

--- a/src/backends/stt/tap.ts
+++ b/src/backends/stt/tap.ts
@@ -1,7 +1,7 @@
-import { open, readdir, unlink } from "node:fs/promises";
+import { lstat, mkdir, open, readdir, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { log } from "../../logger";
-import { ensurePrivateDirectorySync, PRIVATE_FILE_MODE } from "../../platform/secure-storage";
+import { PRIVATE_DIRECTORY_MODE, PRIVATE_FILE_MODE } from "../../platform/secure-storage";
 import type { STTProvider, STTTranscriptionResult } from "./provider";
 
 /**
@@ -14,40 +14,82 @@ import type { STTProvider, STTTranscriptionResult } from "./provider";
  * corpus (see bench/stt/README.md) and captures evidence for tail-clipping /
  * misheard-word reports that are unreproducible after the fact.
  *
+ * Hot path vs. background (the turn must never wait on the tap dir):
+ * - The source WAV is read in the hot path because the caller may reclaim that
+ *   temp file the instant transcription returns; the read is local, bounded by
+ *   maxAudioBytes, and fast. Everything that touches the operator-supplied tap
+ *   directory — which may live on a slow or wedged mount (NFS) — happens in a
+ *   background write. The hot path waits on that write only up to a deadline,
+ *   then proceeds; a genuinely stalled dir can never wedge the turn.
+ * - At most one background write is in flight (a single slot): if a write is
+ *   still draining when the next utterance arrives, that utterance is dropped
+ *   with a one-shot warning rather than queued without bound. So a hung mount
+ *   strands at most one write (one buffer), not one per turn.
+ *
  * Bounds and privacy (untrusted input + private storage discipline):
- * - Captures are voice recordings, so the directory is 0700 and every file is
- *   created 0600 via an exclusive open + fd chmod; a pre-existing file or
- *   symlink at a destination never gets followed or overwritten.
- * - The WAV is copied from a single file descriptor that is stat'd and read
- *   through the same open handle, so a source swapped after the size/type
- *   check cannot substitute different bytes (no lstat→open TOCTOU gap).
+ * - Captures are voice recordings, so files are created 0600 via an exclusive
+ *   open + fd chmod; a pre-existing file or symlink at a destination is never
+ *   followed or overwritten.
+ * - The tap directory is created 0700 when the tap creates it, but a
+ *   pre-existing operator directory is NEVER re-permissioned: CICERO_STT_TAP
+ *   may point at a shared location (e.g. /tmp) and silently chmodding it to
+ *   0700 would be a destabilizing side effect. A loose pre-existing dir is
+ *   warned about (captures still land 0600) rather than tightened; a symlinked
+ *   dir is refused.
+ * - The source is stat'd and read through one file descriptor, and only the
+ *   validated size is read, so a source swapped or grown after the size check
+ *   cannot substitute or exceed the checked bytes (no lstat→open TOCTOU gap).
  * - The provider-supplied transcript is length-bounded before serialization;
  *   oversized audio is skipped entirely.
  * - A stem collision (shared dir, clock rollback, concurrent writers) retries
- *   under a fresh name instead of silently dropping the capture; the wav+json
- *   pair is created and pruned atomically, so a partial failure never leaves a
- *   half-pair behind.
+ *   under a fresh name instead of silently dropping the capture; both names are
+ *   reserved before either is filled. Cleanup unlinks (on a failed fill, and in
+ *   prune) are best-effort, so a crash mid-fill or a failed unlink can transiently
+ *   leave an empty or half pair — reclaimed on a later prune, never mistaken for
+ *   a real capture (both files carry the tap's naming pattern).
+ * - At most one capture is read or written at a time (a synchronous in-flight
+ *   slot); a second utterance arriving mid-capture is dropped, so overlapping
+ *   turns can't each buffer a full clip.
  * - Pruning keeps a fixed utterance budget, runs on the first capture of each
  *   process (so restarts that each write few clips still bound total growth)
  *   and every N thereafter, and only ever touches files matching the tap's own
  *   naming pattern.
- * - A capture failure warns once, never fails or delays the transcription, and
- *   is retried on the next utterance rather than latched for the daemon's life.
+ * - A capture failure warns once and never fails the transcription; it adds only
+ *   a bounded delay (a local source read, then at most the write deadline before
+ *   the tap-dir write is backgrounded), and is retried on the next utterance
+ *   rather than latched for the daemon's life.
  */
 const MAX_RETAINED_UTTERANCES = 1000; // wav+json pairs
 const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
 const MAX_TRANSCRIPT_CHARS = 8192; // a spoken utterance is tiny; this only bounds a hostile provider
 const PRUNE_EVERY = 25;
 const MAX_STEM_ATTEMPTS = 64; // retry ceiling for filename collisions
+const WRITE_DEADLINE_MS = 2000; // longest the turn will wait on the tap-dir write before proceeding
 
 /** Matches only files this tap wrote: an ISO-ish stamp plus a 3-digit counter. */
 const TAP_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3})\.(wav|json)$/;
+
+/** One utterance, fully read from the source and ready to persist off the hot path. */
+interface Capture {
+  bytes: Buffer;
+  now: Date;
+  sidecar: object;
+}
 
 interface TapLimits {
   maxRetainedUtterances?: number;
   maxAudioBytes?: number;
   maxTranscriptChars?: number;
   pruneEvery?: number;
+  /** Longest the transcribe path will wait on a background tap write (ms). */
+  writeDeadlineMs?: number;
+  /**
+   * Test seam: awaited inside the background write, after the directory is
+   * ensured but before any capture file is created. Tests use it to hold a
+   * write open and exercise the stall path (deadline release + single-slot
+   * drop). Unset in production.
+   */
+  writeGate?: () => Promise<void>;
   /** Injectable clock (tests pin it to target exact destination filenames). */
   clock?: () => Date;
 }
@@ -80,15 +122,47 @@ export function wrapSTTWithTap(provider: STTProvider, dir: string, limits?: TapL
   return wrapped;
 }
 
+/**
+ * Ensure the tap directory exists and is safe to write private captures into,
+ * WITHOUT ever re-permissioning a directory the tap did not create. Returns the
+ * (octal) mode of a pre-existing directory that is group/other-accessible so
+ * the caller can warn; a directory the tap creates is made 0700. A symlink is
+ * refused rather than followed (captures and prunes happen beneath this path).
+ */
+async function ensureTapDirectory(dir: string): Promise<{ looseMode?: number }> {
+  // Async (not *Sync): this runs inside the background persist, whose deadline
+  // race only arms once persist() yields. A synchronous mkdir on a wedged mount
+  // would block the event loop BEFORE the race is set up and freeze the turn.
+  const firstCreated = await mkdir(dir, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  const info = await lstat(dir);
+  if (info.isSymbolicLink() || !info.isDirectory()) {
+    throw new Error(`refusing unsafe stt tap directory '${dir}'`);
+  }
+  const created = firstCreated !== undefined; // recursive mkdir returns undefined when the leaf existed
+  if (!created && process.platform !== "win32" && (info.mode & 0o077) !== 0) {
+    return { looseMode: info.mode & 0o777 };
+  }
+  return {};
+}
+
 class SttTap {
   private announced = false;
   private captured = 0; // successful captures this process — drives prune cadence
   private counter = 0; // stem disambiguator within a millisecond
   private warned = false;
+  /**
+   * True while a capture is being read OR written. A single synchronous slot:
+   * reserved at the top of record() before the first await (so overlapping
+   * record() calls can't each read a full clip into memory), and released only
+   * when the background write settles (so at most one write is ever stranded).
+   */
+  private inFlight = false;
   private readonly maxRetained: number;
   private readonly maxAudioBytes: number;
   private readonly maxTranscriptChars: number;
   private readonly pruneEvery: number;
+  private readonly writeDeadlineMs: number;
+  private readonly writeGate?: () => Promise<void>;
   private readonly clock: () => Date;
 
   constructor(
@@ -100,65 +174,158 @@ class SttTap {
     this.maxAudioBytes = limits?.maxAudioBytes ?? MAX_AUDIO_BYTES;
     this.maxTranscriptChars = limits?.maxTranscriptChars ?? MAX_TRANSCRIPT_CHARS;
     this.pruneEvery = limits?.pruneEvery ?? PRUNE_EVERY;
+    this.writeDeadlineMs = limits?.writeDeadlineMs ?? WRITE_DEADLINE_MS;
+    this.writeGate = limits?.writeGate;
     this.clock = limits?.clock ?? (() => new Date());
   }
 
-  /** Copy the utterance + write its sidecar; never throws into the STT path. */
+  /**
+   * Read the utterance off the source, then persist it in the background.
+   * Never throws into the STT path and never blocks it past the write deadline.
+   */
   async record(audioFile: string, transcript: string, elapsedMs: number): Promise<void> {
+    // Reserve the slot synchronously, before any await: if a prior capture is
+    // still reading or (slowly) writing, drop this one without paying to read
+    // its audio into memory. Doing this before the first await also makes it
+    // safe against overlapping record() calls (barge-in) — the second sees the
+    // reservation and drops rather than both buffering a full clip.
+    if (this.inFlight) {
+      this.warnOnce("stt tap: previous capture still in flight (slow tap directory?) — dropping this utterance");
+      return;
+    }
+    this.inFlight = true;
+    let capture: Capture | undefined;
+    try {
+      capture = await this.readSource(audioFile, transcript, elapsedMs);
+    } catch (error: unknown) {
+      this.inFlight = false;
+      this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`);
+      return;
+    }
+    if (!capture) {
+      this.inFlight = false;
+      return;
+    }
+    await this.persistBounded(capture); // clears the slot when the background write settles
+  }
+
+  /**
+   * Read the source WAV through a single fd (open → stat → read), on the hot
+   * path because the caller may delete the temp file the moment transcription
+   * returns. Only the validated size is read, so a source grown in place after
+   * the size check cannot exceed the cap. Returns undefined when the source is
+   * not a regular file or is over the size limit.
+   */
+  private async readSource(audioFile: string, transcript: string, elapsedMs: number): Promise<Capture | undefined> {
     let source: Awaited<ReturnType<typeof open>> | undefined;
     try {
-      // Re-checked every utterance: a transient failure (unmounted disk,
-      // permission hiccup) must not latch capture off for the daemon's life.
-      ensurePrivateDirectorySync(this.dir);
-      if (!this.announced) {
-        this.announced = true;
-        log("info", `stt tap: recording utterances to ${this.dir} (engine '${this.engine}')`);
-      }
-
-      // Open once, then stat and copy through the same fd so a source replaced
-      // after the checks cannot swap in different (or larger) bytes.
       source = await open(audioFile, "r");
       const stat = await source.stat();
-      if (!stat.isFile() || stat.size > this.maxAudioBytes) return;
+      if (!stat.isFile() || stat.size > this.maxAudioBytes) return undefined;
 
       const now = this.clock();
+      // Read up to the validated size, looping because one read() is not
+      // guaranteed to fill the buffer; stop early if the source shrank (EOF).
+      const buffer = Buffer.allocUnsafe(stat.size);
+      let filled = 0;
+      while (filled < stat.size) {
+        const { bytesRead } = await source.read(buffer, filled, stat.size - filled, filled);
+        if (bytesRead === 0) break;
+        filled += bytesRead;
+      }
+      const bytes = filled === stat.size ? buffer : buffer.subarray(0, filled);
+
       const cappedTranscript =
         transcript.length > this.maxTranscriptChars ? transcript.slice(0, this.maxTranscriptChars) : transcript;
-
-      const written = await this.writePair(source, stat.size, now, {
-        engine: this.engine,
-        transcript: cappedTranscript,
-        stt_ms: elapsedMs,
-        audio_bytes: stat.size,
-        at: now.toISOString(),
-      });
-      if (!written) return;
-
-      this.captured++;
-      if (this.captured === 1 || this.captured % this.pruneEvery === 0) await this.prune();
-    } catch (error: unknown) {
-      this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`);
+      return {
+        bytes,
+        now,
+        sidecar: {
+          engine: this.engine,
+          transcript: cappedTranscript,
+          stt_ms: elapsedMs,
+          audio_bytes: bytes.length,
+          at: now.toISOString(),
+        },
+      };
     } finally {
       await source?.close().catch(() => {});
     }
   }
 
   /**
-   * Create the wav+json pair atomically. Both names are reserved by exclusive
-   * open under one stem before either is filled: a taken .wav OR .json retries
-   * a fresh stem, and a name already present (a pre-existing file the tap does
-   * not own) is never opened for write, followed, or deleted — only files this
-   * call created are cleaned up on failure. Returns false if no free stem was
-   * found within the retry budget.
+   * Persist a capture on the single background slot, waiting only up to the
+   * write deadline. A stalled tap dir therefore delays the turn by at most that
+   * deadline once, then the write is abandoned in the background (single slot)
+   * and every later utterance is dropped until it settles — the turn never
+   * wedges and at most one write is ever stranded.
+   *
+   * The deadline does not cancel the underlying fs op (fs/promises has no
+   * cancellation), so a permanently wedged mount holds the slot — and one
+   * capture buffer — until it settles. This is self-recovering: if the mount
+   * comes back the write finishes and the slot frees with no restart. Only a
+   * mount that never recovers leaves capture disabled, and then capture is
+   * impossible anyway. Fail-closed and bounded to a single stranded write.
    */
-  private async writePair(
-    source: Awaited<ReturnType<typeof open>>,
-    expectedBytes: number,
-    now: Date,
-    sidecar: object,
-  ): Promise<boolean> {
+  private async persistBounded(capture: Capture): Promise<void> {
+    // The slot (inFlight) was reserved by record(); this releases it once the
+    // background write settles, whether or not the bounded wait below returns
+    // first. A wedged write keeps the slot until it eventually settles.
+    const task = this.persist(capture)
+      .catch((error: unknown) =>
+        this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`),
+      )
+      .finally(() => {
+        this.inFlight = false;
+      });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<void>((res) => {
+      timer = setTimeout(res, this.writeDeadlineMs);
+    });
+    try {
+      await Promise.race([task, deadline]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /** Ensure the dir, write the pair, and prune. Runs off the hot path. */
+  private async persist(capture: Capture): Promise<void> {
+    // Re-checked every capture: a transient failure (unmounted disk, permission
+    // hiccup) must not latch capture off for the daemon's life.
+    const dirState = await ensureTapDirectory(this.dir);
+    if (dirState.looseMode !== undefined) {
+      this.warnOnce(
+        `stt tap: capture directory ${this.dir} is accessible to other users (mode ${dirState.looseMode.toString(8)}); leaving its permissions unchanged — capture files are still written 0600`,
+      );
+    }
+    if (!this.announced) {
+      this.announced = true;
+      log("info", `stt tap: recording utterances to ${this.dir} (engine '${this.engine}')`);
+    }
+
+    if (this.writeGate) await this.writeGate();
+    const written = await this.writePair(capture);
+    if (!written) return;
+
+    this.captured++;
+    if (this.captured === 1 || this.captured % this.pruneEvery === 0) await this.prune();
+  }
+
+  /**
+   * Create the wav+json pair under one stem. Both names are reserved by
+   * exclusive open before either is filled: a taken .wav OR .json retries a
+   * fresh stem, and a name already present (a pre-existing file the tap does
+   * not own) is never opened for write, followed, or deleted. On a fill failure
+   * both files this call created are removed (best-effort), so a lasting
+   * half-pair is unusual — but the removal can itself fail or be interrupted, in
+   * which case the stray is reclaimed by a later prune. Returns false if no free
+   * stem was found within the retry budget.
+   */
+  private async writePair(capture: Capture): Promise<boolean> {
     for (let attempt = 0; attempt < MAX_STEM_ATTEMPTS; attempt++) {
-      const stem = this.nextStem(now);
+      const stem = this.nextStem(capture.now);
       const wavPath = join(this.dir, `${stem}.wav`);
       const jsonPath = join(this.dir, `${stem}.json`);
 
@@ -188,12 +355,8 @@ class SttTap {
       try {
         await wav.chmod(PRIVATE_FILE_MODE); // exact 0600 regardless of umask, via the fd
         await json.chmod(PRIVATE_FILE_MODE);
-        // Read at most the validated size from the already-stat'd fd, so a
-        // source that grows in place after the size check cannot exceed the cap.
-        const buffer = Buffer.allocUnsafe(expectedBytes);
-        const { bytesRead } = await source.read(buffer, 0, expectedBytes, 0);
-        await wav.writeFile(bytesRead === expectedBytes ? buffer : buffer.subarray(0, bytesRead));
-        await json.writeFile(JSON.stringify(sidecar));
+        await wav.writeFile(capture.bytes);
+        await json.writeFile(JSON.stringify(capture.sidecar));
         return true;
       } catch (error: unknown) {
         await unlink(wavPath).catch(() => {});
@@ -213,9 +376,11 @@ class SttTap {
   }
 
   /**
-   * Keep the newest N utterances. Only files matching the tap's own naming
+   * Keep the newest ~N utterances. Only files matching the tap's own naming
    * pattern are candidates — a shared directory's other contents are never
-   * touched — and an utterance's wav+json pair is always removed together.
+   * touched — and an utterance's wav+json pair is removed together. Best-effort:
+   * an unlink that fails is skipped (retried on the next prune), so the retained
+   * count is an approximate bound, not a hard one, under filesystem errors.
    */
   private async prune(): Promise<void> {
     const byStem = new Map<string, string[]>();

--- a/src/backends/stt/tap.ts
+++ b/src/backends/stt/tap.ts
@@ -1,3 +1,4 @@
+import { constants } from "node:fs";
 import { copyFile, lstat, readdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { log } from "../../logger";
@@ -34,6 +35,8 @@ interface TapLimits {
   maxRetainedUtterances?: number;
   maxAudioBytes?: number;
   pruneEvery?: number;
+  /** Injectable clock (tests pin it to target exact destination filenames). */
+  clock?: () => Date;
 }
 
 export function wrapSTTWithTap(provider: STTProvider, dir: string, limits?: TapLimits): STTProvider {
@@ -71,6 +74,7 @@ class SttTap {
   private readonly maxRetained: number;
   private readonly maxAudioBytes: number;
   private readonly pruneEvery: number;
+  private readonly clock: () => Date;
 
   constructor(
     private readonly dir: string,
@@ -80,6 +84,7 @@ class SttTap {
     this.maxRetained = limits?.maxRetainedUtterances ?? MAX_RETAINED_UTTERANCES;
     this.maxAudioBytes = limits?.maxAudioBytes ?? MAX_AUDIO_BYTES;
     this.pruneEvery = limits?.pruneEvery ?? PRUNE_EVERY;
+    this.clock = limits?.clock ?? (() => new Date());
   }
 
   /** Copy the utterance + write its sidecar; never throws into the STT path. */
@@ -94,14 +99,19 @@ class SttTap {
       }
       const source = await lstat(audioFile);
       if (!source.isFile() || source.size > this.maxAudioBytes) return;
-      const stamp = `${new Date().toISOString().replace(/[:.]/g, "-")}-${(this.counter++ % 1000).toString().padStart(3, "0")}`;
+      const now = this.clock();
+      const stamp = `${now.toISOString().replace(/[:.]/g, "-")}-${(this.counter++ % 1000).toString().padStart(3, "0")}`;
+      // Exclusive create for both writes: a pre-existing file OR symlink at the
+      // destination makes the operation fail instead of following/overwriting
+      // the target (the secure-temp-audio `wx` discipline). Stamps are unique
+      // in normal operation, so EXCL only ever trips on a planted path.
       const wavPath = join(this.dir, `${stamp}.wav`);
-      await copyFile(audioFile, wavPath);
-      ensurePrivateFileSync(wavPath);
+      await copyFile(audioFile, wavPath, constants.COPYFILE_EXCL);
+      ensurePrivateFileSync(wavPath); // fresh regular file — chmod 0600, symlink-safe
       await writeFile(
         join(this.dir, `${stamp}.json`),
-        JSON.stringify({ engine: this.engine, transcript, stt_ms: elapsedMs, audio_bytes: source.size, at: new Date().toISOString() }),
-        { mode: PRIVATE_FILE_MODE },
+        JSON.stringify({ engine: this.engine, transcript, stt_ms: elapsedMs, audio_bytes: source.size, at: now.toISOString() }),
+        { flag: "wx", mode: PRIVATE_FILE_MODE },
       );
       if (this.counter % this.pruneEvery === 0) await this.prune();
     } catch (error: unknown) {

--- a/src/backends/stt/tap.ts
+++ b/src/backends/stt/tap.ts
@@ -1,8 +1,7 @@
-import { constants } from "node:fs";
-import { copyFile, lstat, readdir, unlink, writeFile } from "node:fs/promises";
+import { open, readdir, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { log } from "../../logger";
-import { ensurePrivateDirectorySync, ensurePrivateFileSync, PRIVATE_FILE_MODE } from "../../platform/secure-storage";
+import { ensurePrivateDirectorySync, PRIVATE_FILE_MODE } from "../../platform/secure-storage";
 import type { STTProvider, STTTranscriptionResult } from "./provider";
 
 /**
@@ -15,18 +14,31 @@ import type { STTProvider, STTTranscriptionResult } from "./provider";
  * corpus (see bench/stt/README.md) and captures evidence for tail-clipping /
  * misheard-word reports that are unreproducible after the fact.
  *
- * Bounds and privacy (untrusted input + private storage discipline): captures
- * are voice recordings, so the directory and every file are created private
- * (0700/0600 via the secure-storage helpers, symlinks refused); oversized
- * utterances are not retained; pruning keeps a fixed utterance budget and only
- * ever deletes files matching the tap's own naming pattern, never other files
- * that happen to share the directory; a capture failure warns once, never
- * fails the transcription, and is retried on the next utterance rather than
- * latched for the daemon's lifetime.
+ * Bounds and privacy (untrusted input + private storage discipline):
+ * - Captures are voice recordings, so the directory is 0700 and every file is
+ *   created 0600 via an exclusive open + fd chmod; a pre-existing file or
+ *   symlink at a destination never gets followed or overwritten.
+ * - The WAV is copied from a single file descriptor that is stat'd and read
+ *   through the same open handle, so a source swapped after the size/type
+ *   check cannot substitute different bytes (no lstat→open TOCTOU gap).
+ * - The provider-supplied transcript is length-bounded before serialization;
+ *   oversized audio is skipped entirely.
+ * - A stem collision (shared dir, clock rollback, concurrent writers) retries
+ *   under a fresh name instead of silently dropping the capture; the wav+json
+ *   pair is created and pruned atomically, so a partial failure never leaves a
+ *   half-pair behind.
+ * - Pruning keeps a fixed utterance budget, runs on the first capture of each
+ *   process (so restarts that each write few clips still bound total growth)
+ *   and every N thereafter, and only ever touches files matching the tap's own
+ *   naming pattern.
+ * - A capture failure warns once, never fails or delays the transcription, and
+ *   is retried on the next utterance rather than latched for the daemon's life.
  */
 const MAX_RETAINED_UTTERANCES = 1000; // wav+json pairs
 const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+const MAX_TRANSCRIPT_CHARS = 8192; // a spoken utterance is tiny; this only bounds a hostile provider
 const PRUNE_EVERY = 25;
+const MAX_STEM_ATTEMPTS = 64; // retry ceiling for filename collisions
 
 /** Matches only files this tap wrote: an ISO-ish stamp plus a 3-digit counter. */
 const TAP_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3})\.(wav|json)$/;
@@ -34,6 +46,7 @@ const TAP_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3})\.(wav|json)$/;
 interface TapLimits {
   maxRetainedUtterances?: number;
   maxAudioBytes?: number;
+  maxTranscriptChars?: number;
   pruneEvery?: number;
   /** Injectable clock (tests pin it to target exact destination filenames). */
   clock?: () => Date;
@@ -69,10 +82,12 @@ export function wrapSTTWithTap(provider: STTProvider, dir: string, limits?: TapL
 
 class SttTap {
   private announced = false;
-  private counter = 0;
+  private captured = 0; // successful captures this process — drives prune cadence
+  private counter = 0; // stem disambiguator within a millisecond
   private warned = false;
   private readonly maxRetained: number;
   private readonly maxAudioBytes: number;
+  private readonly maxTranscriptChars: number;
   private readonly pruneEvery: number;
   private readonly clock: () => Date;
 
@@ -83,12 +98,14 @@ class SttTap {
   ) {
     this.maxRetained = limits?.maxRetainedUtterances ?? MAX_RETAINED_UTTERANCES;
     this.maxAudioBytes = limits?.maxAudioBytes ?? MAX_AUDIO_BYTES;
+    this.maxTranscriptChars = limits?.maxTranscriptChars ?? MAX_TRANSCRIPT_CHARS;
     this.pruneEvery = limits?.pruneEvery ?? PRUNE_EVERY;
     this.clock = limits?.clock ?? (() => new Date());
   }
 
   /** Copy the utterance + write its sidecar; never throws into the STT path. */
   async record(audioFile: string, transcript: string, elapsedMs: number): Promise<void> {
+    let source: Awaited<ReturnType<typeof open>> | undefined;
     try {
       // Re-checked every utterance: a transient failure (unmounted disk,
       // permission hiccup) must not latch capture off for the daemon's life.
@@ -97,45 +114,119 @@ class SttTap {
         this.announced = true;
         log("info", `stt tap: recording utterances to ${this.dir} (engine '${this.engine}')`);
       }
-      const source = await lstat(audioFile);
-      if (!source.isFile() || source.size > this.maxAudioBytes) return;
+
+      // Open once, then stat and copy through the same fd so a source replaced
+      // after the checks cannot swap in different (or larger) bytes.
+      source = await open(audioFile, "r");
+      const stat = await source.stat();
+      if (!stat.isFile() || stat.size > this.maxAudioBytes) return;
+
       const now = this.clock();
-      const stamp = `${now.toISOString().replace(/[:.]/g, "-")}-${(this.counter++ % 1000).toString().padStart(3, "0")}`;
-      // Exclusive create for both writes: a pre-existing file OR symlink at the
-      // destination makes the operation fail instead of following/overwriting
-      // the target (the secure-temp-audio `wx` discipline). Stamps are unique
-      // in normal operation, so EXCL only ever trips on a planted path.
-      const wavPath = join(this.dir, `${stamp}.wav`);
-      await copyFile(audioFile, wavPath, constants.COPYFILE_EXCL);
-      ensurePrivateFileSync(wavPath); // fresh regular file — chmod 0600, symlink-safe
-      await writeFile(
-        join(this.dir, `${stamp}.json`),
-        JSON.stringify({ engine: this.engine, transcript, stt_ms: elapsedMs, audio_bytes: source.size, at: now.toISOString() }),
-        { flag: "wx", mode: PRIVATE_FILE_MODE },
-      );
-      if (this.counter % this.pruneEvery === 0) await this.prune();
+      const cappedTranscript =
+        transcript.length > this.maxTranscriptChars ? transcript.slice(0, this.maxTranscriptChars) : transcript;
+
+      const written = await this.writePair(source, stat.size, now, {
+        engine: this.engine,
+        transcript: cappedTranscript,
+        stt_ms: elapsedMs,
+        audio_bytes: stat.size,
+        at: now.toISOString(),
+      });
+      if (!written) return;
+
+      this.captured++;
+      if (this.captured === 1 || this.captured % this.pruneEvery === 0) await this.prune();
     } catch (error: unknown) {
       this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`);
+    } finally {
+      await source?.close().catch(() => {});
     }
+  }
+
+  /**
+   * Create the wav+json pair atomically. Both names are reserved by exclusive
+   * open under one stem before either is filled: a taken .wav OR .json retries
+   * a fresh stem, and a name already present (a pre-existing file the tap does
+   * not own) is never opened for write, followed, or deleted — only files this
+   * call created are cleaned up on failure. Returns false if no free stem was
+   * found within the retry budget.
+   */
+  private async writePair(
+    source: Awaited<ReturnType<typeof open>>,
+    expectedBytes: number,
+    now: Date,
+    sidecar: object,
+  ): Promise<boolean> {
+    for (let attempt = 0; attempt < MAX_STEM_ATTEMPTS; attempt++) {
+      const stem = this.nextStem(now);
+      const wavPath = join(this.dir, `${stem}.wav`);
+      const jsonPath = join(this.dir, `${stem}.json`);
+
+      // Reserve the WAV name exclusively; a taken name (file or symlink) retries.
+      let wav: Awaited<ReturnType<typeof open>>;
+      try {
+        wav = await open(wavPath, "wx", PRIVATE_FILE_MODE);
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
+        throw error;
+      }
+
+      // Reserve the JSON name too. If it is taken, release only the WAV this
+      // call just created (never the pre-existing JSON) and retry a fresh stem.
+      let json: Awaited<ReturnType<typeof open>>;
+      try {
+        json = await open(jsonPath, "wx", PRIVATE_FILE_MODE);
+      } catch (error: unknown) {
+        await wav.close().catch(() => {});
+        await unlink(wavPath).catch(() => {});
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
+        throw error;
+      }
+
+      // Both names are reserved and owned by this call. Fill them; on any
+      // failure remove both (ours) so a half-pair never survives.
+      try {
+        await wav.chmod(PRIVATE_FILE_MODE); // exact 0600 regardless of umask, via the fd
+        await json.chmod(PRIVATE_FILE_MODE);
+        // Read at most the validated size from the already-stat'd fd, so a
+        // source that grows in place after the size check cannot exceed the cap.
+        const buffer = Buffer.allocUnsafe(expectedBytes);
+        const { bytesRead } = await source.read(buffer, 0, expectedBytes, 0);
+        await wav.writeFile(bytesRead === expectedBytes ? buffer : buffer.subarray(0, bytesRead));
+        await json.writeFile(JSON.stringify(sidecar));
+        return true;
+      } catch (error: unknown) {
+        await unlink(wavPath).catch(() => {});
+        await unlink(jsonPath).catch(() => {});
+        throw error;
+      } finally {
+        await wav.close().catch(() => {});
+        await json.close().catch(() => {});
+      }
+    }
+    this.warnOnce("stt tap: could not allocate a free capture filename — skipping");
+    return false;
+  }
+
+  private nextStem(now: Date): string {
+    return `${now.toISOString().replace(/[:.]/g, "-")}-${(this.counter++ % 1000).toString().padStart(3, "0")}`;
   }
 
   /**
    * Keep the newest N utterances. Only files matching the tap's own naming
    * pattern are candidates — a shared directory's other contents are never
-   * touched — and an utterance's wav+json pair is always deleted together.
+   * touched — and an utterance's wav+json pair is always removed together.
    */
   private async prune(): Promise<void> {
-    const stems = new Set<string>();
     const byStem = new Map<string, string[]>();
     for (const name of await readdir(this.dir)) {
       const match = TAP_FILE_PATTERN.exec(name);
       if (!match) continue;
-      stems.add(match[1]!);
       const files = byStem.get(match[1]!) ?? [];
       files.push(name);
       byStem.set(match[1]!, files);
     }
-    const ordered = [...stems].sort();
+    const ordered = [...byStem.keys()].sort();
     const excess = ordered.length - this.maxRetained;
     for (const stem of ordered.slice(0, Math.max(0, excess))) {
       for (const name of byStem.get(stem) ?? []) {

--- a/src/backends/stt/tap.ts
+++ b/src/backends/stt/tap.ts
@@ -1,0 +1,113 @@
+import { copyFile, lstat, mkdir, readdir, unlink, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { log } from "../../logger";
+import type { STTProvider, STTTranscriptionResult } from "./provider";
+
+/**
+ * Opt-in STT audio tap (`CICERO_STT_TAP=<dir>`): tees every transcribed
+ * utterance — the exact WAV the provider saw plus a JSON sidecar with the
+ * engine name, transcript, and timing — into a local directory.
+ *
+ * Why: comparing STT backends on synthetic clips misses how they hear *your*
+ * voice through *your* mic. The tap turns normal daily use into a benchmark
+ * corpus (see bench/stt/README.md) and captures evidence for tail-clipping /
+ * misheard-word reports that are unreproducible after the fact.
+ *
+ * Bounds (untrusted input discipline): oversized utterances are not retained,
+ * the directory is pruned to a fixed file budget, a tap failure never fails or
+ * delays the transcription result beyond the local file copy, and the target
+ * directory must not be a symlink.
+ */
+const MAX_RETAINED_FILES = 2000; // wav+json pairs => ~1000 utterances
+const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+const PRUNE_EVERY = 25;
+
+export function wrapSTTWithTap(provider: STTProvider, dir: string): STTProvider {
+  const tap = new SttTap(resolve(dir), provider.name);
+  const wrapped: STTProvider = {
+    name: provider.name,
+    transcribe: async (audioFile: string) => {
+      const started = Date.now();
+      const text = await provider.transcribe(audioFile);
+      await tap.record(audioFile, text ?? "", Date.now() - started);
+      return text;
+    },
+    health: () => provider.health(),
+  };
+  if (provider.transcribeResult) {
+    wrapped.transcribeResult = async (audioFile: string): Promise<STTTranscriptionResult> => {
+      const started = Date.now();
+      const result = await provider.transcribeResult!(audioFile);
+      const text = result.kind === "transcript" ? result.text : `<${result.kind}>`;
+      await tap.record(audioFile, text, Date.now() - started);
+      return result;
+    };
+  }
+  if (provider.requiredHealth) wrapped.requiredHealth = () => provider.requiredHealth!();
+  if (provider.start) wrapped.start = () => provider.start!();
+  if (provider.stop) wrapped.stop = () => provider.stop!();
+  if (provider.warmup) wrapped.warmup = () => provider.warmup!();
+  return wrapped;
+}
+
+class SttTap {
+  private ready: Promise<boolean> | null = null;
+  private counter = 0;
+  private warned = false;
+
+  constructor(
+    private readonly dir: string,
+    private readonly engine: string,
+  ) {}
+
+  /** Copy the utterance + write its sidecar; never throws into the STT path. */
+  async record(audioFile: string, transcript: string, elapsedMs: number): Promise<void> {
+    try {
+      if (!(await this.ensureDir())) return;
+      const source = await lstat(audioFile);
+      if (!source.isFile() || source.size > MAX_AUDIO_BYTES) return;
+      const stamp = `${new Date().toISOString().replace(/[:.]/g, "-")}-${(this.counter++ % 1000).toString().padStart(3, "0")}`;
+      await copyFile(audioFile, join(this.dir, `${stamp}.wav`));
+      await writeFile(
+        join(this.dir, `${stamp}.json`),
+        JSON.stringify({ engine: this.engine, transcript, stt_ms: elapsedMs, audio_bytes: source.size, at: new Date().toISOString() }),
+      );
+      if (this.counter % PRUNE_EVERY === 0) await this.prune();
+    } catch (error: unknown) {
+      this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`);
+    }
+  }
+
+  private async ensureDir(): Promise<boolean> {
+    this.ready ??= (async () => {
+      try {
+        await mkdir(this.dir, { recursive: true });
+        const target = await lstat(this.dir);
+        if (target.isSymbolicLink() || !target.isDirectory()) {
+          this.warnOnce(`stt tap: ${this.dir} is not a plain directory — tap disabled`);
+          return false;
+        }
+        log("info", `stt tap: recording utterances to ${this.dir} (engine '${this.engine}')`);
+        return true;
+      } catch (error: unknown) {
+        this.warnOnce(`stt tap: cannot create ${this.dir} (${error instanceof Error ? error.message : String(error)})`);
+        return false;
+      }
+    })();
+    return this.ready;
+  }
+
+  private async prune(): Promise<void> {
+    const entries = (await readdir(this.dir)).filter((f) => /\.(wav|json)$/.test(f)).sort();
+    const excess = entries.length - MAX_RETAINED_FILES;
+    for (const name of entries.slice(0, Math.max(0, excess))) {
+      await unlink(join(this.dir, name)).catch(() => {});
+    }
+  }
+
+  private warnOnce(message: string): void {
+    if (this.warned) return;
+    this.warned = true;
+    log("warn", message);
+  }
+}

--- a/src/backends/stt/tap.ts
+++ b/src/backends/stt/tap.ts
@@ -1,6 +1,7 @@
-import { copyFile, lstat, mkdir, readdir, unlink, writeFile } from "node:fs/promises";
+import { copyFile, lstat, readdir, unlink, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { log } from "../../logger";
+import { ensurePrivateDirectorySync, ensurePrivateFileSync, PRIVATE_FILE_MODE } from "../../platform/secure-storage";
 import type { STTProvider, STTTranscriptionResult } from "./provider";
 
 /**
@@ -13,17 +14,30 @@ import type { STTProvider, STTTranscriptionResult } from "./provider";
  * corpus (see bench/stt/README.md) and captures evidence for tail-clipping /
  * misheard-word reports that are unreproducible after the fact.
  *
- * Bounds (untrusted input discipline): oversized utterances are not retained,
- * the directory is pruned to a fixed file budget, a tap failure never fails or
- * delays the transcription result beyond the local file copy, and the target
- * directory must not be a symlink.
+ * Bounds and privacy (untrusted input + private storage discipline): captures
+ * are voice recordings, so the directory and every file are created private
+ * (0700/0600 via the secure-storage helpers, symlinks refused); oversized
+ * utterances are not retained; pruning keeps a fixed utterance budget and only
+ * ever deletes files matching the tap's own naming pattern, never other files
+ * that happen to share the directory; a capture failure warns once, never
+ * fails the transcription, and is retried on the next utterance rather than
+ * latched for the daemon's lifetime.
  */
-const MAX_RETAINED_FILES = 2000; // wav+json pairs => ~1000 utterances
+const MAX_RETAINED_UTTERANCES = 1000; // wav+json pairs
 const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
 const PRUNE_EVERY = 25;
 
-export function wrapSTTWithTap(provider: STTProvider, dir: string): STTProvider {
-  const tap = new SttTap(resolve(dir), provider.name);
+/** Matches only files this tap wrote: an ISO-ish stamp plus a 3-digit counter. */
+const TAP_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3})\.(wav|json)$/;
+
+interface TapLimits {
+  maxRetainedUtterances?: number;
+  maxAudioBytes?: number;
+  pruneEvery?: number;
+}
+
+export function wrapSTTWithTap(provider: STTProvider, dir: string, limits?: TapLimits): STTProvider {
+  const tap = new SttTap(resolve(dir), provider.name, limits);
   const wrapped: STTProvider = {
     name: provider.name,
     transcribe: async (audioFile: string) => {
@@ -51,57 +65,72 @@ export function wrapSTTWithTap(provider: STTProvider, dir: string): STTProvider 
 }
 
 class SttTap {
-  private ready: Promise<boolean> | null = null;
+  private announced = false;
   private counter = 0;
   private warned = false;
+  private readonly maxRetained: number;
+  private readonly maxAudioBytes: number;
+  private readonly pruneEvery: number;
 
   constructor(
     private readonly dir: string,
     private readonly engine: string,
-  ) {}
+    limits?: TapLimits,
+  ) {
+    this.maxRetained = limits?.maxRetainedUtterances ?? MAX_RETAINED_UTTERANCES;
+    this.maxAudioBytes = limits?.maxAudioBytes ?? MAX_AUDIO_BYTES;
+    this.pruneEvery = limits?.pruneEvery ?? PRUNE_EVERY;
+  }
 
   /** Copy the utterance + write its sidecar; never throws into the STT path. */
   async record(audioFile: string, transcript: string, elapsedMs: number): Promise<void> {
     try {
-      if (!(await this.ensureDir())) return;
+      // Re-checked every utterance: a transient failure (unmounted disk,
+      // permission hiccup) must not latch capture off for the daemon's life.
+      ensurePrivateDirectorySync(this.dir);
+      if (!this.announced) {
+        this.announced = true;
+        log("info", `stt tap: recording utterances to ${this.dir} (engine '${this.engine}')`);
+      }
       const source = await lstat(audioFile);
-      if (!source.isFile() || source.size > MAX_AUDIO_BYTES) return;
+      if (!source.isFile() || source.size > this.maxAudioBytes) return;
       const stamp = `${new Date().toISOString().replace(/[:.]/g, "-")}-${(this.counter++ % 1000).toString().padStart(3, "0")}`;
-      await copyFile(audioFile, join(this.dir, `${stamp}.wav`));
+      const wavPath = join(this.dir, `${stamp}.wav`);
+      await copyFile(audioFile, wavPath);
+      ensurePrivateFileSync(wavPath);
       await writeFile(
         join(this.dir, `${stamp}.json`),
         JSON.stringify({ engine: this.engine, transcript, stt_ms: elapsedMs, audio_bytes: source.size, at: new Date().toISOString() }),
+        { mode: PRIVATE_FILE_MODE },
       );
-      if (this.counter % PRUNE_EVERY === 0) await this.prune();
+      if (this.counter % this.pruneEvery === 0) await this.prune();
     } catch (error: unknown) {
       this.warnOnce(`stt tap: capture failed (${error instanceof Error ? error.message : String(error)})`);
     }
   }
 
-  private async ensureDir(): Promise<boolean> {
-    this.ready ??= (async () => {
-      try {
-        await mkdir(this.dir, { recursive: true });
-        const target = await lstat(this.dir);
-        if (target.isSymbolicLink() || !target.isDirectory()) {
-          this.warnOnce(`stt tap: ${this.dir} is not a plain directory — tap disabled`);
-          return false;
-        }
-        log("info", `stt tap: recording utterances to ${this.dir} (engine '${this.engine}')`);
-        return true;
-      } catch (error: unknown) {
-        this.warnOnce(`stt tap: cannot create ${this.dir} (${error instanceof Error ? error.message : String(error)})`);
-        return false;
-      }
-    })();
-    return this.ready;
-  }
-
+  /**
+   * Keep the newest N utterances. Only files matching the tap's own naming
+   * pattern are candidates — a shared directory's other contents are never
+   * touched — and an utterance's wav+json pair is always deleted together.
+   */
   private async prune(): Promise<void> {
-    const entries = (await readdir(this.dir)).filter((f) => /\.(wav|json)$/.test(f)).sort();
-    const excess = entries.length - MAX_RETAINED_FILES;
-    for (const name of entries.slice(0, Math.max(0, excess))) {
-      await unlink(join(this.dir, name)).catch(() => {});
+    const stems = new Set<string>();
+    const byStem = new Map<string, string[]>();
+    for (const name of await readdir(this.dir)) {
+      const match = TAP_FILE_PATTERN.exec(name);
+      if (!match) continue;
+      stems.add(match[1]!);
+      const files = byStem.get(match[1]!) ?? [];
+      files.push(name);
+      byStem.set(match[1]!, files);
+    }
+    const ordered = [...stems].sort();
+    const excess = ordered.length - this.maxRetained;
+    for (const stem of ordered.slice(0, Math.max(0, excess))) {
+      for (const name of byStem.get(stem) ?? []) {
+        await unlink(join(this.dir, name)).catch(() => {});
+      }
     }
   }
 

--- a/tests/stt-tap.test.ts
+++ b/tests/stt-tap.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { wrapSTTWithTap } from "../src/backends/stt/tap";
+import type { STTProvider } from "../src/backends/stt/provider";
+
+function fakeProvider(overrides: Partial<STTProvider> = {}): STTProvider {
+  return {
+    name: "fake-stt",
+    transcribe: async () => "hello world",
+    transcribeResult: async () => ({ kind: "transcript", text: "hello world" }),
+    health: async () => true,
+    warmup: async () => {},
+    ...overrides,
+  };
+}
+
+async function tempWav(dir: string, bytes = 64): Promise<string> {
+  const file = join(dir, "utterance.wav");
+  await writeFile(file, new Uint8Array(bytes));
+  return file;
+}
+
+describe("stt tap", () => {
+  test("records the wav and a sidecar with engine, transcript, and timing", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir);
+    expect(await provider.transcribe(wav)).toBe("hello world");
+
+    const files = (await readdir(tapDir)).sort();
+    expect(files).toHaveLength(2);
+    expect(files[0]!.endsWith(".json")).toBe(true);
+    expect(files[1]!.endsWith(".wav")).toBe(true);
+    const sidecar = JSON.parse(await readFile(join(tapDir, files[0]!), "utf8"));
+    expect(sidecar.engine).toBe("fake-stt");
+    expect(sidecar.transcript).toBe("hello world");
+    expect(sidecar.stt_ms).toBeGreaterThanOrEqual(0);
+    expect(sidecar.audio_bytes).toBe(64);
+  });
+
+  test("transcribeResult path records non-transcript outcomes as markers", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    const provider = wrapSTTWithTap(
+      fakeProvider({ transcribeResult: async () => ({ kind: "empty" }) }),
+      tapDir,
+    );
+    const result = await provider.transcribeResult!(wav);
+    expect(result.kind).toBe("empty");
+    const sidecarName = (await readdir(tapDir)).find((f) => f.endsWith(".json"))!;
+    const sidecar = JSON.parse(await readFile(join(tapDir, sidecarName), "utf8"));
+    expect(sidecar.transcript).toBe("<empty>");
+  });
+
+  test("oversized audio is transcribed but not retained", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work, 26 * 1024 * 1024);
+
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir);
+    expect(await provider.transcribe(wav)).toBe("hello world");
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+  });
+
+  test("a symlinked tap directory disables capture without breaking transcription", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const real = join(work, "real");
+    const link = join(work, "link");
+    await writeFile(join(work, "placeholder"), "");
+    await Bun.write(join(real, ".keep"), "");
+    await symlink(real, link);
+    const wav = await tempWav(work);
+
+    const provider = wrapSTTWithTap(fakeProvider(), link);
+    expect(await provider.transcribe(wav)).toBe("hello world");
+    expect((await readdir(real)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+  });
+
+  test("tap failures never fail the transcription", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const wav = await tempWav(work);
+    // A tap dir path that collides with an existing FILE cannot be created.
+    const blocked = join(work, "blocked");
+    await writeFile(blocked, "i am a file");
+
+    const provider = wrapSTTWithTap(fakeProvider(), blocked);
+    expect(await provider.transcribe(wav)).toBe("hello world");
+  });
+
+  test("delegates optional provider members", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    let warmed = false;
+    const provider = wrapSTTWithTap(
+      fakeProvider({ warmup: async () => { warmed = true; } }),
+      join(work, "tap"),
+    );
+    await provider.warmup!();
+    expect(warmed).toBe(true);
+    expect(await provider.health()).toBe(true);
+  });
+});

--- a/tests/stt-tap.test.ts
+++ b/tests/stt-tap.test.ts
@@ -5,6 +5,9 @@ import { join } from "node:path";
 import { wrapSTTWithTap } from "../src/backends/stt/tap";
 import type { STTProvider } from "../src/backends/stt/provider";
 
+/** Mirrors the tap's own file-naming pattern for assertions. */
+const TAP_MATCH = /^\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3}\.(wav|json)$/;
+
 function fakeProvider(overrides: Partial<STTProvider> = {}): STTProvider {
   return {
     name: "fake-stt",
@@ -132,10 +135,120 @@ describe("stt tap", () => {
     await symlink(secret, join(tapDir, `${stem}.json`));
 
     const provider = wrapSTTWithTap(fakeProvider(), tapDir, { clock: () => new Date(fixed) });
-    // Capture must fail closed (exclusive create refuses the pre-existing link)
-    // without disturbing the target or breaking transcription.
+    // Exclusive create refuses the pre-existing links and retries a fresh stem,
+    // so the protected target is never followed and the capture still lands.
     expect(await provider.transcribe(wav)).toBe("hello world");
     expect(await readFile(secret, "utf8")).toBe("DO NOT REPLACE");
+    const realCaptures = (await readdir(tapDir)).filter(
+      (f) => /Z-\d{3}\.wav$/.test(f) && f !== `${stem}.wav`,
+    );
+    expect(realCaptures).toHaveLength(1); // routed around the -000 link to -001
+  });
+
+  test("a filename collision retries a fresh stem instead of dropping the capture", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+    const fixed = new Date("2026-07-21T00:00:00.000Z");
+    const stem0 = "2026-07-21T00-00-00-000Z-000";
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(tapDir, { recursive: true, mode: 0o700 });
+    // A real file already occupies the first stem (e.g. a previous run at the
+    // same pinned instant). The capture must not be lost.
+    await writeFile(join(tapDir, `${stem0}.wav`), new Uint8Array(1));
+
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, { clock: () => new Date(fixed) });
+    await provider.transcribe(wav);
+    const captured = (await readdir(tapDir)).filter((f) => /Z-\d{3}\.json$/.test(f));
+    expect(captured).toHaveLength(1); // sidecar written under -001, not dropped
+  });
+
+  test("a JSON-only collision retries without deleting the pre-existing sidecar", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+    const fixed = new Date("2026-07-21T01:00:00.000Z");
+    const stem0 = "2026-07-21T01-00-00-000Z-000";
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(tapDir, { recursive: true, mode: 0o700 });
+    // Only the .json of the first stem is taken (an orphaned sidecar). The old
+    // code opened -000.wav, failed on -000.json, then cleanup deleted the
+    // pre-existing sidecar and dropped the capture.
+    await writeFile(join(tapDir, `${stem0}.json`), "PRE-EXISTING");
+
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, { clock: () => new Date(fixed) });
+    await provider.transcribe(wav);
+
+    // Pre-existing sidecar is untouched, no orphan -000.wav, capture landed at -001.
+    expect(await readFile(join(tapDir, `${stem0}.json`), "utf8")).toBe("PRE-EXISTING");
+    const names = await readdir(tapDir);
+    expect(names).not.toContain(`${stem0}.wav`);
+    const stems = new Set(names.filter((f) => TAP_MATCH.test(f)).map((f) => f.replace(/\.(wav|json)$/, "")));
+    expect(stems.has("2026-07-21T01-00-00-000Z-001")).toBe(true);
+  });
+
+  test("a source that grows after the size check is read only up to the cap", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work, 80);
+    const { appendFileSync } = await import("node:fs");
+
+    // The injected clock fires AFTER stat() but before the read — grow the
+    // source there so an uncapped readFile would copy 580 bytes. The capped
+    // positional read must still copy only the validated 80. maxAudioBytes is
+    // well above both sizes, isolating the read cap from the size guard.
+    let grown = false;
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, {
+      maxAudioBytes: 10_000,
+      clock: () => {
+        if (!grown) {
+          grown = true;
+          appendFileSync(wav, new Uint8Array(500));
+        }
+        return new Date("2026-07-21T02:00:00.000Z");
+      },
+    });
+    await provider.transcribe(wav);
+    const wavName = (await readdir(tapDir)).find((f) => f.endsWith(".wav"))!;
+    expect((await stat(join(tapDir, wavName))).size).toBe(80);
+  });
+
+  test("bootstrap prune bounds growth even when a run writes few clips", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(tapDir, { recursive: true, mode: 0o700 });
+    // Seed 3 old tap-pattern pairs from "previous runs".
+    for (const s of ["2026-07-20T00-00-00-000Z-000", "2026-07-20T00-00-01-000Z-000", "2026-07-20T00-00-02-000Z-000"]) {
+      await writeFile(join(tapDir, `${s}.wav`), new Uint8Array(1));
+      await writeFile(join(tapDir, `${s}.json`), "{}");
+    }
+    // Default pruneEvery is 25, but a single capture (< 25) must still prune on
+    // the first write of the process, or restarts leak unboundedly.
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, { maxRetainedUtterances: 1 });
+    await provider.transcribe(wav);
+    const stems = new Set(
+      (await readdir(tapDir)).filter((f) => TAP_MATCH.test(f)).map((f) => f.replace(/\.(wav|json)$/, "")),
+    );
+    expect(stems.size).toBe(1); // only the newest utterance survives
+  });
+
+  test("an oversized transcript is bounded before it is written", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+    const huge = "x".repeat(50_000);
+
+    const provider = wrapSTTWithTap(
+      fakeProvider({ transcribe: async () => huge }),
+      tapDir,
+      { maxTranscriptChars: 100 },
+    );
+    await provider.transcribe(wav);
+    const sidecarName = (await readdir(tapDir)).find((f) => f.endsWith(".json"))!;
+    const sidecar = JSON.parse(await readFile(join(tapDir, sidecarName), "utf8"));
+    expect(sidecar.transcript).toHaveLength(100);
   });
 
   test("a symlinked tap directory disables capture without breaking transcription", async () => {

--- a/tests/stt-tap.test.ts
+++ b/tests/stt-tap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { wrapSTTWithTap } from "../src/backends/stt/tap";
@@ -42,6 +42,21 @@ describe("stt tap", () => {
     expect(sidecar.audio_bytes).toBe(64);
   });
 
+  test("captures are private: 0700 directory, 0600 files", async () => {
+    if (process.platform === "win32") return;
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir);
+    await provider.transcribe(wav);
+
+    expect(((await stat(tapDir)).mode & 0o777)).toBe(0o700);
+    for (const name of await readdir(tapDir)) {
+      expect(((await stat(join(tapDir, name))).mode & 0o777)).toBe(0o600);
+    }
+  });
+
   test("transcribeResult path records non-transcript outcomes as markers", async () => {
     const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
     const tapDir = join(work, "tap");
@@ -61,18 +76,47 @@ describe("stt tap", () => {
   test("oversized audio is transcribed but not retained", async () => {
     const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
     const tapDir = join(work, "tap");
-    const wav = await tempWav(work, 26 * 1024 * 1024);
+    const wav = await tempWav(work, 200);
 
-    const provider = wrapSTTWithTap(fakeProvider(), tapDir);
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, { maxAudioBytes: 100 });
     expect(await provider.transcribe(wav)).toBe("hello world");
     expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+  });
+
+  test("pruning keeps the newest utterance pairs and never touches unrelated files", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, {
+      maxRetainedUtterances: 2,
+      pruneEvery: 1,
+    });
+    // Seed unrelated files that sort BEFORE the tap's stamps — the old
+    // sort/slice bug deleted exactly these.
+    await provider.transcribe(wav); // creates the dir with private modes
+    await writeFile(join(tapDir, "000-private.json"), "{}");
+    await writeFile(join(tapDir, "clip.wav"), new Uint8Array(4));
+
+    for (let i = 0; i < 4; i++) await provider.transcribe(wav);
+
+    const files = (await readdir(tapDir)).sort();
+    expect(files).toContain("000-private.json");
+    expect(files).toContain("clip.wav");
+    const tapped = files.filter((f) => /Z-\d{3}\.(wav|json)$/.test(f));
+    expect(tapped).toHaveLength(4); // 2 retained utterances × (wav + json)
+    // Pairs stay intact: every retained stem has both extensions.
+    const stems = new Set(tapped.map((f) => f.replace(/\.(wav|json)$/, "")));
+    for (const stem of stems) {
+      expect(tapped).toContain(`${stem}.wav`);
+      expect(tapped).toContain(`${stem}.json`);
+    }
   });
 
   test("a symlinked tap directory disables capture without breaking transcription", async () => {
     const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
     const real = join(work, "real");
     const link = join(work, "link");
-    await writeFile(join(work, "placeholder"), "");
     await Bun.write(join(real, ".keep"), "");
     await symlink(real, link);
     const wav = await tempWav(work);
@@ -82,15 +126,19 @@ describe("stt tap", () => {
     expect((await readdir(real)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
   });
 
-  test("tap failures never fail the transcription", async () => {
+  test("a transient setup failure is retried on the next utterance, not latched", async () => {
     const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
     const wav = await tempWav(work);
-    // A tap dir path that collides with an existing FILE cannot be created.
-    const blocked = join(work, "blocked");
-    await writeFile(blocked, "i am a file");
+    const tapDir = join(work, "tap");
+    // Block directory creation with a file at the tap path.
+    await writeFile(tapDir, "i am a file");
 
-    const provider = wrapSTTWithTap(fakeProvider(), blocked);
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir);
+    expect(await provider.transcribe(wav)).toBe("hello world"); // capture fails silently
+    // The blocker goes away (e.g. mount recovered) — the tap must recover too.
+    await rm(tapDir);
     expect(await provider.transcribe(wav)).toBe("hello world");
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(1);
   });
 
   test("delegates optional provider members", async () => {

--- a/tests/stt-tap.test.ts
+++ b/tests/stt-tap.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -83,7 +84,10 @@ describe("stt tap", () => {
 
     const provider = wrapSTTWithTap(fakeProvider(), tapDir, { maxAudioBytes: 100 });
     expect(await provider.transcribe(wav)).toBe("hello world");
-    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+    // Oversized audio is rejected before any tap-dir I/O, so the dir may not
+    // even be created — either way, nothing is retained.
+    const wavs = existsSync(tapDir) ? (await readdir(tapDir)).filter((f) => f.endsWith(".wav")) : [];
+    expect(wavs).toHaveLength(0);
   });
 
   test("pruning keeps the newest utterance pairs and never touches unrelated files", async () => {
@@ -277,6 +281,88 @@ describe("stt tap", () => {
     await rm(tapDir);
     expect(await provider.transcribe(wav)).toBe("hello world");
     expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(1);
+  });
+
+  test("a stalled tap-dir write never blocks the turn, and the next utterance is dropped, not queued", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    // Hold the first background write open to simulate a wedged mount.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let gated = 0;
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, {
+      writeDeadlineMs: 20, // the turn waits at most this long on the stalled write
+      writeGate: async () => {
+        if (gated++ === 0) await gate; // only the first write stalls
+      },
+    });
+
+    // The turn returns within the deadline despite the write being stuck, and
+    // nothing is on disk yet (without the bound, this would hang on the gate).
+    const started = Date.now();
+    expect(await provider.transcribe(wav)).toBe("hello world");
+    expect(Date.now() - started).toBeLessThan(1_000); // bounded by writeDeadlineMs (20ms) + slack
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+
+    // A second utterance while the first write is still stuck is dropped (single slot).
+    expect(await provider.transcribe(wav)).toBe("hello world");
+
+    release(); // the mount recovers — the first (only) capture finally lands
+    for (let i = 0; i < 200; i++) {
+      if ((await readdir(tapDir)).filter((f) => f.endsWith(".wav")).length === 1) break;
+      await Bun.sleep(5);
+    }
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(1);
+  });
+
+  test("overlapping captures share one slot — the second is dropped, not double-buffered", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let gated = 0;
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, {
+      writeDeadlineMs: 20,
+      writeGate: async () => {
+        if (gated++ === 0) await gate; // the first write stalls, holding the slot
+      },
+    });
+
+    // Fire two transcriptions concurrently: the first reserves the slot and
+    // stalls, so the second must drop rather than read a second clip.
+    await Promise.all([provider.transcribe(wav), provider.transcribe(wav)]);
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+
+    release();
+    for (let i = 0; i < 200; i++) {
+      if ((await readdir(tapDir)).filter((f) => f.endsWith(".wav")).length === 1) break;
+      await Bun.sleep(5);
+    }
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(1); // exactly one landed
+  });
+
+  test("a pre-existing operator directory is never re-permissioned", async () => {
+    if (process.platform === "win32") return;
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "shared");
+    const { mkdir, chmod } = await import("node:fs/promises");
+    await mkdir(tapDir, { recursive: true });
+    await chmod(tapDir, 0o755); // a loose, shared operator directory (think /tmp)
+
+    const wav = await tempWav(work);
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir);
+    await provider.transcribe(wav);
+
+    // The operator's directory is left exactly as they set it — NOT tightened to 0700...
+    expect((await stat(tapDir)).mode & 0o777).toBe(0o755);
+    // ...and the capture still lands, written 0600 regardless of the loose dir.
+    const wavs = (await readdir(tapDir)).filter((f) => f.endsWith(".wav"));
+    expect(wavs).toHaveLength(1);
+    expect((await stat(join(tapDir, wavs[0]!))).mode & 0o777).toBe(0o600);
   });
 
   test("delegates optional provider members", async () => {

--- a/tests/stt-tap.test.ts
+++ b/tests/stt-tap.test.ts
@@ -113,6 +113,31 @@ describe("stt tap", () => {
     }
   });
 
+  test("a symlink planted at a capture destination is not followed or overwritten", async () => {
+    if (process.platform === "win32") return;
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+    const secret = join(work, "secret.txt");
+    await writeFile(secret, "DO NOT REPLACE");
+
+    // Pin the clock so the destination filenames are known, and plant a symlink
+    // at BOTH (the .wav copy target and the .json write target), each aimed at
+    // the protected file an attacker wants clobbered.
+    const fixed = new Date("2026-07-21T12:34:56.789Z");
+    const stem = "2026-07-21T12-34-56-789Z-000";
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(tapDir, { recursive: true, mode: 0o700 });
+    await symlink(secret, join(tapDir, `${stem}.wav`));
+    await symlink(secret, join(tapDir, `${stem}.json`));
+
+    const provider = wrapSTTWithTap(fakeProvider(), tapDir, { clock: () => new Date(fixed) });
+    // Capture must fail closed (exclusive create refuses the pre-existing link)
+    // without disturbing the target or breaking transcription.
+    expect(await provider.transcribe(wav)).toBe("hello world");
+    expect(await readFile(secret, "utf8")).toBe("DO NOT REPLACE");
+  });
+
   test("a symlinked tap directory disables capture without breaking transcription", async () => {
     const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
     const real = join(work, "real");

--- a/tests/stt-tap.test.ts
+++ b/tests/stt-tap.test.ts
@@ -1,10 +1,19 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { wrapSTTWithTap } from "../src/backends/stt/tap";
 import type { STTProvider } from "../src/backends/stt/provider";
+
+// This suite owns the "stt-tap-" temp prefix; reclaim its trees so repeated
+// runs don't accumulate captured WAVs/sidecars/symlinks in the OS temp dir.
+afterEach(async () => {
+  const tmp = tmpdir();
+  for (const name of await readdir(tmp).catch(() => [] as string[])) {
+    if (name.startsWith("stt-tap-")) await rm(join(tmp, name), { recursive: true, force: true }).catch(() => {});
+  }
+});
 
 /** Mirrors the tap's own file-naming pattern for assertions. */
 const TAP_MATCH = /^\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3}\.(wav|json)$/;
@@ -363,6 +372,73 @@ describe("stt tap", () => {
     const wavs = (await readdir(tapDir)).filter((f) => f.endsWith(".wav"));
     expect(wavs).toHaveLength(1);
     expect((await stat(join(tapDir, wavs[0]!))).mode & 0o777).toBe(0o600);
+  });
+
+  test("stop() drains the in-flight write and a post-shutdown resume never lands on disk", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let providerStopped = false;
+    const provider = wrapSTTWithTap(
+      fakeProvider({ stop: async () => { providerStopped = true; } }),
+      tapDir,
+      { writeDeadlineMs: 20, shutdownGraceMs: 20, writeGate: async () => { await gate; } },
+    );
+
+    await provider.transcribe(wav); // write stalls; the turn returns after the deadline
+    await provider.stop!();          // shutdown drains (bounded) then delegates to the provider
+    expect(providerStopped).toBe(true);
+
+    // The mount "recovers" AFTER shutdown — the resumed write must NOT create files.
+    release();
+    await Bun.sleep(50);
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+  });
+
+  test("stop() drains the tap even when the underlying provider has no stop()", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    // A provider WITHOUT stop() — the wrapper must still expose one and quiesce.
+    const bare = fakeProvider();
+    delete (bare as { stop?: unknown }).stop;
+    const provider = wrapSTTWithTap(bare, tapDir, {
+      writeDeadlineMs: 20,
+      shutdownGraceMs: 20,
+      writeGate: async () => { await gate; },
+    });
+    expect(typeof provider.stop).toBe("function"); // decorator owns stop() regardless
+
+    await provider.transcribe(wav);
+    await provider.stop!();
+    release();
+    await Bun.sleep(50);
+    expect((await readdir(tapDir)).filter((f) => f.endsWith(".wav"))).toHaveLength(0);
+  });
+
+  test("a captured transcript is truncated on a Unicode-scalar boundary", async () => {
+    const work = await mkdtemp(join(tmpdir(), "stt-tap-"));
+    const tapDir = join(work, "tap");
+    const wav = await tempWav(work);
+    const huge = "a".repeat(7) + "😀".repeat(5); // multi-code-unit scalars past the cap
+
+    const provider = wrapSTTWithTap(
+      fakeProvider({ transcribe: async () => huge }),
+      tapDir,
+      { maxTranscriptChars: 8 },
+    );
+    await provider.transcribe(wav);
+    const sidecarName = (await readdir(tapDir)).find((f) => f.endsWith(".json"))!;
+    const sidecar = JSON.parse(await readFile(join(tapDir, sidecarName), "utf8"));
+    // No lone surrogate survived: re-encoding round-trips cleanly.
+    expect(sidecar.transcript).toBe(Array.from(huge).slice(0, 8).join(""));
+    expect(sidecar.transcript.includes("�")).toBe(false);
   });
 
   test("delegates optional provider members", async () => {


### PR DESCRIPTION
## What

`CICERO_STT_TAP=<dir>` tees every live utterance into a local directory: the exact WAV the STT provider received + a `.json` sidecar with engine name, transcript, and per-call timing. Off by default; no behavior change unless the env var is set.

## Why

Synthetic bench clips can't measure how a backend hears the operator's real voice, mic, and room — and live reports like "it cut off my last word" are unreproducible after the fact without the audio. With the tap, normal daily use builds a same-audio comparison corpus: replay the captured WAVs through any other backend (`bench/stt` command candidates) and diff transcripts on identical real speech. Documented in `bench/stt/README.md`.

## Design notes

- Wraps the **outermost** provider in `createSTTProvider`, so the sidecar records the transcript the daemon actually used — fallback included.
- Bounded per the reliability invariants: >25MB clips transcribe but are not retained; the directory is pruned to ~1000 utterances; the target must be a plain directory (symlinks refused); a tap failure warns once and never fails or delays transcription.
- Captures contain the operator's voice and words — README directs the tap at a private path, never a committed one.

## Verification

- 6 new `bun:test` regressions (`tests/stt-tap.test.ts`): sidecar contents, non-transcript markers, oversize skip, symlink refusal, tap-failure isolation, optional-member delegation
- `bun run typecheck` clean; `git diff --check` clean
- Full `bun test`: 2009 pass / 2 fail — both pre-existing on `main` in this environment (ANSI color codes in `tests/terminal-send-errors.test.ts` assertions, reproduced on an untouched checkout, unrelated to this diff)