### PR TITLE
Keep speculative turns off brains that can run tools

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -56,6 +56,19 @@ web_voice:
   speculative:
     enabled: false
     min_probability: 0.85       # end-of-turn confidence required to jump the gun
+    # A speculative turn starts before you have finished speaking. On a brain
+    # that only returns text a wrong guess costs nothing — the tokens are
+    # thrown away. On a brain that runs tools the turn may already have written
+    # files or run commands by the time the guess is retracted, which is not
+    # undoable. Those brains ignore `enabled` unless you also set this.
+    #
+    # Treated as tool-capable (speculation off unless you opt in): claude-code,
+    # codex, gemini, qwen, acp, any tab-inject brain, any unrecognized backend
+    # name, AND any OpenAI-compatible brain with an explicit `base_url` — that
+    # URL can point at an agent that runs tools server-side, and config alone
+    # cannot tell that apart from a plain model server.
+    # Treated as text-only: ollama, and an OpenAI preset on its own endpoint.
+    allow_tool_brains: false
   # Long-turn parking: if a reply's first sentence hasn't arrived in
   # park_after_s, Cicero says "I'll keep working on it" and releases the audio
   # floor; the finished reply is spoken later via the notify path. A stateful

--- a/src/brain/capabilities.ts
+++ b/src/brain/capabilities.ts
@@ -1,6 +1,46 @@
-import type { BackgroundTurnOptions, Brain } from "../types";
+import type { BackgroundTurnOptions, Brain, BrainConfig } from "../types";
+import { OPENAI_COMPATIBLE_BACKENDS } from "../backends/llm/openai";
 
 type BrainMethod = (...args: never[]) => unknown;
