### PR TITLE
fix(windows): unblock local Cicero startup

### DIFF
--- a/src/brain/subprocess-cli.ts
+++ b/src/brain/subprocess-cli.ts
@@ -136,10 +136,19 @@ export class SubprocessCLIBrain implements Brain {
   /** Called after a turn's subprocess exits 0 — hook for session tracking. */
   protected onTurnComplete(): void {}
 
+  private resolvedBinary(env: Record<string, string | undefined>): string {
+    if (process.platform !== "win32") return this.config.binary;
+    let path: string | undefined;
+    for (const [key, value] of Object.entries(env)) {
+      if (key.toLowerCase() === "path") path = value;
+    }
+    return Bun.which(this.config.binary, { PATH: path }) ?? this.config.binary;
+  }
+
   private spawnProc(message: string, options: BrainTurnOptions) {
     const fullMessage = this.buildPrompt(message, options.systemContext);
     const env = this.buildEnv();
-    const { binary } = this.config;
+    const binary = this.resolvedBinary(env);
     const args = this.argsForTurn();
 
     if (this.config.promptViaStdin) {
@@ -167,7 +176,7 @@ export class SubprocessCLIBrain implements Brain {
    */
   protected spawnWithArgs(args: string[], message: string, systemContext?: string) {
     const env = this.buildEnv();
-    return spawnOwnedProcess([this.config.binary, ...args, this.buildPrompt(message, systemContext)], {
+    return spawnOwnedProcess([this.resolvedBinary(env), ...args, this.buildPrompt(message, systemContext)], {
       stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -882,13 +882,18 @@ export class CiceroDaemon {
     };
     this.brain.setCallMeHandler?.(dialBack);
 
+    let conversationHistory: TurnHistory | undefined;
+    const history = () => conversationHistory ??= new TurnHistory(
+      join(homedir(), ".cicero", "web-voice", "history.jsonl"),
+    );
+
     if (this.config.notify?.telegram) {
       // Since Jul 10 the bot is the office's TEXT surface (the tgcall userbot
       // keeps only calls): "log …" hits the health record instantly, "call me"
       // spools a dial-back for the tgcall sidecar, and anything else is a
       // chat turn against the same brain the voice surfaces reach — recorded
       // in the shared history so voice sessions resume with it.
-      const tgHistory = new TurnHistory(join(homedir(), ".cicero", "web-voice", "history.jsonl"));
+      const tgHistory = history();
       // Semantic fallback for dial-back phrasings the lexical pattern misses
       // ("get ada on the horn") — the same small local model the
       // switchboard uses for spoken transfers. Lexical-only without a
@@ -929,8 +934,7 @@ export class CiceroDaemon {
       const resumeTurns = this.config.web_voice?.resume_turns ?? 10;
       if (this.config.web_voice?.enabled && resumeTurns > 0) {
         try {
-          const history = new TurnHistory(join(homedir(), ".cicero", "web-voice", "history.jsonl"));
-          const primer = buildResumePrimer(await history.recent(resumeTurns));
+          const primer = buildResumePrimer(await history().recent(resumeTurns));
           if (primer) warmMsg = primer;
         } catch { /* no history — plain warmup */ }
       }
@@ -1050,7 +1054,7 @@ export class CiceroDaemon {
       }
       this.assertStartupActive();
       assertWebTlsPolicy(webHost, tls, tlsExplicitlyDisabled);
-      const webHistory = new TurnHistory(join(homedir(), ".cicero", "web-voice", "history.jsonl"));
+      const webHistory = history();
       // Every spoken sentence funnels through here — the one place to strip
       // Markdown/typography so a voice never says "dash" or glitches on an
       // em-dash. A sentence that is pure markup flattens to nothing and is

--- a/src/sidecar/codex-hook.ts
+++ b/src/sidecar/codex-hook.ts
@@ -39,11 +39,14 @@ async function readHookBody(
 ): Promise<string> {
   const reader = input.getReader();
   const chunks: Uint8Array[] = [];
-  const signal = AbortSignal.timeout(timeoutMs);
+  const controller = new AbortController();
+  const deadline = setTimeout(() => {
+    controller.abort(new DOMException("Codex hook input timed out", "TimeoutError"));
+  }, timeoutMs);
   let total = 0;
   try {
     while (true) {
-      const result = await readBeforeDeadline(reader, signal);
+      const result = await readBeforeDeadline(reader, controller.signal);
       if (result.done) break;
       const value = result.value;
       if (!value || value.byteLength === 0) continue;
@@ -67,6 +70,7 @@ async function readHookBody(
     });
     throw error;
   } finally {
+    clearTimeout(deadline);
     reader.releaseLock();
   }
 }

--- a/src/web-voice/history.ts
+++ b/src/web-voice/history.ts
@@ -28,6 +28,7 @@ const KEEP_LINES = 500;   // … rewrite keeping this many
 export class TurnHistory {
   private pending: Promise<void> = Promise.resolve();
   private available = true;
+  private lineCount: number | null = null;
 
   constructor(private file: string) {
     try {
@@ -72,8 +73,14 @@ export class TurnHistory {
   }
 
   private async trimIfNeeded(): Promise<void> {
+    if (this.lineCount !== null) {
+      this.lineCount += 1;
+      if (this.lineCount <= MAX_LINES) return;
+    }
     const lines = (await readFile(this.file, "utf8")).split("\n").filter(Boolean);
-    if (lines.length <= MAX_LINES) return;
+    this.lineCount = lines.length;
+    if (this.lineCount <= MAX_LINES) return;
     await writeFile(this.file, lines.slice(-KEEP_LINES).join("\n") + "\n", { mode: PRIVATE_FILE_MODE });
+    this.lineCount = KEEP_LINES;
   }
 }

--- a/src/web-voice/tls.ts
+++ b/src/web-voice/tls.ts
@@ -129,7 +129,7 @@ async function assertOwnedRegularPair(certPath: string, keyPath: string): Promis
 }
 
 async function syncFile(path: string): Promise<void> {
-  const handle = await open(path, "r");
+  const handle = await open(path, "r+");
   try {
     await handle.sync();
   } finally {

--- a/tests/brain-subprocess-cli.test.ts
+++ b/tests/brain-subprocess-cli.test.ts
@@ -1,4 +1,7 @@
 import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import {
   awaitOwnedTurnExit,
   SubprocessCLIBrain,
@@ -10,6 +13,33 @@ test("SubprocessCLIBrain spawns the configured binary with prompt", async () => 
   await brain.start();
   const out = await brain.send("hello");
   expect(out).toContain("hello");
+});
+
+test.skipIf(process.platform !== "win32")("resolves Windows PATH command shims before spawning", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "cicero-brain-shim-"));
+  try {
+    writeFileSync(join(directory, "cicero-brain-shim.cmd"), "@echo off\r\necho %*\r\n");
+    class InspectBrain extends SubprocessCLIBrain {
+      spawnExplicit() {
+        return this.spawnWithArgs(["--stream"], "hello");
+      }
+    }
+    const brain = new InspectBrain({
+      name: "test",
+      binary: "cicero-brain-shim",
+      args: ["--print"],
+      env: { PATH: `${directory}${delimiter}${process.env.PATH ?? ""}` },
+      rememberTurns: false,
+    });
+
+    expect(await brain.send("hello")).toContain("--print hello");
+    const explicit = brain.spawnExplicit();
+    const output = await new Response(explicit.stdout).text();
+    expect(await awaitOwnedTurnExit(explicit)).toBe(0);
+    expect(output).toContain("--stream hello");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("injected context is prepended once and completed turns become bounded history", () => {

--- a/tests/voice-cli.test.ts
+++ b/tests/voice-cli.test.ts
@@ -30,7 +30,7 @@ function writeFixtureWav(path: string): void {
 
 async function cli(home: string, ...args: string[]): Promise<{ code: number; out: string; err: string }> {
   const proc = Bun.spawn(["bun", INDEX, "voice", ...args], {
-    env: { ...process.env, HOME: home },
+    env: { ...process.env, HOME: home, USERPROFILE: home },
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
## Summary

Cicero can now complete its documented local Windows startup under the pinned Bun runtime. Codex command shims launch through the configured child PATH, automatic TLS certificates survive the Windows fsync path, stalled hook input remains bounded, and voice CLI tests no longer write synthetic data into the operator profile.

Conversation history also avoids rereading the full JSONL file after every turn while keeping Telegram, warmup, and web voice behind one serialized writer.

## Validation

- `bun run typecheck`
- Focused Windows regressions: 34 passed, 5 platform-skipped, 0 failed
- `git diff --check`
- Live installed-stack smoke: HTTPS `/health` and `/ready` returned 200; faster-whisper, Pocket-TTS, Ollama `qwen3.5:4b`, and the Codex brain all reported reachable

The complete Windows `bun test` run remains red outside this diff: existing fake-PID tree-cleanup tests assume POSIX signaling, two assertions assume POSIX paths, and Bun 1.3.14 panics in `node:net` `BlockList` on the IPv6 browser-policy case. The focused changed behavior and live runtime were verified independently of those failures.

## Post-Deploy Monitoring & Validation

- Window/owner: maintainer or Windows operator watches the first three local starts and one normal stop.
- Healthy signals: `/health` and `/ready` stay 200; `cicero status` reports STT, TTS, LLM, and brain reachable; history remains near its configured trim bound.
- Search logs for `Brain (Codex CLI) error`, `web-voice history write skipped`, TLS generation failures, or hook deadline/cancellation failures.
- Roll back this commit if Windows command shims stop launching, generated TLS cannot publish, providers fail readiness, or history growth stops being bounded.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
