### PR TITLE
fix(notify): gate stale-task nudges behind unfinished parent tasks

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -71,7 +71,7 @@ import { MAX_TURN_AUDIO_BYTES } from "./web-voice/protocol";
 import { TurnHistory } from "./web-voice/history";
 import { classifyCallIntent, sendTelegramVoice, sendTelegramText, startTelegramUpdatePoller, telegramToken } from "./notify/telegram";
 import { briefingTurnContext, notificationTurnContext } from "./notify/context";
-import { KanbanWatcher, listViaCli, nudgeLine, spokenLine, taskLinkViaCli, type KanbanTask } from "./notify/kanban-watch";
+import { KanbanWatcher, listViaCli, nudgeLine, spokenLine, taskLinkViaCli, taskParentsViaCli, type KanbanTask } from "./notify/kanban-watch";
 import { inQuietHours, composeBriefing, composeBriefingDigest, chunkBriefingDigest, minutesPrompt, worthMinutes, callMinutesThresholdMs, dayOf } from "./notify/briefing";
 import { PromptScheduler, scheduleLabel } from "./notify/schedules";
 import {
@@ -395,6 +395,13 @@ export class CiceroDaemon {
           await this.webVoice?.notify(nudgeLine(t, waited, nth));
         },
         nudgeAfterMs: (kw.nudge_after_minutes ?? 60) * 60_000,
+        // Parents come from the per-task detail (the list feed omits them), so a
+        // gated companion (e.g. a QA card parented to a not-yet-done work card)
+        // is recognized as parked-behind-a-dependency, not "nobody picked it up".
+        // Only wired when a task_command exists; without it, nudge on age alone.
+        parents: kw.task_command
+          ? (t, signal) => taskParentsViaCli(t.id, kw.task_command!, { signal })
+          : undefined,
       });
       // Poll immediately only when no web voice surface will exist (Telegram-only
       // / host-mic-only), so the board snapshot is still populated there. When web

--- a/src/notify/kanban-watch.ts
+++ b/src/notify/kanban-watch.ts
@@ -154,6 +154,90 @@ export async function taskLinkViaCli(
   }
 }
 
