### PR TITLE
fix(gitignore): ignore a symlinked node_modules, not just a real directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
-node_modules/
+# No trailing slash: a `dir/` pattern matches directories only, so a
+# node_modules symlinked at a shared install (a common git-worktree setup)
+# stays untracked-but-visible and can be swept into a commit by `git add -A`.
+node_modules
 dist/
 .env
 .env.*


### PR DESCRIPTION
## Problem

`.gitignore` had `node_modules/`. A trailing-slash pattern matches **directories only**, so pointing a worktree's `node_modules` at a shared install — a normal way to avoid N copies of the dependency tree across git worktrees — leaves the symlink untracked but visible, and `git add -A` sweeps it into the commit.

This happened on this repo today and had to be amended out of a commit.

## Fix

Drop the trailing slash. One line, plus a comment recording why it must stay off.

## Verification

Reproduced and confirmed both directions, in a real worktree:

```
# BEFORE — pattern `node_modules/`, node_modules is a symlink
$ git status --short
?? node_modules                    <- visible to `git add -A`
$ git check-ignore -v node_modules
(no output — NOT ignored)

# AFTER — pattern `node_modules`
$ git check-ignore -v node_modules
.gitignore:5:node_modules   node_modules      <- symlink ignored

# regression check: a real directory must still be ignored
$ git check-ignore -v node_modules            # now a real dir again
.gitignore:5:node_modules   node_modules      <- still ignored
```

No tracked file becomes newly ignored:

```
$ git ls-files | git check-ignore --stdin --no-index
(empty)
```

`git diff --check` clean. No source or test files touched, so the test suite is unaffected.

## Scope

Left the other `dir/` patterns (`dist/`, `.venv/`, `.claude/`, …) unchanged. I checked every existing worktree on this machine and none of them symlink those — `node_modules` is the only one symlinked in practice, and keeping the diff to the case that actually bit avoids broadening ignore rules speculatively.