### PR TITLE
Let notify callers skip quiet hours, and stop reporting defers as undelivered

### DIFF
--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -18,11 +18,22 @@ export interface NotifyRequest {
   token: string;
   text: string;
   timeoutMs?: number;
+  /**
+   * Skip the daemon's quiet-hours defer. For alerts that need a human now
+   * (an ops escalation) rather than in the next morning briefing. Off by
+   * default so ordinary notifications keep respecting quiet hours.
+   */
+  urgent?: boolean;
 }
 
 export interface NotifyResult {
   delivered: number;
   parked: boolean;
+  /**
+   * Quiet hours deferred it into the morning briefing. Distinct from a plain
+   * `delivered: 0` — the text is queued, not dropped and not parked.
+   */
+  deferred: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -38,7 +49,7 @@ export async function sendWebVoiceNotification(
   if (text.length > MAX_NOTIFY_TEXT_CHARS) {
     throw new RangeError(`notification text exceeds ${MAX_NOTIFY_TEXT_CHARS} characters`);
   }
-  const body = JSON.stringify({ text });
+  const body = JSON.stringify(request.urgent ? { text, urgent: true } : { text });
   if (new TextEncoder().encode(body).byteLength > MAX_NOTIFY_JSON_BYTES) {
     throw new RangeError(`notification JSON exceeds ${MAX_NOTIFY_JSON_BYTES} bytes`);
   }
@@ -76,11 +87,15 @@ export async function sendWebVoiceNotification(
     || !Number.isSafeInteger(payload.delivered)
     || payload.delivered < 0
     || (payload.parked !== undefined && typeof payload.parked !== "boolean")
+    || (payload.deferred !== undefined && typeof payload.deferred !== "boolean")
   ) {
     throw new Error("notify response has an invalid delivery result");
   }
   return {
     delivered: payload.delivered,
     parked: payload.parked === true,
+    // Absent on an older daemon that predates the field — reads as "not
+    // deferred", which matches how that daemon actually behaved.
+    deferred: payload.deferred === true,
   };
 }

--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -94,8 +94,14 @@ export async function sendWebVoiceNotification(
   return {
     delivered: payload.delivered,
     parked: payload.parked === true,
-    // Absent on an older daemon that predates the field — reads as "not
-    // deferred", which matches how that daemon actually behaved.
-    deferred: payload.deferred === true,
+    // A daemon predating `deferred` still says which case it was, implicitly:
+    // every real zero-delivery on that daemon parks (`parked: true`), so the
+    // only way it reports zero delivered AND not parked is the quiet-hours
+    // defer. Inferring it keeps a CLI upgraded ahead of its daemon — the
+    // window between deploying new code and restarting the daemon — from
+    // reporting a queued escalation as undelivered, which is the whole point
+    // of the field.
+    deferred: payload.deferred === true
+      || (payload.deferred === undefined && payload.delivered === 0 && payload.parked !== true),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,8 +387,13 @@ program
         // Not a delivery failure and not a drop: quiet hours queued it for the
         // next morning briefing. Saying "no voice client is connected" here
         // (as this used to) reads as lost, which hides real alerts.
+        //
+        // A defer that survives --urgent means the daemon is older than the
+        // flag and dropped it, so pointing at --urgent again would be a loop.
         console.error(
-          "[cicero] notify deferred by quiet hours — queued for the next morning briefing. Use --urgent to deliver now.",
+          opts.urgent === true
+            ? "[cicero] notify deferred by quiet hours despite --urgent — the running daemon predates the flag. Restart it to pick up the current build."
+            : "[cicero] notify deferred by quiet hours — queued for the next morning briefing. Use --urgent to deliver now.",
         );
       } else if (result.delivered === 0) {
         const suffix = result.parked ? " It was parked for the next client." : "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,7 +352,8 @@ program
   .command("notify")
   .description("Speak a notification through connected web-voice clients (proactive voice-back — use from kanban hooks, cron, CI)")
   .argument("[text...]", "Notification text (or pipe from stdin)")
-  .action(async (textParts: string[]) => {
+  .option("--urgent", "Skip quiet hours — deliver now instead of queueing for the morning briefing (for alerts that need a human tonight)")
+  .action(async (textParts: string[], opts: { urgent?: boolean }) => {
     const text = await commandText(
       textParts,
       Bun.stdin.stream(),
@@ -380,8 +381,16 @@ program
         token: wv.token,
         text,
         timeoutMs: config.ttsBackend.timeout_ms,
+        urgent: opts.urgent === true,
       });
-      if (result.delivered === 0) {
+      if (result.deferred) {
+        // Not a delivery failure and not a drop: quiet hours queued it for the
+        // next morning briefing. Saying "no voice client is connected" here
+        // (as this used to) reads as lost, which hides real alerts.
+        console.error(
+          "[cicero] notify deferred by quiet hours — queued for the next morning briefing. Use --urgent to deliver now.",
+        );
+      } else if (result.delivered === 0) {
         const suffix = result.parked ? " It was parked for the next client." : "";
         console.error(`[cicero] notify rendered, but no voice client is connected right now.${suffix}`);
       } else {

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -178,7 +178,7 @@ export interface WebVoiceHandle {
    * broadcast, park when nobody's connected) — for in-process callers like the
    * kanban watcher. Resolves null when unavailable, saturated, or quiescing.
    */
-  notify: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal }) => Promise<{ delivered: number; parked: boolean } | null>;
+  notify: (text: string, voice?: string, opts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal }) => Promise<{ delivered: number; parked: boolean; deferred?: boolean } | null>;
   /** Broadcast a newly pending brain-owned confirmation to live clients. */
   confirmPending: (summary: string, nonce: string) => number;
   /** Quiesce ingress, cancel owned work, close sockets, and drain handlers. */
@@ -660,7 +660,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     text: string,
     voice?: string,
     notifyOpts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal },
-  ): Promise<{ delivered: number; parked: boolean } | null> => {
+  ): Promise<{ delivered: number; parked: boolean; deferred?: boolean } | null> => {
     if (!onNotify) return null;
     const signal = notifyOpts?.signal ?? shutdownController.signal;
     if (signal.aborted) return null;
@@ -683,9 +683,12 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     }
     if (signal.aborted) return null;
     // null = the daemon deferred it (quiet hours) — no broadcast, no parking.
+    // `deferred` distinguishes this from an ordinary zero-delivery: the text is
+    // queued for the morning briefing, NOT dropped and NOT parked. Callers that
+    // report delivery to a human must be able to tell those apart.
     if (providerAudio === null) {
       log("info", `notify: "${text.substring(0, 60)}" deferred (quiet hours)`);
-      return { delivered: 0, parked: false };
+      return { delivered: 0, parked: false, deferred: true };
     }
     const audio = snapshotSynthesizedWav(providerAudio, {
       maxBytes: MAX_TURN_AUDIO_BYTES,
@@ -746,7 +749,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     text: string,
     voice?: string,
     notifyOpts?: { urgent?: boolean; telegramMirror?: boolean; signal?: AbortSignal },
-  ): Promise<{ delivered: number; parked: boolean } | null> => {
+  ): Promise<{ delivered: number; parked: boolean; deferred?: boolean } | null> => {
     const normalizedText = text.trim();
     const normalizedVoice = voice?.trim() || undefined;
     if (
@@ -993,6 +996,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           return withRequestLease(req, async (signal) => {
             let text = "";
             let voice: string | undefined;
+            let urgent = false;
             try {
               const body = await readRequestJsonLimited(req, {
                 maxBytes: MAX_NOTIFY_JSON_BYTES,
@@ -1005,8 +1009,15 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               if (body.voice !== undefined && typeof body.voice !== "string") {
                 return Response.json({ error: "voice must be a string" }, { status: 400 });
               }
+              if (body.urgent !== undefined && typeof body.urgent !== "boolean") {
+                return Response.json({ error: "urgent must be a boolean" }, { status: 400 });
+              }
               text = body.text.trim();
               voice = body.voice?.trim() || undefined;
+              // Opt-in only: an urgent notification skips the quiet-hours defer
+              // so an alert that needs a human tonight is not queued until the
+              // morning briefing. Everything else keeps the quiet-hours default.
+              urgent = body.urgent === true;
             } catch (error) {
               return jsonReadError(error, shutdownController.signal.aborted);
             }
@@ -1015,9 +1026,12 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               return Response.json({ error: "notification text or voice is too long" }, { status: 413 });
             }
             try {
-              const result = await dispatchNotify(text, voice, { signal });
+              const result = await dispatchNotify(text, voice, { urgent, signal });
               if (signal.aborted) return requestAbortedResponse(signal);
               if (!result) return Response.json({ error: "notify not available" }, { status: 501 });
+              if (result.deferred) {
+                return Response.json({ delivered: result.delivered, deferred: true });
+              }
               return result.parked
                 ? Response.json({ delivered: result.delivered, parked: true })
                 : Response.json({ delivered: result.delivered });

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -58,6 +58,28 @@ test("a quiet-hours defer is distinct from a park and from a zero delivery", asy
     .rejects.toThrow(/invalid delivery result/);
 });
 
+test("a defer from a daemon predating the field is still reported as a defer", async () => {
+  // Rolling upgrade: new CLI, daemon not yet restarted. That daemon cannot send
+  // `deferred`, but its wire format is unambiguous anyway — every real
+  // zero-delivery parks, so zero delivered AND not parked can only be the
+  // quiet-hours defer. Without this the CLI falls back to "no voice client is
+  // connected", which is exactly the misreport this change exists to kill.
+  const responder = (payload: unknown) => (async () => Response.json(payload)) as typeof fetch;
+  const base = { scheme: "https" as const, port: 8090, token: "secret", text: "fork sync stalled" };
+
+  // Legacy defer, both shapes the old route could emit.
+  expect(await sendWebVoiceNotification(base, responder({ delivered: 0 })))
+    .toEqual({ delivered: 0, parked: false, deferred: true });
+  expect(await sendWebVoiceNotification(base, responder({ delivered: 0, parked: false })))
+    .toEqual({ delivered: 0, parked: false, deferred: true });
+
+  // Legacy park and legacy delivery must NOT be inferred as defers.
+  expect(await sendWebVoiceNotification(base, responder({ delivered: 0, parked: true })))
+    .toEqual({ delivered: 0, parked: true, deferred: false });
+  expect(await sendWebVoiceNotification(base, responder({ delivered: 3 })))
+    .toEqual({ delivered: 3, parked: false, deferred: false });
+});
+
 test("notify rejects character and encoded-JSON overflow before fetch", async () => {
   let calls = 0;
   const mockFetch = (async () => {

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -18,7 +18,7 @@ test("notify stays on loopback, disables redirects, and validates delivery JSON"
     text: " hello ",
   }, mockFetch);
 
-  expect(result).toEqual({ delivered: 2, parked: false });
+  expect(result).toEqual({ delivered: 2, parked: false, deferred: false });
   expect(observedUrl).toBe("https://127.0.0.1:8090/api/notify");
   expect(observedInit?.redirect).toBe("error");
   expect(observedInit?.headers).toEqual({
@@ -27,6 +27,35 @@ test("notify stays on loopback, disables redirects, and validates delivery JSON"
   });
   expect(observedInit?.body).toBe(JSON.stringify({ text: "hello" }));
   expect(observedInit?.signal).toBeInstanceOf(AbortSignal);
+});
+
+test("urgent rides the body only when asked for", async () => {
+  let body: string | undefined;
+  const mockFetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    body = init?.body as string;
+    return Response.json({ delivered: 1 });
+  }) as typeof fetch;
+  const base = { scheme: "https" as const, port: 8090, token: "secret", text: "build is down" };
+
+  await sendWebVoiceNotification({ ...base, urgent: true }, mockFetch);
+  expect(JSON.parse(body!)).toEqual({ text: "build is down", urgent: true });
+
+  await sendWebVoiceNotification(base, mockFetch);
+  expect(JSON.parse(body!)).toEqual({ text: "build is down" });
+});
+
+test("a quiet-hours defer is distinct from a park and from a zero delivery", async () => {
+  // Regression: an ops escalation deferred into the morning briefing used to be
+  // reported as "no voice client is connected", which reads as lost.
+  const responder = (payload: unknown) => (async () => Response.json(payload)) as typeof fetch;
+  const base = { scheme: "https" as const, port: 8090, token: "secret", text: "fork sync stalled" };
+
+  expect(await sendWebVoiceNotification(base, responder({ delivered: 0, deferred: true })))
+    .toEqual({ delivered: 0, parked: false, deferred: true });
+  expect(await sendWebVoiceNotification(base, responder({ delivered: 0, parked: true })))
+    .toEqual({ delivered: 0, parked: true, deferred: false });
+  await expect(sendWebVoiceNotification(base, responder({ delivered: 0, deferred: "yes" })))
+    .rejects.toThrow(/invalid delivery result/);
 });
 
 test("notify rejects character and encoded-JSON overflow before fetch", async () => {

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -1136,6 +1136,55 @@ test("onNotified does NOT fire when the daemon defers the notification (quiet ho
   expect(called).toBe(0);
 });
 
+test("a quiet-hours defer reports deferred:true, not a silent zero delivery", async () => {
+  // Regression: the defer used to be indistinguishable from "nobody connected",
+  // so an ops escalation queued for the morning briefing read as undelivered.
+  const base = start({ onNotify: async () => null });
+  const res = await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "fork sync needs a decision" }),
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ delivered: 0, deferred: true });
+});
+
+test("POST /api/notify forwards urgent:true so an alert can skip quiet hours", async () => {
+  const seen: Array<boolean | undefined> = [];
+  const base = start({
+    onNotify: async (_text, _voice, opts) => { seen.push(opts?.urgent); return wav(5); },
+  });
+  await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "build is down", urgent: true }),
+  });
+  expect(seen).toEqual([true]);
+});
+
+test("POST /api/notify defaults urgent to false so quiet hours still apply", async () => {
+  const seen: Array<boolean | undefined> = [];
+  const base = start({
+    onNotify: async (_text, _voice, opts) => { seen.push(opts?.urgent); return wav(5); },
+  });
+  await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "routine news" }),
+  });
+  expect(seen).toEqual([false]);
+});
+
+test("POST /api/notify rejects a non-boolean urgent", async () => {
+  const base = start({ onNotify: async () => wav(5) });
+  const res = await fetch(base + "/api/notify", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "hi", urgent: "yes" }),
+  });
+  expect(res.status).toBe(400);
+});
+
 test("a throwing onNotified hook does not fail the delivery", async () => {
   const base = start({
     onNotify: async () => wav(5),

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -1565,6 +1565,29 @@ test("handle.notify() forwards telegramMirror to onNotify (the morning-briefing 
   expect(seen).toEqual([false, undefined]);
 });
 
+test("handle.notify() reports a quiet-hours defer to in-process callers too", async () => {
+  // The kanban watcher and other in-process callers go through handle.notify()
+  // rather than the HTTP route; a defer must be distinguishable there as well,
+  // not just for the CLI.
+  start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async () => null, // daemon signals quiet-hours deferral
+  });
+  expect(await handle!.notify("fork sync needs a decision"))
+    .toEqual({ delivered: 0, parked: false, deferred: true });
+});
+
+test("handle.notify() forwards urgent so an in-process alert can skip quiet hours", async () => {
+  const seen: Array<boolean | undefined> = [];
+  start({
+    onStreamTurn: async () => { /* unused */ },
+    onNotify: async (_text, _voice, opts) => { seen.push(opts?.urgent); return wav(1); },
+  });
+  await handle!.notify("build is down", undefined, { urgent: true });
+  await handle!.notify("routine news");
+  expect(seen).toEqual([true, undefined]);
+});
+
 test("/api/say renders text to WAV without broadcasting; 501/400 guarded", async () => {
   let notified = 0;
   let said = 0;


### PR DESCRIPTION
## What went wrong

The `audiocpp-fork-sync.sh` cron escalated a real failure every night for 12 days and it never registered as an alert.

The cron runs at 05:15 UTC = **01:15 ET**, inside the configured quiet hours (`23:30`–`08:30`). The daemon's quiet-hours branch enqueues the text for the morning briefing and returns `null`, which `dispatchNotify` converts to `{delivered: 0, parked: false}` — byte-identical to "nobody was listening and it wasn't parked". The CLI then printed:

```
[cicero] notify rendered, but no voice client is connected right now.
```

which reads as *lost*. It wasn't lost — it went out inside the 08:30 briefing digest (`briefing-status.json`: `"deferredCount": 14`), one line among fourteen. A hard ops failure was indistinguishable from routine news.

## Two gaps

**1. No HTTP/CLI caller could ever mark a notification urgent.** `urgent` exists in the internal contract and is what the kanban watcher uses to skip the quiet-hours defer, but `POST /api/notify` parsed only `{text, voice}`. So the one mechanism designed for "this needs a human now" was unreachable from cron, CI, or any external integration.

**2. A defer was indistinguishable from a drop.** Same `{delivered: 0, parked: false}` for both.

## Changes

- `POST /api/notify` accepts an optional boolean `urgent`, rejecting a non-boolean with 400. Defaults to `false` — ordinary notifications keep respecting quiet hours.
- `cicero notify --urgent` sets it.
- `dispatchNotify` marks a quiet-hours defer `deferred: true`; the route returns it; the CLI reports it as queued for the next morning briefing and points at `--urgent`.
- A daemon predating the field omits it, which parses as "not deferred" — matching how that daemon actually behaved.

Deliberately **not** changed: quiet hours still apply by default, and nothing is auto-escalated. Whether a given alert is worth a 1am ping stays the caller's decision.

## Verification

- `bun run typecheck` clean, `git diff --check` clean.
- Full `bun test`: **2035 pass / 3 fail / 1 error**, against a main baseline of **2029 pass / 3 fail / 1 error** — six new tests, zero new failures. The 3 failures (`tests/cli/status.test.ts`, `tests/terminal-send-errors.test.ts`) reproduce on clean `main` at c87e45b and are unrelated.
- New coverage: defer reports `deferred:true`; `urgent:true` reaches `onNotify`; omitted `urgent` defaults false; non-boolean `urgent` 400s; CLI sends `urgent` only when asked; defer/park/delivered stay distinct.

Not live-verified against the running daemon — the flag reaches the box on deploy.