### PR TITLE
docs(compute): state the Linux floor for the optional browser driver

### DIFF
--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -49,14 +49,19 @@ The browser driver is optional. Install its browser once before using `--web`:
 bun x playwright install chromium
 ```
 
-`--web` can only run where Playwright ships a prebuilt browser, so its Linux
-floor is whatever the installed Playwright supports. **From Playwright 1.62
-that means Debian 12+ or Ubuntu 20.04+** (x86-64 or arm64): 1.62 removed the
-Debian 11 builds that 1.61.x still provides, so on Debian 11 a 1.62
-`playwright install` has no browser to fetch and a later `--web` navigation
-fails at launch. macOS and Windows are unaffected. So are the CLI, the daemon,
-voice, and every other computer-use tool — only this optional driver needs a
-prebuilt browser.
+`--web` can only run where Playwright ships a prebuilt browser, so it inherits
+the installed Playwright's platform support — a narrower set than the rest of
+Cicero. **Playwright 1.62 supports Debian 12/13 or Ubuntu 22.04/24.04/26.04
+(x86-64 or arm64), macOS 14+, and Windows 11+ / Server 2019+ / WSL.** It
+dropped the Debian 11 and macOS 13-and-older builds that 1.61.x still ships,
+so on a dropped platform `playwright install` has no browser to fetch and a
+later `--web` navigation fails at launch. Cicero already requires macOS 14+,
+so only the Linux floor is new here.
+
+Nothing else is affected: the browser package is an optional dependency,
+imported lazily and only when `--web` is passed, so the CLI, the daemon,
+voice, and every other computer-use tool run normally with no browser
+installed.
 
 ```bash
 cicero do "summarize the README files in this folder"

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -49,13 +49,14 @@ The browser driver is optional. Install its browser once before using `--web`:
 bun x playwright install chromium
 ```
 
-Playwright publishes prebuilt browsers for a fixed list of Linux distributions,
-and that list is the real floor for `--web` on Linux: **Debian 12+ or Ubuntu
-20.04+** (x86-64 or arm64), plus macOS and Windows. Playwright 1.62 dropped its
-Debian 11 builds, so on Debian 11 `playwright install` has no browser to fetch
-and a later `--web` navigation fails at launch. This floor applies only to this
-optional driver — the CLI, the daemon, voice, and every other computer-use tool
-are unaffected.
+`--web` can only run where Playwright ships a prebuilt browser, so its Linux
+floor is whatever the installed Playwright supports. **From Playwright 1.62
+that means Debian 12+ or Ubuntu 20.04+** (x86-64 or arm64): 1.62 removed the
+Debian 11 builds that 1.61.x still provides, so on Debian 11 a 1.62
+`playwright install` has no browser to fetch and a later `--web` navigation
+fails at launch. macOS and Windows are unaffected. So are the CLI, the daemon,
+voice, and every other computer-use tool — only this optional driver needs a
+prebuilt browser.
 
 ```bash
 cicero do "summarize the README files in this folder"

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -49,6 +49,14 @@ The browser driver is optional. Install its browser once before using `--web`:
 bun x playwright install chromium
 ```
 
+Playwright publishes prebuilt browsers for a fixed list of Linux distributions,
+and that list is the real floor for `--web` on Linux: **Debian 12+ or Ubuntu
+20.04+** (x86-64 or arm64), plus macOS and Windows. Playwright 1.62 dropped its
+Debian 11 builds, so on Debian 11 `playwright install` has no browser to fetch
+and a later `--web` navigation fails at launch. This floor applies only to this
+optional driver — the CLI, the daemon, voice, and every other computer-use tool
+are unaffected.
+
 ```bash
 cicero do "summarize the README files in this folder"
 cicero do --root ~/Documents/notes "summarize my notes"


### PR DESCRIPTION
## Summary

`docs/daemon-mode.md` tells operators to run `bun x playwright install chromium` without saying where that works. Playwright 1.62 drops platforms, so a Debian 11 operator would follow the documented command, get no browser, and only find out later at `chromium.launch()`.

This states the supported set where the install command lives, scoped to `--web` alone, and quotes **Playwright's official system requirements** rather than inferring a floor from which download URLs still resolve.

Written per Playwright version rather than as current state, so it is correct before and after #51 lands, in either merge order.

## What it says

> Playwright 1.62 supports Debian 12/13 or Ubuntu 22.04/24.04/26.04 (x86-64 or arm64), macOS 14+, and Windows 11+ / Server 2019+ / WSL. It dropped the Debian 11 and macOS 13-and-older builds that 1.61.x still ships… Cicero already requires macOS 14+, so only the Linux floor is new here.

Plus why nothing else is affected: `playwright` is in `optionalDependencies`, `launchPlaywrightDriver` does `await import("playwright")` lazily, and the tool is registered only when `web` is set.

## Verification

Registry diff across the two tags, all keys (not just Linux):

| key | 1.61.1 | 1.62.0 |
|---|---|---|
| `debian11-x64` / `-arm64` | real URLs | **all 10 `undefined`** |
| `mac11` / `12` / `13` (+arm64) | 2/10 undefined | **10/10 undefined** |
| `mac10.13` / `10.14` / `10.15` | 4/10 undefined | **10/10 undefined** |
| `mac14+`, `win64`, other Linux keys | unchanged | unchanged |

Confirmed empirically on the locked 1.61.1 binary:

```
$ PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=debian11-x64 playwright install --dry-run chromium
Download url: .../linux64/chrome-linux64.zip
Download url: .../ffmpeg/1011/ffmpeg-linux.zip
Download url: .../linux64/chrome-headless-shell-linux64.zip
```

Cicero's own macOS floor is already 14+ (`docs/setup.md:136`, `src/platform/python.ts:5`), so the macOS removals don't move our support matrix.

Why CI can't catch the underlying break: `tests/compute/tools/browser.test.ts` injects a fake driver, `tests/compute/index.test.ts` only asserts the tool name is registered, and CI runs `ubuntu-latest`.

## Gate

- `bun run typecheck` clean
- `bun run docs:build` clean
- `git diff --check` clean
- Full `bun test` identical to `main`'s baseline (verified by stashing the change and re-running). Markdown-only diff.

## Review history

Two rounds of independent review, both of which found real errors:

1. `82d725c` stated the Debian 12+ floor unconditionally — false, since `bun.lock` pins 1.61.1 where Debian 11 works. Fixed by qualifying per version.
2. `19dc530` claimed "macOS and Windows are unaffected" (false — 1.62 drops every pre-14 macOS key) and "Ubuntu 20.04+" (conflated a resolvable URL with official support; 20.04 has artifacts but is not in Playwright's supported set). Fixed in `aa7dd47` by quoting the official requirements and enumerating rather than using `12+`/`20.04+`.

`aa7dd47` re-reviewed adversarially against all five claims: verified.

## Relation to #51

With this merged, the Debian 11 regression in #51 is a documented platform floor rather than a silent break.