+/** Cap on parent ids read from a task's detail — a sane board has a handful. */
+const MAX_PARENT_IDS = 32;
+
+/** How often a parked (parent-gated) task re-evaluates its gate. */
+const GATE_RECHECK_MS = 5 * 60_000;
+
+/**
+ * Per-lookup deadline for a parent-gate detail read. Deliberately shorter than
+ * the general command timeout: a `show <id>` is a fast point read, and the poll
+ * loop runs these sequentially, so a slow one must not dominate a poll.
+ */
+const GATE_LOOKUP_TIMEOUT_MS = 3_000;
+
+/**
+ * Most parent-gate lookups run in a single poll. Beyond this, a task's gate
+ * decision is deferred to a later poll rather than running an unbounded number
+ * of sequential subprocesses — which would delay every later task's nudge and
+ * announcement in the same poll. Deferred tasks keep their escalation state and
+ * are re-evaluated on the next cadence, so nothing is skipped, only spread out.
+ *
+ * Deferred tasks are marked due again immediately while looked-up-gated tasks
+ * enter the longer {@link GATE_RECHECK_MS} cooldown, so on the next poll the
+ * overflow is what's due and rotates in — fair coverage as long as the poll
+ * interval is shorter than the gate recheck window (the default 20s vs 5min has
+ * a wide margin). Only if an operator sets a poll interval LONGER than the gate
+ * recheck could tasks early in a very large gated backlog keep winning the
+ * budget; that misconfiguration delays (never drops) a reminder.
+ */
+const MAX_GATE_LOOKUPS_PER_POLL = 16;
+
+/**
+ * Parent statuses that DON'T gate a child — a parent in any of these has
+ * reached a terminal state, so the dependency is satisfied. Anything else that
+ * is present on the board (todo/doing/blocked/…) is an unfinished parent that
+ * gates. Matched case-insensitively. Terminal-but-not-"done" statuses like
+ * `archived`/`cancelled` are included so a child is never silenced forever
+ * behind a parent that will never reach exactly `done`.
+ */
+const SATISFIED_PARENT_STATUSES = new Set([
+  "done",
+  "complete",
+  "completed",
+  "resolved",
+  "closed",
+  "archived",
+  "cancelled",
+  "canceled",
+]);
+
+/**
+ * A task's parent ids from `<task_command> <id> --json`. The board's list
+ * output omits parents (it is null there), so a dependency gate is only
+ * visible via the per-task detail. Returns [] when the task has no parents,
+ * the field is absent/malformed, or the CLI hiccups — a lookup failure must
+ * never be mistaken for "gated" (that would silence a genuinely stalled task).
+ */
+export async function taskParentsViaCli(
+  id: string,
+  command: string[],
+  options: KanbanCommandOptions = {},
+): Promise<string[]> {
+  try {
+    const result = await runBoundedCommand([...command, id, "--json"], {
+      signal: options.signal,
+      timeoutMs: options.timeoutMs ?? GATE_LOOKUP_TIMEOUT_MS,
+      stdoutLimitBytes: KANBAN_LINK_STDOUT_LIMIT_BYTES,
+      stderrLimitBytes: KANBAN_STDERR_LIMIT_BYTES,
+      totalLimitBytes: KANBAN_LINK_STDOUT_LIMIT_BYTES + KANBAN_STDERR_LIMIT_BYTES,
+      outputLimitBehavior: "error",
+      stderrCapture: "tail",
+    });
+    if (result.exitCode !== 0) return [];
+    const d = JSON.parse(result.stdout.text) as { parents?: unknown };
+    if (!Array.isArray(d.parents)) return [];
+    return d.parents
+      .filter((p): p is string => typeof p === "string")
+      .slice(0, MAX_PARENT_IDS)
+      .map((p) => p.slice(0, 128));
+  } catch (error) {
+    if (error instanceof CommandAbortError || options.signal?.aborted) throw error;
+    return [];
+  }
+}
+
 export class KanbanWatcher {
   /** Last status seen per task id. Empty until the first successful poll seeds it. */
   private known = new Map<string, string>();
@@ -169,6 +253,12 @@ export class KanbanWatcher {
   /** Per unstarted task: reminders already sent and when the next is allowed. */
   private nudged = new Map<string, { count: number; nextAt: number }>();
 
+  /** Status by id from the current poll's task list — used for parent-gate checks. */
+  private statusById = new Map<string, string>();
+
+  /** Parent-gate lookups spent in the current poll — reset each poll, bounded. */
+  private gateLookupsThisPoll = 0;
+
   constructor(private opts: {
     list: (signal: AbortSignal) => Promise<KanbanTask[]>;
     /** Called with the transitioned task — the caller formats and voices it. */
@@ -177,6 +267,20 @@ export class KanbanWatcher {
     /** Called for each reminder about a task sitting unstarted past nudgeAfterMs. */
     nudge?: (task: KanbanTask, waitedMinutes: number, nth: number, signal: AbortSignal) => void | Promise<void>;
     nudgeAfterMs?: number;
+    /**
+     * A task's parent ids (the list feed omits them). When provided, a task
+     * whose parent is still on the board in a non-terminal status is treated as
+     * parked behind a dependency, not neglected, so no "nobody picked this up"
+     * nudge fires. Absent = nudge on age alone (previous behavior).
+     */
+    parents?: (task: KanbanTask, signal: AbortSignal) => Promise<string[]>;
+    /**
+     * How often a parent-gated task re-checks its gate (ms). A parked task is
+     * re-evaluated at most this often, NOT every poll, so a large/slow board
+     * never runs a parent-lookup subprocess per parked task per poll. Default
+     * {@link GATE_RECHECK_MS}; tests set 0 to re-check on every tick.
+     */
+    gateRecheckMs?: number;
     /** Clock override for tests. */
     now?: () => number;
   }) {}
@@ -261,6 +365,14 @@ export class KanbanWatcher {
       totalTasks: tasks.length,
       tasks: tasks.slice(0, KANBAN_SNAPSHOT_TASK_LIMIT).map(boundedTask).filter((task): task is KanbanTask => task !== null),
     };
+    // Whole-list status map, built before the loop so a parent-gate check sees
+    // every current status regardless of task order (a child may precede its
+    // parent). A parent absent here (done-and-archived, or off the board) is
+    // treated as a satisfied gate.
+    this.statusById = new Map(
+      tasks.filter((t) => t?.id && typeof t.status === "string").map((t) => [t.id, t.status]),
+    );
+    this.gateLookupsThisPoll = 0; // fresh per-poll subprocess budget
     for (const t of tasks) {
       if (signal.aborted) return;
       if (!t?.id || typeof t.status !== "string") continue;
@@ -325,6 +437,36 @@ export class KanbanWatcher {
     if (waitedMs < nudgeAfterMs) return;
     const state = this.nudged.get(t.id) ?? { count: 0, nextAt: 0 };
     if (now < state.nextAt) return;
+    // Gate check happens only here — right before a nudge would fire — so the
+    // per-task detail lookup runs for the rare stale-and-due task, not every
+    // task every poll. A task parked behind an unfinished parent is waiting by
+    // design, not neglected.
+    const recheckMs = this.opts.gateRecheckMs ?? GATE_RECHECK_MS;
+    if (this.opts.parents) {
+      // Bound the sequential subprocess work in one poll: past the budget, defer
+      // this task's gate decision to a later poll rather than let a large board
+      // run an unbounded chain of ~seconds-long lookups that would delay every
+      // later task's nudge and announcement. Deferred tasks stay due (not the
+      // longer gate cooldown) so once the looked-up tasks enter their cooldown
+      // the overflow rotates in and no task is starved. Escalation is preserved.
+      if (this.gateLookupsThisPoll >= MAX_GATE_LOOKUPS_PER_POLL) {
+        this.nudged.set(t.id, { count: state.count, nextAt: now });
+        return;
+      }
+      this.gateLookupsThisPoll++;
+      if (await this.isGatedByParent(t, signal)) {
+        // The lookup may have awaited across a shutdown; a superseded/aborted
+        // poll must not publish a late nudge into a stopped watcher.
+        if (signal.aborted) return;
+        // Re-check the gate on a bounded cadence rather than every poll, so a
+        // parked task doesn't run a parent-lookup subprocess on every poll.
+        // Escalation state (count) is preserved so an eventual un-gating nudges
+        // at the right level instead of restarting from zero.
+        this.nudged.set(t.id, { count: state.count, nextAt: now + recheckMs });
+        return;
+      }
+      if (signal.aborted) return;
+    }
     const gap = Math.min(nudgeAfterMs * 2 ** state.count, Math.max(nudgeAfterMs, 4 * 3_600_000));
     this.nudged.set(t.id, { count: state.count + 1, nextAt: now + gap });
     try {
@@ -333,6 +475,41 @@ export class KanbanWatcher {
       if (signal.aborted) return;
       log("warn", `kanban watch: nudge failed: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  /**
+   * True when the task has a parent still on the board in a non-terminal status
+   * — i.e. a dependency gate that has not opened. Deliberately fails toward
+   * informing rather than hiding a possibly-stalled task:
+   * - A lookup failure returns false (the nudge fires) — a broken detail command
+   *   must never silence a genuinely neglected task.
+   * - A parent absent from the current board returns not-gating. NOTE: if the
+   *   configured list command filters (by assignee/status/tenant), an unfinished
+   *   parent it omits looks satisfied; on a filtered board this can still let a
+   *   nudge through. That is the safe direction (a spurious reminder, never a
+   *   silenced task) and single-operator Hermes boards are unfiltered.
+   * - A terminal-but-not-`done` parent ({@link SATISFIED_PARENT_STATUSES},
+   *   e.g. `archived`) does NOT gate, so a child is never parked forever behind
+   *   a parent that will never reach exactly `done`. A self-parent never gates.
+   * The status snapshot is taken once per poll, so a parent that flips right
+   * after the snapshot is one poll stale — bounded and self-correcting.
+   */
+  private async isGatedByParent(t: KanbanTask, signal: AbortSignal): Promise<boolean> {
+    if (!this.opts.parents) return false;
+    let parentIds: string[];
+    try {
+      parentIds = await this.opts.parents(t, signal);
+    } catch (error) {
+      if (signal.aborted) return false;
+      log("warn", `kanban watch: parent lookup failed: ${error instanceof Error ? error.message : String(error)}`);
+      return false;
+    }
+    return parentIds.some((pid) => {
+      if (pid === t.id) return false; // a self-parent is not a real dependency
+      const status = this.statusById.get(pid);
+      if (status === undefined) return false; // not on the board = treated as satisfied
+      return !SATISFIED_PARENT_STATUSES.has(status.toLowerCase());
+    });
   }
 }
 

--- a/tests/notify/kanban-watch.test.ts
+++ b/tests/notify/kanban-watch.test.ts
@@ -4,6 +4,7 @@ import {
   listViaCli,
   spokenLine,
   taskLinkViaCli,
+  taskParentsViaCli,
   type KanbanTask,
 } from "../../src/notify/kanban-watch";
 import { CommandAbortError, CommandDeadlineError } from "../../src/process/bounded-command";
@@ -183,6 +184,240 @@ test("nudge: reminders repeat with a doubling gap and stop when someone starts t
   board[0] = { ...board[0]!, started_at: Math.floor(clock / 1000) };
   clock += 5 * 3600_000; await w.tick();            // started — silence, state cleared
   expect(nudges).toEqual(["t1#1", "t1#2", "t1#3"]);
+});
+
+test("nudge: a task gated behind an unfinished parent is not nudged", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const board: KanbanTask[] = [
+    { id: "work", title: "Implement X", status: "blocked", created_at: now - 2 * 3600 },
+    { id: "qa", title: "Verify X", status: "todo", created_at: now - 2 * 3600 }, // stale, but parented to blocked work
+  ];
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    parents: async (t) => (t.id === "qa" ? ["work"] : []),
+  });
+  await w.tick();
+  expect(nudges).toEqual([]); // qa is parked behind blocked work, not neglected
+});
+
+test("nudge: the gate opens once the parent is done, then the task nudges", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const work: KanbanTask = { id: "work", title: "Implement X", status: "blocked", created_at: now - 2 * 3600 };
+  const qa: KanbanTask = { id: "qa", title: "Verify X", status: "todo", created_at: now - 2 * 3600 };
+  let board: KanbanTask[] = [work, qa];
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    gateRecheckMs: 0, // re-check the gate on the very next tick, not after a backoff
+    parents: async (t) => (t.id === "qa" ? ["work"] : []),
+  });
+  await w.tick();                                        // gated — no nudge
+  board = [{ ...work, status: "done" }, qa];             // parent finishes
+  await w.tick();                                        // gate open — qa is genuinely unpicked now
+  expect(nudges).toEqual(["qa"]);
+});
+
+test("nudge: a terminal-but-not-done parent (archived) does not gate forever", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const board: KanbanTask[] = [
+    { id: "work", title: "Implement X", status: "archived", created_at: now - 2 * 3600, started_at: now - 3600 },
+    { id: "qa", title: "Verify X", status: "todo", created_at: now - 2 * 3600 },
+  ];
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    parents: async (t) => (t.id === "qa" ? ["work"] : []),
+  });
+  await w.tick();
+  expect(nudges).toEqual(["qa"]); // archived is terminal — the dependency is satisfied
+});
+
+test("nudge: a self-referential parent does not gate the task against itself", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const board: KanbanTask[] = [
+    { id: "loop", title: "Waiting on itself", status: "todo", created_at: now - 2 * 3600 },
+  ];
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    parents: async () => ["loop"], // a self-parent must not silence the task
+  });
+  await w.tick();
+  expect(nudges).toEqual(["loop"]);
+});
+
+test("nudge: the gate sees the parent even when the child is listed first", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  // Child precedes its parent in the feed — statusById is built for the whole
+  // list before the nudge loop, so ordering must not affect the gate.
+  const board: KanbanTask[] = [
+    { id: "qa", title: "Verify X", status: "todo", created_at: now - 2 * 3600 },
+    { id: "work", title: "Implement X", status: "doing", created_at: now - 2 * 3600, started_at: now - 3600 },
+  ];
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    parents: async (t) => (t.id === "qa" ? ["work"] : []),
+  });
+  await w.tick();
+  expect(nudges).toEqual([]); // parent is unfinished regardless of list order
+});
+
+test("nudge: a parked task re-checks its gate on a cadence, not every poll", async () => {
+  const now = Math.floor(Date.now() / 1000);
+  const board: KanbanTask[] = [
+    { id: "work", title: "Implement X", status: "doing", created_at: now - 2 * 3600, started_at: now - 3600 },
+    { id: "qa", title: "Verify X", status: "todo", created_at: now - 2 * 3600 },
+  ];
+  let lookups = 0;
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: () => {},
+    nudgeAfterMs: 60 * 60_000,
+    gateRecheckMs: 60 * 60_000, // a long backoff: the second quick tick must not re-look-up
+    parents: async (t) => {
+      if (t.id === "qa") lookups++;
+      return t.id === "qa" ? ["work"] : [];
+    },
+  });
+  await w.tick();
+  await w.tick();
+  expect(lookups).toBe(1); // the parked task is not re-queried on every poll
+});
+
+test("nudge: parent-gate lookups are bounded per poll and deferred work is retried, not starved", async () => {
+  const now = Math.floor(Date.now() / 1000);
+  // One in-progress parent gating many stale children — more than fit in a
+  // single poll's lookup budget (16).
+  const children = Array.from({ length: 20 }, (_, i) => ({
+    id: `qa${i}`,
+    title: `Verify ${i}`,
+    status: "todo",
+    created_at: now - 2 * 3600,
+  }));
+  const board: KanbanTask[] = [
+    { id: "work", title: "Implement", status: "doing", created_at: now - 2 * 3600, started_at: now - 3600 },
+    ...children,
+  ];
+  let lookups = 0;
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: () => {},
+    nudgeAfterMs: 60 * 60_000,
+    gateRecheckMs: 60 * 60_000, // looked-up tasks cool down so the deferred ones get a turn
+    parents: async (t) => {
+      if (t.id.startsWith("qa")) lookups++;
+      return t.id.startsWith("qa") ? ["work"] : [];
+    },
+  });
+  await w.tick();
+  expect(lookups).toBe(16); // capped at MAX_GATE_LOOKUPS_PER_POLL — not all 20 in one poll
+  await w.tick();
+  expect(lookups).toBe(20); // the deferred 4 are retried next poll, none starved
+});
+
+test("nudge: an aborted parent lookup does not emit a late nudge on shutdown", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const board: KanbanTask[] = [
+    { id: "qa", title: "Verify X", status: "todo", created_at: now - 2 * 3600 },
+  ];
+  let entered!: () => void;
+  const reached = new Promise<void>((r) => (entered = r));
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    parents: (_t, signal) =>
+      new Promise<string[]>((_res, reject) => {
+        entered();
+        signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      }),
+  });
+  const tick = w.tick();
+  await reached;   // the poll is now parked inside the parent lookup
+  await w.stop();  // aborts the in-flight poll
+  await tick;
+  expect(nudges).toEqual([]); // a superseded/aborted poll must publish nothing
+});
+
+test("taskParentsViaCli reads the parents array from the task detail JSON", async () => {
+  const cmd = [process.execPath, "-e", "console.log(JSON.stringify({ parents: ['work', 'other'] }))"];
+  expect(await taskParentsViaCli("qa", cmd)).toEqual(["work", "other"]);
+});
+
+test("taskParentsViaCli swallows failures and malformed output into an empty list", async () => {
+  expect(await taskParentsViaCli("x", [process.execPath, "-e", "process.exit(3)"])).toEqual([]);
+  expect(await taskParentsViaCli("x", [process.execPath, "-e", "console.log('{ not json')"])).toEqual([]);
+  expect(
+    await taskParentsViaCli("x", [process.execPath, "-e", "console.log(JSON.stringify({ parents: 'nope' }))"]),
+  ).toEqual([]);
+  expect(
+    await taskParentsViaCli("x", [process.execPath, "-e", "console.log(JSON.stringify({ other: 1 }))"]),
+  ).toEqual([]);
+});
+
+test("nudge: a parent that is done-and-archived (off the board) does not gate", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const board: KanbanTask[] = [
+    { id: "qa", title: "Verify X", status: "todo", created_at: now - 2 * 3600 },
+  ];
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    parents: async () => ["archived-parent"], // parent not present in the snapshot
+  });
+  await w.tick();
+  expect(nudges).toEqual(["qa"]); // absent parent = satisfied gate, so it's genuinely unpicked
+});
+
+test("nudge: a parent lookup failure informs rather than hides a stalled task", async () => {
+  const nudges: string[] = [];
+  const now = Math.floor(Date.now() / 1000);
+  const board: KanbanTask[] = [
+    { id: "orphan", title: "Waiting", status: "todo", created_at: now - 2 * 3600 },
+  ];
+  const w = new KanbanWatcher({
+    list: async () => board,
+    announce: () => {},
+    intervalMs: 60_000,
+    nudge: (t) => nudges.push(t.id),
+    nudgeAfterMs: 60 * 60_000,
+    parents: async () => { throw new Error("kanban show failed"); },
+  });
+  await w.tick();
+  expect(nudges).toEqual(["orphan"]); // unknown gate state must not silence the nudge
 });
 
 test("nudge: off without a callback or with nudgeAfterMs 0", async () => {


### PR DESCRIPTION
## What

A "nobody's picked this up" staleness nudge fired for a task that was correctly **parked behind an unfinished parent** — e.g. a gated QA card waiting on its work card. This is the "why is this chilling: *The task … has been waiting 60 minutes — nobody's picked it up yet*" report.

Root cause: the kanban **list** feed returns `parents: null`, so the staleness nudge was blind to dependency gates. Only the per-task **`show <id> --json`** detail carries parents.

## Fix

`KanbanWatcher` gains an optional `parents` lookup and suppresses the nudge while a parent is still on the board in a non-terminal status. Everything else (age-only nudging when no `task_command` is configured) is unchanged.

### Reliability bounds (from Codex review — 3 rounds)
- **No permanent silencing:** terminal-but-not-`done` parents (`archived`/`cancelled`/`closed`, case-insensitive) and self-parents don't gate.
- **Fail toward informing:** a lookup failure or an absent parent lets the nudge fire — a broken detail command never hides a genuinely stalled task.
- **Bounded work:** gated tasks re-check on a cadence (`GATE_RECHECK_MS`, 5 min), not every poll; a shorter 3 s per-lookup timeout; and a per-poll budget of 16 lookups with next-poll deferral so a large board can't stall announcements. Deferred tasks stay due so the overflow rotates in (no starvation for any sane poll-interval < recheck config).
- **Abort-safe:** the lookup honors the poll's `AbortSignal`; an aborted/superseded poll publishes no late nudge.

### Documented best-effort limits
- A **filtered** list command could make an unfinished-but-omitted parent look satisfied → a spurious reminder (never a silenced task).
- Snapshot/detail **TOCTOU** is one poll wide and self-correcting.

## Tests
`tests/notify/kanban-watch.test.ts`: gated-not-nudged, gate-opens-then-nudges, archived/self parent, child-listed-before-parent, per-poll budget + deferral rotation, abort-on-shutdown, and the real `taskParentsViaCli` parse/failure paths. 30/30 pass; `bun run typecheck` and `git diff --check` clean.

Verified locally with Codex (gpt-5.6-sol) across three rounds; all High findings resolved.