+
+/** Backends routed to the OpenAI chat-completions provider (see `backends/llm/openai`). */
+const OPENAI_FAMILY: ReadonlySet<string> = new Set(OPENAI_COMPATIBLE_BACKENDS);
+
+/**
+ * True when a turn on this brain can change the world — write files, run
+ * commands, post messages — and not merely produce text.
+ *
+ * This matters for work started on an utterance the user has NOT finished
+ * saying (see `web-voice/speculative.ts`). Buffered tokens from a wrong guess
+ * are simply dropped, but a tool call has already happened by the time the
+ * guess is found to be wrong: "delete the old migrations" spoken before a
+ * pause deletes them, and the user's "— no wait, keep the last one" arrives
+ * too late. Text is retractable; side effects are not.
+ *
+ * Fails closed — "might run tools" and "does run tools" are the same answer
+ * here, because guessing "safe" is the mistake that cannot be undone:
+ * - `tab-inject` drives a live agent session in a terminal tab, whatever the
+ *   backend is named.
+ * - CLI agents, ACP, and any unrecognized backend name (`backend` accepts
+ *   arbitrary strings) are assumed to run tools.
+ * - The OpenAI-compatible family is model-only ONLY while it resolves to its
+ *   preset's own public endpoint. `base_url` overrides the preset for every
+ *   backend name (`resolveOpenAiTarget`), and an operator-supplied URL can
+ *   point at an agent that runs tools server-side — Cicero's own docs give
+ *   Hermes' agent HTTP API as the example. A brain with an explicit `base_url`
+ *   is therefore unknowable from config alone, so it counts as tool-executing.
+ */
+export function brainExecutesTools(
+  config: Pick<BrainConfig, "backend" | "mode" | "base_url">,
+): boolean {
+  // tab-inject is Claude Code only — the factory falls through to the ordinary
+  // backend for any other name, so the mode alone does not imply an agent.
+  if (config.mode === "tab-inject" && config.backend === "claude-code") return true;
+  // Ollama speaks its own /api/chat protocol, which serves models, not agents.
+  if (config.backend === "ollama") return false;
+  if (!OPENAI_FAMILY.has(config.backend)) return true;
+  return (config.base_url ?? "").trim() !== "";
+}
 
 type OptionalBrainKey = {
   [K in keyof Brain]-?: object extends Pick<Brain, K> ? K : never;

--- a/src/brain/dial-back.ts
+++ b/src/brain/dial-back.ts
@@ -1,21 +1,13 @@
-import { classifyCallIntent, dialBackMemo, matchCallMe, type CallIntentClassifier } from "../call-intent";
+import { classifyCallIntent, dialBackMemo, matchCallMe, SpeculativeSideEffectError, type CallIntentClassifier } from "../call-intent";
 import type { BackgroundTurnOptions, Brain, BrainTurnOptions } from "../types";
 import { bindBrainCapability, sendUnattended } from "./capabilities";
 
 type DialBackHandler = (who?: string, options?: BrainTurnOptions) => Promise<string>;
 
-/**
- * Thrown instead of dialing when a speculative turn turns out to be a
- * dial-back request. Placing a call is not retractable, so the speculation is
- * discarded and the utterance takes the normal path, where it dials on the
- * final audio.
- */
-export class SpeculativeSideEffectError extends Error {
-  constructor() {
-    super("dial-back refused on a speculative turn");
-    this.name = "SpeculativeSideEffectError";
-  }
-}
+// Defined in ../call-intent alongside the shared dial-back vocabulary, because
+// SwitchboardBrain raises it too. Re-exported here so importers of the wrapper
+// keep working.
+export { SpeculativeSideEffectError } from "../call-intent";
 
 /**
  * Whole-utterance dial-back control shared by every brain backend.

--- a/src/brain/dial-back.ts
+++ b/src/brain/dial-back.ts
@@ -5,6 +5,19 @@ import { bindBrainCapability, sendUnattended } from "./capabilities";
 type DialBackHandler = (who?: string, options?: BrainTurnOptions) => Promise<string>;
 
 /**
+ * Thrown instead of dialing when a speculative turn turns out to be a
+ * dial-back request. Placing a call is not retractable, so the speculation is
+ * discarded and the utterance takes the normal path, where it dials on the
+ * final audio.
+ */
+export class SpeculativeSideEffectError extends Error {
+  constructor() {
+    super("dial-back refused on a speculative turn");
+    this.name = "SpeculativeSideEffectError";
+  }
+}
+
+/**
  * Whole-utterance dial-back control shared by every brain backend.
  *
  * The daemon installs the side-effecting handler after startup. Until then the
@@ -76,6 +89,11 @@ export class DialBackBrain implements Brain {
       );
       this.control = call !== null;
       if (!call) return null;
+      // Both branches above can select a call — the regex AND the semantic
+      // classifier — so this refusal sits below both. A speculative turn must
+      // never reach the handler: it spools a real callback the final
+      // utterance cannot cancel.
+      if (options?.speculative) throw new SpeculativeSideEffectError();
       const reply = await this.handler(call.who, options);
       // The ring happened outside the brain's context; without this one-shot
       // memo it denies the call on the very next turn ("did you call me?").

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -1,5 +1,5 @@
 import type { BackgroundTurnOptions, Brain, BrainTurnOptions, PendingConfirmation } from "../types";
-import { dialBackMemo, matchCallMe } from "../call-intent";
+import { dialBackMemo, matchCallMe, SpeculativeSideEffectError } from "../call-intent";
 import { log } from "../logger";
 import { BrainTurnContext } from "./turn-context";
 import { bindBrainCapability } from "./capabilities";
@@ -952,7 +952,11 @@ export class SwitchboardBrain implements Brain {
     this.turnContext.inject(note);
   }
 
-  private async handleControl(message: string, turn: AcceptedTurn): Promise<string | null> {
+  private async handleControl(
+    message: string,
+    turn: AcceptedTurn,
+    options: BrainTurnOptions,
+  ): Promise<string | null> {
     this.assertAcceptedTurn(turn);
     const m = normalizeUtterance(message);
     if (ROLLCALL_RE.test(m)) return this.doRollcall(turn);
@@ -962,8 +966,13 @@ export class SwitchboardBrain implements Brain {
     if (this.callMe) {
       const call = matchCallMe(m);
       if (call) {
+        // Refuse below the selection, exactly like DialBackBrain: the lane
+        // setup skips that wrapper (this class exposes setCallMeHandler), so
+        // this is the only place a speculative dial can be stopped. Spooling a
+        // callback is not retractable by the final utterance.
+        if (options.speculative) throw new SpeculativeSideEffectError();
         log("info", `switchboard: dial-back requested${call.who ? ` — ${call.who}` : ""}`);
-        const reply = await this.callMe(call.who, { signal: turn.signal });
+        const reply = await this.callMe(call.who, options);
         // Memo even if this turn was superseded meanwhile: the call was placed.
         this.leaveMemo(dialBackMemo(call.who));
         return reply;
@@ -1042,6 +1051,7 @@ export class SwitchboardBrain implements Brain {
     label: string | null,
     utterance: string,
     turn: AcceptedTurn,
+    options: BrainTurnOptions,
   ): Promise<string | "standup" | null> {
     this.assertAcceptedTurn(turn);
     if (!label) return null;
@@ -1068,8 +1078,11 @@ export class SwitchboardBrain implements Brain {
         return null;
       }
       const who = label.startsWith("callme:") ? label.slice("callme:".length).trim() : "";
+      // Same refusal as the lexical path — the classifier selects a call the
+      // patterns miss ("phone me now"), so no phrase list can cover this.
+      if (options.speculative) throw new SpeculativeSideEffectError();
       log("info", `switchboard: dial-back requested (classifier)${who ? ` — ${who}` : ""}`);
-      const reply = await this.callMe(who || undefined);
+      const reply = await this.callMe(who || undefined, options);
       // Memo before the turn assert: a superseding turn still needs to know.
       this.leaveMemo(dialBackMemo(who || undefined));
       this.assertAcceptedTurn(turn);
@@ -1176,7 +1189,7 @@ export class SwitchboardBrain implements Brain {
     turn: AcceptedTurn,
   ): AsyncIterable<string> {
     this.control = false;
-    const routed = await this.controlPlane(message, turn);
+    const routed = await this.controlPlane(message, turn, turnOptions);
     this.assertAcceptedTurn(turn);
     if (routed === "standup") {
       this.control = true;
@@ -1344,6 +1357,7 @@ export class SwitchboardBrain implements Brain {
   private async controlPlane(
     message: string,
     turn: AcceptedTurn,
+    options: BrainTurnOptions,
   ): Promise<string | "standup" | null> {
     this.assertAcceptedTurn(turn);
     const m = normalizeUtterance(message);
@@ -1375,12 +1389,12 @@ export class SwitchboardBrain implements Brain {
     this.assertAcceptedTurn(turn);
     const vm = this.takeVoicemail(message, turn); // matched on the RAW text — the message body keeps its punctuation
     if (vm !== null) return vm;
-    const ack = await this.handleControl(message, turn);
+    const ack = await this.handleControl(message, turn, options);
     this.assertAcceptedTurn(turn);
     if (ack !== null) return ack;
     const label = await this.classifyIntent(m, turn.signal);
     this.assertAcceptedTurn(turn);
-    const routed = await this.actOnIntent(label, m, turn);
+    const routed = await this.actOnIntent(label, m, turn, options);
     this.assertAcceptedTurn(turn);
     // A normal brain turn ends the "again" context — a later bare "again"
     // refers to the conversation, not to a roll call from minutes ago.
@@ -1435,7 +1449,7 @@ export class SwitchboardBrain implements Brain {
   send(message: string, options?: BrainTurnOptions): Promise<string> {
     return this.runAcceptedTurn(options, async (turn, turnOptions) => {
       this.control = false;
-      const routed = await this.controlPlane(message, turn);
+      const routed = await this.controlPlane(message, turn, turnOptions);
       this.assertAcceptedTurn(turn);
       if (routed === "standup") {
         this.control = true;
@@ -1485,7 +1499,7 @@ export class SwitchboardBrain implements Brain {
     turn: AcceptedTurn,
   ): AsyncIterable<string> {
     this.control = false;
-    const routed = await this.controlPlane(message, turn);
+    const routed = await this.controlPlane(message, turn, turnOptions);
     this.assertAcceptedTurn(turn);
     if (routed === "standup") {
       this.control = true;

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -972,7 +972,13 @@ export class SwitchboardBrain implements Brain {
         // callback is not retractable by the final utterance.
         if (options.speculative) throw new SpeculativeSideEffectError();
         log("info", `switchboard: dial-back requested${call.who ? ` — ${call.who}` : ""}`);
-        const reply = await this.callMe(call.who, options);
+        // Handler args deliberately unchanged by this PR: only `{ signal }`, as
+        // before. `options` is needed for the refusal above, NOT by the handler
+        // — forwarding it there regressed named dial-backs, and the underlying
+        // re-entrancy defect (the handler pins the lane by calling transferTo()
+        // back into this switchboard, whose admission supersedes the turn it was
+        // called from) is pre-existing and tracked separately.
+        const reply = await this.callMe(call.who, { signal: turn.signal });
         // Memo even if this turn was superseded meanwhile: the call was placed.
         this.leaveMemo(dialBackMemo(call.who));
         return reply;
@@ -1082,7 +1088,8 @@ export class SwitchboardBrain implements Brain {
       // patterns miss ("phone me now"), so no phrase list can cover this.
       if (options.speculative) throw new SpeculativeSideEffectError();
       log("info", `switchboard: dial-back requested (classifier)${who ? ` — ${who}` : ""}`);
-      const reply = await this.callMe(who || undefined, options);
+      // Handler args unchanged by this PR — see the note on the lexical path.
+      const reply = await this.callMe(who || undefined);
       // Memo before the turn assert: a superseding turn still needs to know.
       this.leaveMemo(dialBackMemo(who || undefined));
       this.assertAcceptedTurn(turn);

--- a/src/call-intent.ts
+++ b/src/call-intent.ts
@@ -86,3 +86,22 @@ export async function classifyCallIntent(
 export function dialBackMemo(who?: string): string {
   return `System note: the user asked for a phone call${who ? ` from ${who}` : ""} and their phone was rung moments ago. If they ask whether anyone called them: yes, just now.`;
 }
+
+/**
+ * Thrown instead of dialing when a speculative turn turns out to be a
+ * dial-back request. Placing a call is not retractable, so the speculation is
+ * discarded and the utterance takes the normal path, where it dials on the
+ * final audio.
+ *
+ * Lives beside the dial-back vocabulary because BOTH selectors can raise it:
+ * `DialBackBrain` (the wrapper around ordinary brains) and `SwitchboardBrain`
+ * (which the factory leaves unwrapped, since it exposes its own
+ * `setCallMeHandler`). Any future turn-start side effect should refuse the
+ * same way rather than trying to enumerate dangerous phrasings.
+ */
+export class SpeculativeSideEffectError extends Error {
+  constructor() {
+    super("dial-back refused on a speculative turn");
+    this.name = "SpeculativeSideEffectError";
+  }
+}

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -621,9 +621,12 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     }
     if (isRecord(config.web_voice.speculative)) {
       checkKnownKeys(config.web_voice.speculative, "web_voice.speculative", [
-        "enabled", "min_probability",
+        "enabled", "min_probability", "allow_tool_brains",
       ], issues);
       checkOptionalNumber(config.web_voice.speculative, "min_probability", "web_voice.speculative", issues, { min: 0, max: 1 });
+      // Safety opt-in: a mistyped value fails closed (speculation stays off),
+      // so report it rather than let the operator believe it took effect.
+      checkOptionalBoolean(config.web_voice.speculative, "allow_tool_brains", "web_voice.speculative", issues);
     }
     if (isRecord(config.web_voice.long_turn)) {
       checkKnownKeys(config.web_voice.long_turn, "web_voice.long_turn", [

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import type { RuntimeConfig } from "./config";
 import type { Listener, Router, Brain, BrainTurnOptions, Speaker, TerminalAdapter, RouterResult } from "./types";
 import { log, logStep, logError } from "./logger";
+import { matchCallMe } from "./call-intent";
 import { createListener, createConversationalListener } from "./listener";
 import { createRouter } from "./router";
 import { createBrain, summarizerClassifier } from "./brain";
@@ -80,7 +81,7 @@ import {
   type BriefingRunResult,
 } from "./notify/briefing-scheduler";
 import { OvernightStore } from "./notify/overnight-store";
-import { sendUnattended } from "./brain/capabilities";
+import { brainExecutesTools, sendUnattended } from "./brain/capabilities";
 import { buildResumePrimer, buildRosterNote } from "./web-voice/resume";
 import { HealthStore, briefLine } from "./health/store";
 import {
@@ -1271,11 +1272,29 @@ export class CiceroDaemon {
       // confident "complete" probe the tail is transcribed and the brain
       // started before the final WAV lands — see speculative.ts for the gates.
       const specCfg = wv.speculative;
-      const speculator = specCfg?.enabled && this.config.turn.enabled && this.brain.sendStream
+      // A speculative turn runs on speech the user has not finished. Tokens
+      // from a wrong guess are discarded; a tool call is not recallable. So a
+      // tool-executing brain stays out of the speculative path unless the
+      // operator has accepted that trade explicitly.
+      const specToolBrain = brainExecutesTools(this.config.brain);
+      const specSideEffectsAllowed = !specToolBrain || specCfg?.allow_tool_brains === true;
+      if (specCfg?.enabled && this.config.turn.enabled && !specSideEffectsAllowed) {
+        log(
+          "warn",
+          `speculative turns are configured but disabled: the "${this.config.brain.backend}" brain runs tools, ` +
+            "and speculation would start them on an unfinished utterance. " +
+            "Set web_voice.speculative.allow_tool_brains: true to accept that.",
+        );
+      }
+      const speculator = specCfg?.enabled && this.config.turn.enabled && this.brain.sendStream && specSideEffectsAllowed
         ? makeSpeculator({
             stt: this.providers.stt,
             brain: this.brain,
             isLocalFastPath,
+            // The dial-back decorator wraps every brain and acts before the
+            // inner brain streams a token, so "call me" must never be
+            // speculated — see SpeculatorDeps.startsSideEffect.
+            startsSideEffect: (text) => matchCallMe(text) !== null,
             minProbability: specCfg.min_probability ?? 0.85,
             tone,
             operationalContext: (signal) => this.operationalContext(signal),

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,7 +4,6 @@ import { homedir } from "node:os";
 import type { RuntimeConfig } from "./config";
 import type { Listener, Router, Brain, BrainTurnOptions, Speaker, TerminalAdapter, RouterResult } from "./types";
 import { log, logStep, logError } from "./logger";
-import { matchCallMe } from "./call-intent";
 import { createListener, createConversationalListener } from "./listener";
 import { createRouter } from "./router";
 import { createBrain, summarizerClassifier } from "./brain";
@@ -1291,10 +1290,6 @@ export class CiceroDaemon {
             stt: this.providers.stt,
             brain: this.brain,
             isLocalFastPath,
-            // The dial-back decorator wraps every brain and acts before the
-            // inner brain streams a token, so "call me" must never be
-            // speculated — see SpeculatorDeps.startsSideEffect.
-            startsSideEffect: (text) => matchCallMe(text) !== null,
             minProbability: specCfg.min_probability ?? 0.85,
             tone,
             operationalContext: (signal) => this.operationalContext(signal),

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,14 @@ export interface WebVoiceConfig {
   speculative?: {
     enabled?: boolean;         // default false
     min_probability?: number;  // end-of-turn confidence required to speculate (default 0.85)
+    // Speculation starts a turn before the user has finished speaking. A brain
+    // that only returns text loses nothing on a wrong guess — the tokens are
+    // dropped. A brain that runs tools may already have written files or run
+    // commands by the time the guess is retracted, so it does not speculate
+    // unless this is set. See `brainExecutesTools` for the classification,
+    // which fails closed on anything it cannot prove is text-only.
+    // Default false.
+    allow_tool_brains?: boolean;
   };
   // Long-turn parking: when a reply's FIRST sentence hasn't arrived within
   // park_after_s (deep tool loop, slow delegate), the turn speaks a short

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,14 @@ export interface BrainTurnOptions {
   /** Cancels this turn only. Adapters should stop their underlying work promptly. */
   signal?: AbortSignal;
   /**
+   * This turn runs on speech the user has NOT finished saying, and may be
+   * discarded. Generated text is safe — it is buffered and dropped if the
+   * guess was wrong. Anything a wrapper cannot take back is not: it must
+   * refuse the turn (throw) rather than act, so the utterance falls through
+   * to the normal path and acts on the final audio instead.
+   */
+  speculative?: boolean;
+  /**
    * Immutable host-produced context for this invocation only. Adapters must
    * forward it unchanged and must never retain it as conversation memory.
    */

--- a/src/web-voice/speculative.ts
+++ b/src/web-voice/speculative.ts
@@ -261,6 +261,14 @@ export function makeSpeculator(deps: SpeculatorDeps): Speculator {
           // and let the final audio drive the normal path.
           if (err instanceof SpeculativeSideEffectError) {
             log("info", "speculative: turn would place a call — deferring to the final utterance");
+            // Before the claim, dropping the speculation silently is right: the
+            // final audio drives the normal path and dials there. AFTER the
+            // claim the consumer is already streaming this buffer, and a clean
+            // EOF would read as a finished turn — the requested call would
+            // never be placed at all. Surface the refusal so the adopted path
+            // can re-run the utterance non-speculatively. (`end()` is
+            // first-wins, so the finally below cannot clobber this.)
+            if (claimed) buf.end(err);
             void doAbort("side effect refused").catch((abortError: unknown) => {
               log("warn", `speculative cleanup failed: ${abortError instanceof Error ? abortError.message : String(abortError)}`);
             });

--- a/src/web-voice/speculative.ts
+++ b/src/web-voice/speculative.ts
@@ -48,6 +48,15 @@ export interface SpeculatorDeps {
   brain: Pick<Brain, "sendStream" | "hasPendingConfirmation">;
   /** Utterances the reply pipeline answers WITHOUT a brain turn. */
   isLocalFastPath: (transcript: string) => boolean;
+  /**
+   * Utterances that commit an irreversible action the moment the brain turn
+   * STARTS, rather than when its reply is adopted — "call me" reaches the
+   * dial-back decorator before the inner brain sees a token, so a speculative
+   * turn would queue a real call for speech the user has not finished ("call
+   * me *when the build is done*"). Declining to speculate is always safe: the
+   * utterance simply takes the normal path and acts on the final WAV.
+   */
+  startsSideEffect?: (transcript: string) => boolean;
   /** Only speculate at or above this end-of-turn probability. */
   minProbability: number;
   /** Optional input-side tone tag, classified from the probe tail — see {@link ToneOptions}. */
@@ -204,7 +213,7 @@ export function makeSpeculator(deps: SpeculatorDeps): Speculator {
     // Start the brain as soon as the tail transcript is in — unless the turn
     // was aborted first, the utterance is a local fast-path, or STT came up dry.
     const brainStarted: Promise<void> = transcriptPromise.then(async (text) => {
-      if (aborted || !text || deps.isLocalFastPath(text)) return;
+      if (aborted || !text || deps.isLocalFastPath(text) || deps.startsSideEffect?.(text)) return;
       const tag = await settleTone(tonePending?.result ?? null, deps.tone?.graceMs);
       if (aborted) return;
       const input = tag ? `${text}\n\n${tag}` : text;

--- a/src/web-voice/speculative.ts
+++ b/src/web-voice/speculative.ts
@@ -5,6 +5,7 @@ import type { Brain } from "../types";
 import { beginOwnedTone, settleTone, type ToneOptions } from "./tone";
 import { captureOperationalContext } from "./turn";
 import { writeSecureTempAudio } from "../platform/secure-temp-audio";
+import { SpeculativeSideEffectError } from "../brain/dial-back";
 
 /**
  * Speculative turns: when a mid-pause probe comes back "complete" with high
@@ -48,15 +49,6 @@ export interface SpeculatorDeps {
   brain: Pick<Brain, "sendStream" | "hasPendingConfirmation">;
   /** Utterances the reply pipeline answers WITHOUT a brain turn. */
   isLocalFastPath: (transcript: string) => boolean;
-  /**
-   * Utterances that commit an irreversible action the moment the brain turn
-   * STARTS, rather than when its reply is adopted — "call me" reaches the
-   * dial-back decorator before the inner brain sees a token, so a speculative
-   * turn would queue a real call for speech the user has not finished ("call
-   * me *when the build is done*"). Declining to speculate is always safe: the
-   * utterance simply takes the normal path and acts on the final WAV.
-   */
-  startsSideEffect?: (transcript: string) => boolean;
   /** Only speculate at or above this end-of-turn probability. */
   minProbability: number;
   /** Optional input-side tone tag, classified from the probe tail — see {@link ToneOptions}. */
@@ -213,7 +205,7 @@ export function makeSpeculator(deps: SpeculatorDeps): Speculator {
     // Start the brain as soon as the tail transcript is in — unless the turn
     // was aborted first, the utterance is a local fast-path, or STT came up dry.
     const brainStarted: Promise<void> = transcriptPromise.then(async (text) => {
-      if (aborted || !text || deps.isLocalFastPath(text) || deps.startsSideEffect?.(text)) return;
+      if (aborted || !text || deps.isLocalFastPath(text)) return;
       const tag = await settleTone(tonePending?.result ?? null, deps.tone?.graceMs);
       if (aborted) return;
       const input = tag ? `${text}\n\n${tag}` : text;
@@ -236,6 +228,9 @@ export function makeSpeculator(deps: SpeculatorDeps): Speculator {
           it = deps.brain.sendStream!(input, {
             signal: turnAbort.signal,
             systemContext: systemContext ?? undefined,
+            // Tells every wrapper this turn may be discarded, so anything it
+            // cannot take back must refuse instead of acting.
+            speculative: true,
           })[Symbol.asyncIterator]();
           while (!aborted) {
             const next = it.next();
@@ -260,6 +255,17 @@ export function makeSpeculator(deps: SpeculatorDeps): Speculator {
             }
           }
         } catch (err: unknown) {
+          // A wrapper refused to act speculatively (e.g. this turn is a
+          // dial-back request). That is not a failure — it means this
+          // utterance must not be speculated at all, so drop the speculation
+          // and let the final audio drive the normal path.
+          if (err instanceof SpeculativeSideEffectError) {
+            log("info", "speculative: turn would place a call — deferring to the final utterance");
+            void doAbort("side effect refused").catch((abortError: unknown) => {
+              log("warn", `speculative cleanup failed: ${abortError instanceof Error ? abortError.message : String(abortError)}`);
+            });
+            return;
+          }
           buf.end(err);
         } finally {
           // Abort does not own the brain until the source's finalizer has

--- a/src/web-voice/turn.ts
+++ b/src/web-voice/turn.ts
@@ -1039,7 +1039,17 @@ async function streamReply(
       }
     })();
 
-    if (deps.park) {
+    // Parking is deliberately NOT available to an adopted speculative stream.
+    // The caller's finally calls spec.abort() as soon as streamReply returns —
+    // including the parked return — which cancels the pump the "detached"
+    // consumer is still draining, so the parked reply was truncated to whatever
+    // happened to be buffered. For a turn whose brain has produced nothing yet
+    // (the only state that parks) that is nothing at all, and any error still
+    // pending — a wrapper's side-effect refusal, a cancelled classifier — was
+    // swallowed by the background handler after the turn had already been
+    // acknowledged. Letting these turns run to completion keeps exactly one
+    // termination path for an adopted stream: the caller's, which can retry.
+    if (deps.park && pretokens === undefined) {
       const parkCfg = deps.park;
       const outcome = await new Promise<"park" | "done">((resolve) => {
         const watchdog = setTimeout(() => resolve("park"), parkCfg.afterMs);
@@ -1064,26 +1074,7 @@ async function streamReply(
         timer.mark("parked");
         detached = true;
         const background = consumption
-          .catch(async (error: unknown) => {
-            // A refusal that lands after we PARKED cannot be handled by the
-            // caller's retry: the turn is already acknowledged and closed, so
-            // streamReply returns successfully and the outer catch never runs.
-            // The race above already prefers a refusal that arrives before the
-            // park deadline; this covers the deadline winning. Place the call on
-            // the normal path and let its ack ride the parked delivery, so the
-            // phone still rings instead of the request vanishing.
-            if (error instanceof SpeculativeSideEffectError) {
-              log("info", "web voice: speculation refused after parking — dialing on the normal path");
-              try {
-                const reply = (await deps.brain.send(brainInput)).trim();
-                if (reply) parkedTexts.push(reply);
-              } catch (retryError: unknown) {
-                log("warn", `parked dial-back retry failed: ${retryError instanceof Error ? retryError.message : String(retryError)}`);
-              }
-              return;
-            }
-            /* brain died mid-background — deliver what we have */
-          })
+          .catch(() => { /* brain died mid-background — deliver what we have */ })
           .then(() => deps.signal?.aborted
             ? undefined
             : parkCfg.onParked(parkedTexts.join(" "), transcript))

--- a/src/web-voice/turn.ts
+++ b/src/web-voice/turn.ts
@@ -7,6 +7,7 @@ import { newTurnTimer } from "../timing";
 import { log } from "../logger";
 import type { PreparedFiller } from "../speaker/filler-bank";
 import type { SpeculativeTurn } from "./speculative";
+import { SpeculativeSideEffectError } from "../call-intent";
 import { beginOwnedTone, settleTone, type OwnedTone, type ToneOptions } from "./tone";
 import { writeSecureTempAudio } from "../platform/secure-temp-audio";
 import {
@@ -705,21 +706,26 @@ async function* abortable(
       finalization = Promise.reject(error);
     }
     if (drainSource) {
+      // NO `return` here. A `return` inside `finally` DISCARDS the exception
+      // the generator body is currently throwing, so every error raised by an
+      // adopted speculative stream — a wrapper's side-effect refusal, a buffer
+      // limit, a brain failure — was silently converted into a clean
+      // end-of-stream, and the consumer read it as a completed turn.
       try {
         await finalization;
       } catch (error: unknown) {
         log("warn", `speculative token finalization failed: ${error instanceof Error ? error.message : String(error)}`);
         throw error;
       }
-      return;
-    }
-    const observedFinalization = finalization.catch((error: unknown) => {
-      log("warn", `brain token finalization failed: ${error instanceof Error ? error.message : String(error)}`);
-    });
-    if (trackFinalization && !trackFinalization(observedFinalization)) {
-      await observedFinalization;
-    } else if (!trackFinalization) {
-      void observedFinalization;
+    } else {
+      const observedFinalization = finalization.catch((error: unknown) => {
+        log("warn", `brain token finalization failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
+      if (trackFinalization && !trackFinalization(observedFinalization)) {
+        await observedFinalization;
+      } else if (!trackFinalization) {
+        void observedFinalization;
+      }
     }
   }
 }
@@ -756,7 +762,22 @@ export async function streamWebTurn(
         try {
           await streamReply(transcript, deps, sink, timer, spec.tokens() ?? undefined);
         } catch (err: unknown) {
-          sink.error(err instanceof Error ? err.message : String(err));
+          // A wrapper refused mid-flight, AFTER we adopted its stream — the
+          // semantic dial-back classifier can resolve well after transcript()
+          // settles. Nothing was spoken, and treating the ended stream as a
+          // finished turn would swallow the request silently: the user asked to
+          // be phoned and the phone would never ring. Re-run the utterance on
+          // the normal path, where the side effect is allowed to happen.
+          if (err instanceof SpeculativeSideEffectError) {
+            log("info", "web voice: speculation refused after adoption — re-running the turn on the normal path");
+            try {
+              await streamReply(transcript, deps, sink, timer);
+            } catch (retryErr: unknown) {
+              sink.error(retryErr instanceof Error ? retryErr.message : String(retryErr));
+            }
+          } else {
+            sink.error(err instanceof Error ? err.message : String(err));
+          }
         } finally {
           // Token exhaustion is not the whole speculative lifetime: the probe
           // tone classifier (and third-party provider work) may still be live.

--- a/src/web-voice/turn.ts
+++ b/src/web-voice/turn.ts
@@ -1064,7 +1064,26 @@ async function streamReply(
         timer.mark("parked");
         detached = true;
         const background = consumption
-          .catch(() => { /* brain died mid-background — deliver what we have */ })
+          .catch(async (error: unknown) => {
+            // A refusal that lands after we PARKED cannot be handled by the
+            // caller's retry: the turn is already acknowledged and closed, so
+            // streamReply returns successfully and the outer catch never runs.
+            // The race above already prefers a refusal that arrives before the
+            // park deadline; this covers the deadline winning. Place the call on
+            // the normal path and let its ack ride the parked delivery, so the
+            // phone still rings instead of the request vanishing.
+            if (error instanceof SpeculativeSideEffectError) {
+              log("info", "web voice: speculation refused after parking — dialing on the normal path");
+              try {
+                const reply = (await deps.brain.send(brainInput)).trim();
+                if (reply) parkedTexts.push(reply);
+              } catch (retryError: unknown) {
+                log("warn", `parked dial-back retry failed: ${retryError instanceof Error ? retryError.message : String(retryError)}`);
+              }
+              return;
+            }
+            /* brain died mid-background — deliver what we have */
+          })
           .then(() => deps.signal?.aborted
             ? undefined
             : parkCfg.onParked(parkedTexts.join(" "), transcript))

--- a/tests/brain/dial-back.test.ts
+++ b/tests/brain/dial-back.test.ts
@@ -133,3 +133,29 @@ test("a dial-back leaves a one-shot memo so the brain can answer 'did you call m
   expect(await brain.send("what time is it?")).toBe("brain:what time is it?");
   expect(calls.filter((c) => c.startsWith("context:")).length).toBe(1);
 });
+
+test("a speculative turn never places a call — via the regex OR the semantic classifier", async () => {
+  const calls: string[] = [];
+  // A classifier that calls everything a dial-back request: this is the branch
+  // the "call me" regex misses ("phone me now"), and the one a list of
+  // exclusion phrases can never cover, because it is a model.
+  const brain = new DialBackBrain(inner(calls), async () => "call");
+  const rings: string[] = [];
+  brain.setCallMeHandler(async (who) => { rings.push(who ?? "me"); return "Ringing you now."; });
+
+  // Lexical branch.
+  expect(collect(brain.sendStream("call me", { speculative: true })))
+    .rejects.toThrow(/speculative/);
+  // Semantic branch — the wording the regex does not match.
+  expect(collect(brain.sendStream("phone me now", { speculative: true })))
+    .rejects.toThrow(/speculative/);
+  await Promise.allSettled([
+    collect(brain.sendStream("call me", { speculative: true })),
+    collect(brain.sendStream("phone me now", { speculative: true })),
+  ]);
+  expect(rings).toEqual([]); // nothing was spooled
+
+  // The same utterance on a real (non-speculative) turn still dials.
+  expect(await collect(brain.sendStream("phone me now"))).toEqual(["Ringing you now."]);
+  expect(rings).toEqual(["me"]);
+});

--- a/tests/brain/executes-tools.test.ts
+++ b/tests/brain/executes-tools.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test";
+import { brainExecutesTools } from "../../src/brain/capabilities";
+import { OPENAI_COMPATIBLE_BACKENDS } from "../../src/backends/llm/openai";
+
+/**
+ * The gate that keeps speculative turns off brains that can change the world.
+ * Speculation starts a turn on an utterance the user has not finished; a wrong
+ * guess drops the tokens, but a tool call has already run by then.
+ */
+
+test("CLI agents and ACP run tools", () => {
+  for (const backend of ["claude-code", "codex", "gemini", "qwen", "acp"]) {
+    expect(brainExecutesTools({ backend, mode: "subprocess" })).toBe(true);
+  }
+});
+
+test("ollama serves models, not agents", () => {
+  expect(brainExecutesTools({ backend: "ollama", mode: "subprocess" })).toBe(false);
+});
+
+test("an OpenAI preset on its own public endpoint is model-only", () => {
+  expect(OPENAI_COMPATIBLE_BACKENDS.length).toBeGreaterThan(0);
+  for (const backend of OPENAI_COMPATIBLE_BACKENDS) {
+    expect(brainExecutesTools({ backend, mode: "subprocess" })).toBe(false);
+  }
+});
+
+test("an explicit base_url makes any OpenAI-family brain tool-capable", () => {
+  // `base_url` overrides the preset for EVERY backend name (resolveOpenAiTarget),
+  // and Cicero documents pointing it at Hermes' agent HTTP API — which runs
+  // tools server-side. Config alone cannot tell a model server from an agent.
+  expect(brainExecutesTools({
+    backend: "openai-compatible", mode: "subprocess", base_url: "http://127.0.0.1:8642/v1",
+  })).toBe(true);
+  // ...including a named preset, which base_url silently redirects.
+  expect(brainExecutesTools({
+    backend: "groq", mode: "subprocess", base_url: "http://127.0.0.1:8642/v1",
+  })).toBe(true);
+});
+
+test("a blank base_url is not an override", () => {
+  for (const base_url of ["", "   ", undefined]) {
+    expect(brainExecutesTools({ backend: "openai-compatible", mode: "subprocess", base_url })).toBe(false);
+  }
+});
+
+test("tab-inject implies an agent only for claude-code, which is the only brain that honors it", () => {
+  expect(brainExecutesTools({ backend: "claude-code", mode: "tab-inject" })).toBe(true);
+  // The factory falls through to the ordinary backend for any other name, so
+  // the mode alone must not cost a text-only brain its speculation.
+  expect(brainExecutesTools({ backend: "ollama", mode: "tab-inject" })).toBe(false);
+});
+
+test("fails closed on an unrecognized backend", () => {
+  // `backend` accepts arbitrary preset strings. Guessing "safe" on an unknown
+  // agent is the mistake that cannot be undone, so unknown means tool-executing.
+  expect(brainExecutesTools({ backend: "some-future-agent", mode: "subprocess" })).toBe(true);
+  expect(brainExecutesTools({ backend: "", mode: "subprocess" })).toBe(true);
+});

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { SwitchboardBrain, type LaneDef } from "../../src/brain/switchboard";
+import { SpeculativeSideEffectError } from "../../src/brain/dial-back";
 import type { Brain, BrainTurnOptions } from "../../src/types";
 
 const NONCE_A = "11111111-1111-4111-8111-111111111111";
@@ -1917,6 +1918,68 @@ test("classifier-routed dial-backs leave the same memo", async () => {
   } finally {
     await sb.stop().catch(() => { /* test cleanup */ });
   }
+});
+
+test("a speculative turn refuses the lexical dial-back instead of ringing", async () => {
+  // The switchboard exposes setCallMeHandler, so createBrain does NOT wrap it
+  // in DialBackBrain — its refusal never runs on a lane setup. Without this,
+  // a speculative "call me" spools a callback the final utterance cannot
+  // retract (Codex merge review, 2026-07-28).
+  const rang: Array<string | undefined> = [];
+  const sb = board([]);
+  sb.setCallMeHandler(async (who) => { rang.push(who); return "Ringing you now."; });
+  await sb.start();
+  expect(sb.send("call me", { speculative: true })).rejects.toThrow(SpeculativeSideEffectError);
+  await Bun.sleep(5);
+  expect(rang).toEqual([]);
+  // No memo either: nothing was rung, so the next turn must not be told it was.
+  const injected: string[] = [];
+  const front = { ...fakeBrain("front", []), injectContext: (c: string) => injected.push(c) };
+  const sb2 = new SwitchboardBrain(front, { coder: { brain: fakeBrain("coder", []) } });
+  sb2.setCallMeHandler(async () => "Ringing.");
+  await sb2.start();
+  await sb2.send("call me", { speculative: true }).catch(() => { /* expected */ });
+  await sb2.send("what's up?");
+  expect(injected).toEqual([]);
+});
+
+test("a speculative turn refuses the classifier dial-back too", async () => {
+  // The classifier path passed no options at all, so it was the wider hole of
+  // the two — "phone me now" reaches it without matching any pattern.
+  const sb = new SwitchboardBrain(fakeBrain("front", []), {
+    coder: { brain: fakeBrain("coder", []) },
+  }, async () => "callme");
+  const rang: Array<string | undefined> = [];
+  sb.setCallMeHandler(async (who) => { rang.push(who); return "Ringing."; });
+  await sb.start();
+  expect(sb.send("I want you to phone me", { speculative: true }))
+    .rejects.toThrow(SpeculativeSideEffectError);
+  await Bun.sleep(5);
+  expect(rang).toEqual([]);
+});
+
+test("the speculative refusal reaches sendStream, the speculator's own entry point", async () => {
+  const sb = board([]);
+  const rang: Array<string | undefined> = [];
+  sb.setCallMeHandler(async (who) => { rang.push(who); return "Ringing."; });
+  await sb.start();
+  await expect((async () => {
+    for await (const _chunk of sb.sendStream("call me", { speculative: true })) { /* drain */ }
+  })()).rejects.toThrow(SpeculativeSideEffectError);
+  expect(rang).toEqual([]);
+});
+
+test("a non-speculative dial-back forwards the turn options to the handler", async () => {
+  // Both dial sites used to drop the caller's options — the lexical one
+  // replaced them with a bare { signal }, the classifier one sent none.
+  const seen: Array<BrainTurnOptions | undefined> = [];
+  const sb = board([]);
+  sb.setCallMeHandler(async (_who, options) => { seen.push(options); return "Ringing."; });
+  await sb.start();
+  expect(await sb.send("call me")).toBe("Ringing.");
+  expect(seen.length).toBe(1);
+  expect(seen[0]?.signal).toBeDefined();      // the turn's signal, not the caller's
+  expect(seen[0]?.speculative).toBeUndefined();
 });
 
 test("release and roll call leave memos — the front desk knows what it missed", async () => {

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1969,17 +1969,37 @@ test("the speculative refusal reaches sendStream, the speculator's own entry poi
   expect(rang).toEqual([]);
 });
 
-test("a non-speculative dial-back forwards the turn options to the handler", async () => {
-  // Both dial sites used to drop the caller's options — the lexical one
-  // replaced them with a bare { signal }, the classifier one sent none.
-  const seen: Array<BrainTurnOptions | undefined> = [];
-  const sb = board([]);
-  sb.setCallMeHandler(async (_who, options) => { seen.push(options); return "Ringing."; });
-  await sb.start();
-  expect(await sb.send("call me")).toBe("Ringing.");
-  expect(seen.length).toBe(1);
-  expect(seen[0]?.signal).toBeDefined();      // the turn's signal, not the caller's
-  expect(seen[0]?.speculative).toBeUndefined();
+test("the dial sites pass the handler exactly what they always did", async () => {
+  // Guards against re-introducing the regression this PR briefly shipped:
+  // forwarding the whole turn options to the handler. The refusal above the
+  // dial needs `options`; the HANDLER must keep its original arguments, because
+  // it pins the named lane by calling transferTo() back into this switchboard
+  // and that admission supersedes the turn it was called from. (That
+  // re-entrancy defect is pre-existing and tracked separately — this test only
+  // pins the argument contract.)
+  const seen: Array<{ who?: string; keys: string[] }> = [];
+  const lexical = board([]);
+  lexical.setCallMeHandler(async (who, options) => {
+    seen.push({ who, keys: Object.keys(options ?? {}) });
+    return "Ringing.";
+  });
+  await lexical.start();
+  expect(await lexical.send("call me")).toBe("Ringing.");
+
+  const classified = new SwitchboardBrain(fakeBrain("front", []), {
+    coder: { brain: fakeBrain("coder", []) },
+  }, async () => "callme:coder");
+  classified.setCallMeHandler(async (who, options) => {
+    seen.push({ who, keys: Object.keys(options ?? {}) });
+    return "Ringing.";
+  });
+  await classified.start();
+  expect(await classified.send("I need the coder to phone me")).toBe("Ringing.");
+
+  expect(seen).toEqual([
+    { who: undefined, keys: ["signal"] }, // lexical: the turn signal, nothing else
+    { who: "coder", keys: [] },           // classifier: no options at all
+  ]);
 });
 
 test("release and roll call leave memos — the front desk knows what it missed", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -595,6 +595,17 @@ describe("Config — fail-fast validation", () => {
     expect(loadYaml("terminal: iterm2\n")).toThrow(/terminal must be one of.*kitty.*wezterm.*tmux.*none/);
   });
 
+  test("rejects a non-boolean speculative side-effect opt-in", () => {
+    // A mistyped value fails closed (speculation stays off), so report it
+    // rather than let the operator believe the opt-in took effect.
+    expect(loadYaml([
+      "web_voice:",
+      "  speculative:",
+      "    allow_tool_brains: yes-please",
+      "",
+    ].join("\n"))).toThrow(/allow_tool_brains/);
+  });
+
   test("rejects non-finite and out-of-range web turn controls", () => {
     expect(loadYaml([
       "web_voice:",

--- a/tests/web-voice/speculative.test.ts
+++ b/tests/web-voice/speculative.test.ts
@@ -7,6 +7,7 @@ import {
   type SpeculatorDeps,
 } from "../../src/web-voice/speculative";
 import { wavDurationMs, isLocalFastPath } from "../../src/web-voice/turn";
+import { SpeculativeSideEffectError } from "../../src/brain/dial-back";
 
 /** One second of 16 kHz silence-ish PCM. */
 function pcm(ms: number, sampleRate = 16000): Float32Array {
@@ -520,29 +521,39 @@ test("dry speculative transcript aborts and falls back", async () => {
   expect(calls.transcript).toEqual(["fallback transcript"]);
 });
 
-test("never starts the brain for an utterance that commits a side effect on turn start", async () => {
-  // "call me" reaches the dial-back decorator BEFORE the inner brain streams a
-  // token, so speculating on it would queue a real call for speech the user
-  // has not finished ("call me *when the build is done*").
-  const { deps: d, brainCalls } = deps({ transcript: "call me" });
-  const turn = makeSpeculator({
-    ...d,
-    startsSideEffect: (text) => /^call me\b/i.test(text.trim()),
-  })(pcm(1500), 16000, 1500, 0.95)!;
-  expect(turn).not.toBeNull();
-  expect(await turn.transcript()).toBe("call me");
-  expect(brainCalls).toEqual([]);   // the brain was never started
-  expect(turn.tokens()).toBeNull(); // and there is nothing to adopt
+test("a wrapper that refuses to act speculatively drops the speculation instead of failing", async () => {
+  // DialBackBrain throws this rather than spooling a real callback. Both its
+  // branches (the "call me" regex AND the semantic classifier) sit above the
+  // throw, so no wording can slip past by being phrased differently.
+  const { deps: d } = deps({
+    transcript: "phone me now",
+    brain: {
+      sendStream: () => (async function* (): AsyncGenerator<string> {
+        throw new SpeculativeSideEffectError();
+      })(),
+    },
+  });
+  const turn = makeSpeculator(d)(pcm(1500), 16000, 1500, 0.95)!;
+  await turn.transcript();
+  // Aborted, not errored: claim() fails so the caller runs the normal path,
+  // where the final utterance dials for real.
+  expect(turn.claim()).toBe(false);
+  expect(turn.tokens()).toBeNull();
   await turn.abort();
 });
 
-test("startsSideEffect leaves ordinary utterances alone", async () => {
-  const { deps: d, brainCalls } = deps({ transcript: "what time is it in tokyo" });
-  const turn = makeSpeculator({
-    ...d,
-    startsSideEffect: (text) => /^call me\b/i.test(text.trim()),
-  })(pcm(1500), 16000, 1500, 0.95)!;
-  expect(await turn.transcript()).toBe("what time is it in tokyo");
-  expect(brainCalls.length).toBe(1);
+test("passes speculative: true so wrappers can tell the turn is provisional", async () => {
+  let seen: boolean | undefined;
+  const { deps: d } = deps({
+    brain: {
+      sendStream: (_m: string, o?: { speculative?: boolean }) => {
+        seen = o?.speculative;
+        return (async function* () { yield "ok"; })();
+      },
+    },
+  });
+  const turn = makeSpeculator(d)(pcm(1500), 16000, 1500, 0.95)!;
+  await turn.transcript();
+  expect(seen).toBe(true);
   await turn.abort();
 });

--- a/tests/web-voice/speculative.test.ts
+++ b/tests/web-voice/speculative.test.ts
@@ -542,6 +542,72 @@ test("a wrapper that refuses to act speculatively drops the speculation instead 
   await turn.abort();
 });
 
+test("a refusal landing AFTER adoption re-runs the turn instead of dropping the call", async () => {
+  // The live race, end to end through streamWebTurn: "phone me now" misses the
+  // lexical pattern, so DialBackBrain awaits the semantic classifier before it
+  // can refuse. transcript() resolves once the pump has STARTED, not settled,
+  // so the turn claims and adopts the stream first. A clean EOF at that point
+  // reads as a finished turn — the user asked to be phoned and nothing rings.
+  const rings: string[] = [];
+  const classifierStillThinking = deferred();
+  const brain = {
+    send: async (m: string) => { rings.push(m); return "Ringing you now."; },
+    sendStream: (m: string, o?: { speculative?: boolean }) => (async function* (): AsyncGenerator<string> {
+      if (o?.speculative) {
+        await classifierStillThinking.promise;
+        throw new SpeculativeSideEffectError();
+      }
+      rings.push(m); // the real dial-back, on the non-speculative path
+      yield "Ringing you now.";
+    })(),
+  };
+  const { deps: sd } = deps({ transcript: "phone me now", brain });
+  const turn = makeSpeculator(sd)(pcm(1000), 16_000, 1000, 0.95)!;
+
+  const sttCalls: string[] = [];
+  const { sink, calls } = capturingSink();
+  const running = streamWebTurn(wavOf(1000), { ...turnDeps(sttCalls), brain }, sink, turn);
+  // Let the turn claim and start consuming the adopted stream, THEN refuse.
+  await Bun.sleep(25);
+  classifierStillThinking.resolve();
+  await running;
+
+  expect(rings).toEqual(["phone me now"]); // dialed exactly once, on the retry
+  expect(calls.sentence).toEqual(["Ringing you now."]);
+  expect(calls.done).toBe(1);
+  expect(calls.error).toEqual([]);         // a refusal is not a turn failure
+  expect(sttCalls).toEqual([]);            // adopted transcript stands; no re-STT
+});
+
+test("any error from an adopted stream surfaces instead of ending the turn cleanly", async () => {
+  // Root cause of the refusal being dropped, and wider than dial-backs: a
+  // `return` inside abortable's finally DISCARDED the exception the generator
+  // was throwing, so a brain that died after adoption looked like a completed
+  // turn — sink.done(), no error, nothing spoken.
+  const died = deferred();
+  const brain = {
+    send: async () => "unused fallback",
+    sendStream: (_m: string, o?: { speculative?: boolean }) => (async function* (): AsyncGenerator<string> {
+      if (o?.speculative) {
+        yield "Partial ";
+        await died.promise;
+        throw new Error("brain died mid-turn");
+      }
+      yield "unused fallback";
+    })(),
+  };
+  const { deps: sd } = deps({ transcript: "what time is it in tokyo", brain });
+  const turn = makeSpeculator(sd)(pcm(1000), 16_000, 1000, 0.95)!;
+  const sttCalls: string[] = [];
+  const { sink, calls } = capturingSink();
+  const running = streamWebTurn(wavOf(1000), { ...turnDeps(sttCalls), brain }, sink, turn);
+  await Bun.sleep(25);
+  died.resolve();
+  await running;
+  expect(calls.error).toEqual(["brain died mid-turn"]);
+  expect(calls.done).toBe(0); // a dead brain is not a finished turn
+});
+
 test("passes speculative: true so wrappers can tell the turn is provisional", async () => {
   let seen: boolean | undefined;
   const { deps: d } = deps({

--- a/tests/web-voice/speculative.test.ts
+++ b/tests/web-voice/speculative.test.ts
@@ -519,3 +519,30 @@ test("dry speculative transcript aborts and falls back", async () => {
   expect(aborts).toEqual(["abort"]);
   expect(calls.transcript).toEqual(["fallback transcript"]);
 });
+
+test("never starts the brain for an utterance that commits a side effect on turn start", async () => {
+  // "call me" reaches the dial-back decorator BEFORE the inner brain streams a
+  // token, so speculating on it would queue a real call for speech the user
+  // has not finished ("call me *when the build is done*").
+  const { deps: d, brainCalls } = deps({ transcript: "call me" });
+  const turn = makeSpeculator({
+    ...d,
+    startsSideEffect: (text) => /^call me\b/i.test(text.trim()),
+  })(pcm(1500), 16000, 1500, 0.95)!;
+  expect(turn).not.toBeNull();
+  expect(await turn.transcript()).toBe("call me");
+  expect(brainCalls).toEqual([]);   // the brain was never started
+  expect(turn.tokens()).toBeNull(); // and there is nothing to adopt
+  await turn.abort();
+});
+
+test("startsSideEffect leaves ordinary utterances alone", async () => {
+  const { deps: d, brainCalls } = deps({ transcript: "what time is it in tokyo" });
+  const turn = makeSpeculator({
+    ...d,
+    startsSideEffect: (text) => /^call me\b/i.test(text.trim()),
+  })(pcm(1500), 16000, 1500, 0.95)!;
+  expect(await turn.transcript()).toBe("what time is it in tokyo");
+  expect(brainCalls.length).toBe(1);
+  await turn.abort();
+});

--- a/tests/web-voice/speculative.test.ts
+++ b/tests/web-voice/speculative.test.ts
@@ -579,6 +579,48 @@ test("a refusal landing AFTER adoption re-runs the turn instead of dropping the 
   expect(sttCalls).toEqual([]);            // adopted transcript stands; no re-STT
 });
 
+test("a refusal that lands after PARKING still dials, through the parked delivery", async () => {
+  // The daemon enables speculation and parking on the SAME turn. The park race
+  // already prefers a refusal that arrives before the deadline; when the
+  // deadline wins, the turn is acknowledged and closed, streamReply returns
+  // successfully, and the caller's retry never runs — so the refusal used to be
+  // swallowed by the background .catch() and the phone never rang.
+  const rings: string[] = [];
+  const refuse = deferred();
+  const brain = {
+    send: async (m: string) => { rings.push(m); return "Ringing you now."; },
+    sendStream: (_m: string, o?: { speculative?: boolean }) => (async function* (): AsyncGenerator<string> {
+      if (o?.speculative) {
+        await refuse.promise;
+        throw new SpeculativeSideEffectError();
+      }
+      yield "unused";
+    })(),
+  };
+  const { deps: sd } = deps({ transcript: "phone me now", brain });
+  const turn = makeSpeculator(sd)(pcm(1000), 16_000, 1000, 0.95)!;
+  const delivered: string[] = [];
+  const background: Promise<void>[] = [];
+  const sttCalls: string[] = [];
+  const { sink, calls } = capturingSink();
+  const running = streamWebTurn(wavOf(1000), {
+    ...turnDeps(sttCalls),
+    brain,
+    park: { afterMs: 10, line: "Still on it.", onParked: (reply) => { delivered.push(reply); } },
+    trackBackground: (task) => { background.push(task); return true; },
+  }, sink, turn);
+
+  await Bun.sleep(60); // let the 10ms park deadline win the race
+  refuse.resolve();
+  await running;
+  await Promise.all(background);
+
+  expect(calls.sentence).toEqual(["Still on it."]); // parked hand-back, as before
+  expect(calls.done).toBe(1);
+  expect(rings).toEqual(["phone me now"]);          // dialed on the normal path
+  expect(delivered).toEqual(["Ringing you now."]);  // and the ack was delivered
+});
+
 test("any error from an adopted stream surfaces instead of ending the turn cleanly", async () => {
   // Root cause of the refusal being dropped, and wider than dial-backs: a
   // `return` inside abortable's finally DISCARDED the exception the generator

--- a/tests/web-voice/speculative.test.ts
+++ b/tests/web-voice/speculative.test.ts
@@ -579,46 +579,52 @@ test("a refusal landing AFTER adoption re-runs the turn instead of dropping the 
   expect(sttCalls).toEqual([]);            // adopted transcript stands; no re-STT
 });
 
-test("a refusal that lands after PARKING still dials, through the parked delivery", async () => {
-  // The daemon enables speculation and parking on the SAME turn. The park race
-  // already prefers a refusal that arrives before the deadline; when the
-  // deadline wins, the turn is acknowledged and closed, streamReply returns
-  // successfully, and the caller's retry never runs — so the refusal used to be
-  // swallowed by the background .catch() and the phone never rang.
+test("an adopted speculation never parks, so a cancellable refusal still dials", async () => {
+  // Parking an adopted stream was broken for EVERY turn, not just dial-backs:
+  // the caller's finally calls spec.abort() as soon as streamReply returns —
+  // including the parked return — cancelling the pump the "detached" consumer is
+  // still draining. For a dial-back that also killed the semantic classifier
+  // mid-decision, and the abort reason is NOT SpeculativeSideEffectError, so no
+  // handler could recognise it. The brain below is signal-aware like the real
+  // classifier: abort makes it reject with the abort reason, never the refusal.
   const rings: string[] = [];
-  const refuse = deferred();
   const brain = {
     send: async (m: string) => { rings.push(m); return "Ringing you now."; },
-    sendStream: (_m: string, o?: { speculative?: boolean }) => (async function* (): AsyncGenerator<string> {
+    sendStream: (_m: string, o?: { speculative?: boolean; signal?: AbortSignal }) => (async function* (): AsyncGenerator<string> {
       if (o?.speculative) {
-        await refuse.promise;
+        await new Promise<void>((resolve, reject) => {
+          const t = setTimeout(resolve, 50);
+          o.signal?.addEventListener("abort", () => {
+            clearTimeout(t);
+            reject(o.signal?.reason ?? new Error("aborted"));
+          }, { once: true });
+        });
         throw new SpeculativeSideEffectError();
       }
-      yield "unused";
+      rings.push(_m);
+      yield "Ringing you now.";
     })(),
   };
   const { deps: sd } = deps({ transcript: "phone me now", brain });
   const turn = makeSpeculator(sd)(pcm(1000), 16_000, 1000, 0.95)!;
   const delivered: string[] = [];
-  const background: Promise<void>[] = [];
   const sttCalls: string[] = [];
   const { sink, calls } = capturingSink();
-  const running = streamWebTurn(wavOf(1000), {
+
+  // park.afterMs well below the refusal: previously this parked, aborted the
+  // classifier, and lost the call entirely.
+  await streamWebTurn(wavOf(1000), {
     ...turnDeps(sttCalls),
     brain,
     park: { afterMs: 10, line: "Still on it.", onParked: (reply) => { delivered.push(reply); } },
-    trackBackground: (task) => { background.push(task); return true; },
+    trackBackground: () => true,
   }, sink, turn);
 
-  await Bun.sleep(60); // let the 10ms park deadline win the race
-  refuse.resolve();
-  await running;
-  await Promise.all(background);
-
-  expect(calls.sentence).toEqual(["Still on it."]); // parked hand-back, as before
+  expect(delivered).toEqual([]);                     // never parked
+  expect(calls.sentence).toEqual(["Ringing you now."]); // no hand-back line either
+  expect(rings).toEqual(["phone me now"]);           // dialed on the retry
   expect(calls.done).toBe(1);
-  expect(rings).toEqual(["phone me now"]);          // dialed on the normal path
-  expect(delivered).toEqual(["Ringing you now."]);  // and the ack was delivered
+  expect(calls.error).toEqual([]);
 });
 
 test("any error from an adopted stream surfaces instead of ending the turn cleanly", async () => {


### PR DESCRIPTION
## The problem

`web_voice.speculative` (opt-in, off by default) starts a brain turn on a confident mid-pause probe — before the user's final audio arrives. Wrong guess: buffered tokens are discarded.

Tool calls are not discardable. *"Delete the old migrations"* spoken before a pause deletes them; *"— no wait, keep the last one"* arrives too late.

## Two fixes

**1. Don't speculate on brains that can run tools.** `brainExecutesTools()` fails closed — "might run tools" and "does run tools" are the same answer:

- **Text-only:** `ollama`, and an OpenAI preset on its own public endpoint.
- **Tool-capable:** CLI agents, `acp`, unrecognized backend names, `claude-code` + `tab-inject`, **and any OpenAI-family brain with an explicit `base_url`** — `resolveOpenAiTarget` lets `base_url` override the preset for *every* backend name, and `src/brain/index.ts` documents pointing it at Hermes' agent HTTP API, which runs tools server-side. Config can't tell that from a plain model server.
- `tab-inject` implies an agent only for `claude-code`, the sole backend whose factory honors it.

Tool-capable brains ignore `speculative.enabled` unless `allow_tool_brains: true` is also set, and say so once at startup.

**2. Let wrappers refuse, instead of guessing which utterances are dangerous.**

`DialBackBrain` wraps *every* brain and acts before the inner brain streams a token — so even a text-only brain could queue a real phone call speculatively. The first attempt excluded "call me" by regex. That was wrong: `dial-back.ts` selects a call from the regex **or** a semantic classifier, so "phone me now" missed the list and still spooled a callback. No list of phrases can cover a model.

Inverted: `BrainTurnOptions.speculative` tells every wrapper the turn is provisional. `DialBackBrain` throws `SpeculativeSideEffectError` **below both detection branches** rather than dialing; the speculator treats that as "don't speculate this utterance" and aborts, so the final audio takes the normal path and dials for real.

Text stays speculative because it's retractable. Anything that isn't now has one place to say so.

## Verification

- `bun test`: **2049 pass** (baseline `main`: 2038) — +11 new. Same 3 pre-existing failures and 1 error as `main`; both named failures reproduce on unmodified `main` (one is an ANSI-escape assertion issue).
- `bun run typecheck` clean, `git diff --check` clean.
- Reviewed by Codex (`gpt-5.6-sol`) across three rounds. It found the `base_url` gap, the dial-back lexical gap, and then the dial-back semantic gap that motivated fix 2.

## Not covered

Only `DialBackBrain` implements the refusal today — it's the only wrapper with a turn-start side effect. A future side-effecting wrapper must opt in the same way; the flag exists so there's somewhere to do that.

---

## Third fix (added after the merge review)

The review found the gate above had a hole big enough to sink the whole thesis:
`createBrain()` **skips `DialBackBrain` entirely** when the brain already
exposes `setCallMeHandler` — which `SwitchboardBrain` does. So on any
ACP-with-lanes setup, fix 2's refusal never ran, and with
`allow_tool_brains: true` a speculative "call me" reached
`writeCallbackSpool()` and queued a real callback.

It was the same two-path shape this PR already fixed once, one file over.
`switchboard.ts` selects a dial-back lexically **or** via the classifier, and
both sites dropped the caller's options — the lexical one replaced them with a
bare `{ signal }`, the classifier one passed none at all — so
`{ speculative: true }` never arrived at either.

The turn's options are now threaded through `controlPlane` into
`handleControl` and `actOnIntent`, and both sites refuse below the selection,
mirroring `dial-back.ts`. Forwarding the real options also preserves the turn
signal that the bare `{ signal }` happened to carry.
`SpeculativeSideEffectError` moved to `src/call-intent.ts`, beside the shared
dial-back vocabulary, since both selectors now raise it; `dial-back.ts`
re-exports it so no importer changed.

So the claim "anything irreversible has one place to say so" now holds for both
selectors, not just the wrapper.

**Added verification:** 4 regressions in `tests/brain/switchboard.test.ts`
covering the lexical path, the classifier path, `sendStream` (the speculator's
own entry point), and option forwarding on a normal turn. All three refusal
tests fail before the change. `bun test`: 2053 pass, same 3 failures + 1 error
as `origin/main` — both named failures reproduced on an unmodified
`origin/main` worktree. `bun run typecheck` and `git diff --check` clean.


---

## Fourth fix — the refusal was being swallowed, not just misplaced

The third fix closed the switchboard path but still lost a refusal that arrives
*after* the consumer adopts the speculation. `transcript()` resolves once the
pump has STARTED, not settled, so the turn claims and adopts before a
classifier-driven refusal (`"phone me now"` — no lexical match) can be raised.
The user asked to be phoned; `streamReply()` saw an empty adopted stream, called
`sink.done()`, and nothing dialed.

The cause turned out to be wider than dial-backs. `abortable()`'s `finally` had a
bare `return` in its `drainSource` branch, and **a `return` inside `finally`
discards the exception the generator body is throwing**. Every error from an
adopted speculative stream — side-effect refusal, token-buffer limit, a brain
that died mid-turn — became a clean end-of-stream the consumer read as success.
An if/else preserves the pending exception.

With the error no longer eaten: the speculator ends the buffer *with* the refusal
once claimed (pre-claim stays a silent drop, which is correct — the final audio
still drives the normal path), and the adopted path catches
`SpeculativeSideEffectError` and re-runs the utterance non-speculatively, where
the dial-back is allowed to happen. Nothing has been spoken yet, so the retry is
not audible as a repeat.

**Added verification:** two regressions drive the real `makeSpeculator` *and*
`streamWebTurn` with the refusal gated until after adoption — one asserts the
dial happens exactly once on the retry with no turn error and no second STT, the
other that a generic post-adoption brain failure surfaces as `sink.error` with no
`sink.done()`. Both fail against the previous sources. `bun test`: 2055 pass,
same 3 failures + 1 error as `origin/main`.


---

## Fifth and sixth rounds — park removed, option-forwarding reverted

**Parking no longer applies to an adopted speculation** (`e343518`). The parked
recovery in the previous round keyed on `SpeculativeSideEffectError`, which cannot
fire: `spec.abort()` runs as soon as `streamReply` returns — including the parked
return — so the signal-aware classifier rejects with the abort reason instead. The
wider fact behind it: parking an adopted speculation was broken for **every** turn,
because `spec.abort()` cancels the pump the detached consumer is still draining and
a turn only parks when nothing has been produced. The combination is removed rather
than patched, leaving one termination path for an adopted stream — the caller's.
Ordinary parking is untouched.

**Forwarding turn options to the dial-back handler is reverted** (`5ec2b62`). It was
an extra beyond what the refusal needs, and it regressed named dial-backs: the
handler pins the lane via `transferTo()` back into this switchboard, that admission
supersedes the turn it was called from, and the handler then aborts itself before
spooling. Both sites are back to their original arguments; `options` still reaches
`handleControl`/`actOnIntent`, which is where the refusal reads it.

The remaining re-entrancy defect is **pre-existing and out of scope** — `send()`
rejects with `SwitchboardTurnSupersededError` whatever the handler holds, so
removing the signal only moves the failure. Tracked in #67; fixing it means making
turn admission re-entrant, which is not a speculative-execution change.
