### PR TITLE
fix(vendor): point the audio.cpp submodule at the maintained fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/audio.cpp"]
 	path = vendor/audio.cpp
 	url = https://github.com/5uck1ess/audio.cpp-fork
-	branch = main
+	branch = cicero-integration

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/audio.cpp"]
 	path = vendor/audio.cpp
-	url = https://github.com/5uck1ess/audio.cpp
+	url = https://github.com/5uck1ess/audio.cpp-fork
 	branch = main

--- a/docs/voice-cloning.md
+++ b/docs/voice-cloning.md
@@ -26,6 +26,17 @@ audio.cpp is vendored as a git submodule (`vendor/audio.cpp`, pinned in
 `.gitmodules`). A fresh clone gets it with `git submodule update --init
 --recursive`; `provision-audiocpp.sh` does that and compiles the CUDA binary.
 
+The provisioner builds with `--deployment-build`, which compiles audio.cpp's
+`model_specs/` catalog into the binary. That matters: a model directory holds
+weights only, so without an embedded catalog the server looks for a spec file on
+disk — under the model directory, its parent's `model_specs/`, and `model_specs/`
+in the ancestors of whatever directory it was started from — and none of those is
+`vendor/audio.cpp/model_specs/`. It then exits with `model contract spec not
+found for family 'pocket_tts'`. **If you build audio.cpp yourself** rather than
+through the provisioner, either pass `--deployment-build` too, or give the server
+`--model-spec-override vendor/audio.cpp/model_specs/pocket_tts.json`. The same
+applies to a server you run on a remote host.
+
 ```json
 // servers/audiocpp_server.local.json (machine-local, untracked)
 {

--- a/scripts/provision-audiocpp.sh
+++ b/scripts/provision-audiocpp.sh
@@ -33,6 +33,26 @@ echo "==> Syncing vendor/audio.cpp submodule to its pinned commit…"
 # clobber `origin` and break the upstream-sync pipeline that reads it.
 if [[ -d "$SUB/.git" ]]; then
   echo "    vendor/audio.cpp is a standalone clone — leaving its remotes untouched."
+  # Leaving the remotes alone is not enough: `submodule update` fetches from
+  # whatever `origin` is, and on this layout `origin` is UPSTREAM, which does not
+  # carry a fork-only pin. Fetch the pinned commit directly BY URL from the one
+  # recorded in .gitmodules — a URL fetch creates and rewrites no remote, so the
+  # upstream-tracking `origin` the sync pipeline reads is preserved.
+  PIN="$(git -C "$ROOT" rev-parse "HEAD:vendor/audio.cpp" 2>/dev/null || true)"
+  URL="$(git -C "$ROOT" config -f "$ROOT/.gitmodules" --get submodule.vendor/audio.cpp.url || true)"
+  if [[ -n "$PIN" && -n "$URL" ]] && ! git -C "$SUB" cat-file -e "$PIN^{commit}" 2>/dev/null; then
+    echo "    pinned $PIN is not present locally — fetching it from $URL"
+    # Fetch the exact commit when the server allows it; otherwise take the
+    # recorded branch (or all refs) and re-check.
+    git -C "$SUB" fetch --quiet "$URL" "$PIN" 2>/dev/null \
+      || git -C "$SUB" fetch --quiet "$URL" \
+           "$(git -C "$ROOT" config -f "$ROOT/.gitmodules" --get submodule.vendor/audio.cpp.branch || echo HEAD)" 2>/dev/null \
+      || git -C "$SUB" fetch --quiet "$URL" || true
+    if ! git -C "$SUB" cat-file -e "$PIN^{commit}" 2>/dev/null; then
+      echo "!! pinned $PIN is not reachable from $URL — cannot provision this checkout." >&2
+      exit 1
+    fi
+  fi
 else
   git -C "$ROOT" submodule sync --recursive vendor/audio.cpp
 fi

--- a/scripts/provision-audiocpp.sh
+++ b/scripts/provision-audiocpp.sh
@@ -17,6 +17,21 @@ FORCE=0
 [[ "${1:-}" == "--force" ]] && FORCE=1
 
 echo "==> Syncing vendor/audio.cpp submodule to its pinned commit…"
+# `update --init` writes .git/config only for a submodule it is initializing for
+# the FIRST time. A checkout that initialized the submodule before its URL
+# changed keeps the old URL and tries to fetch the newly pinned commit from a
+# repo that does not have it, failing before the build. `submodule sync` is the
+# only operation that republishes .gitmodules → .git/config.
+#
+# Skipped when vendor/audio.cpp is a standalone clone — its own .git DIRECTORY
+# rather than a gitlink file. That is the fork-sync development layout, where
+# `origin` deliberately tracks upstream and `fork` tracks ours; sync would
+# clobber `origin` and break the upstream-sync pipeline that reads it.
+if [[ -d "$SUB/.git" ]]; then
+  echo "    vendor/audio.cpp is a standalone clone — leaving its remotes untouched."
+else
+  git -C "$ROOT" submodule sync --recursive vendor/audio.cpp
+fi
 git -C "$ROOT" submodule update --init --recursive vendor/audio.cpp
 
 if [[ -x "$BIN" && "$FORCE" -eq 0 ]]; then

--- a/scripts/provision-audiocpp.sh
+++ b/scripts/provision-audiocpp.sh
@@ -14,9 +14,25 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUB="$ROOT/vendor/audio.cpp"
 BUILD_DIR="$SUB/build/linux-cuda-release"
 BIN="$BUILD_DIR/bin/audiocpp_server"
-# Which source commit produced $BIN. Lives inside the (git-ignored) build tree,
-# so it is discarded exactly when the build output is.
+# How $BIN was produced: source commit on line 1, build options on line 2. Lives
+# inside the (git-ignored) build tree, so it is discarded exactly when the build
+# output is. Both halves matter — see BUILD_ARGS.
 STAMP="$BUILD_DIR/.built-from-commit"
+
+# `--deployment-build` compiles the model_specs catalog INTO the binary. Without
+# it audio.cpp resolves a family's spec from disk at load time, searching the
+# model directory, its parent's model_specs/, and model_specs/ under the CWD's
+# ancestors — none of which is where a Cicero checkout keeps the file
+# (vendor/audio.cpp/model_specs/). The documented setup installs a model without
+# a spec file (the fork's model manager fetches weights only), and Cicero launches
+# the server without a CWD or --model-spec-override, so a non-deployment build
+# throws "model contract spec not found for family 'pocket_tts'" and exits 1
+# before serving. Embedding the catalog makes a provisioned binary self-contained
+# instead of dependent on where it happens to be started from.
+BUILD_ARGS=(--backend cuda --deployment-build --target audiocpp_cli --target audiocpp_server)
+# Recorded next to the commit because the same source can build either a binary
+# that resolves specs or one that cannot; only the option set separates them.
+BUILD_ID="${BUILD_ARGS[*]}"
 FORCE=0
 [[ "${1:-}" == "--force" ]] && FORCE=1
 
@@ -63,10 +79,14 @@ git -C "$ROOT" submodule update --init --recursive vendor/audio.cpp
 # keep running the previously built revision — including past the security and
 # stability fixes the new pin was chosen for. Compare commits, not presence.
 SRC_COMMIT="$(git -C "$SUB" rev-parse HEAD 2>/dev/null || true)"
-BUILT_COMMIT="$(cat "$STAMP" 2>/dev/null || true)"
+BUILT_COMMIT=""
+BUILT_BUILD_ID=""
+if [[ -f "$STAMP" ]]; then
+  { IFS= read -r BUILT_COMMIT || true; IFS= read -r BUILT_BUILD_ID || true; } < "$STAMP"
+fi
 
 if [[ -x "$BIN" && "$FORCE" -eq 0 ]]; then
-  if [[ -n "$SRC_COMMIT" && "$BUILT_COMMIT" == "$SRC_COMMIT" ]]; then
+  if [[ -n "$SRC_COMMIT" && "$BUILT_COMMIT" == "$SRC_COMMIT" && "$BUILT_BUILD_ID" == "$BUILD_ID" ]]; then
     echo "==> Already built at $SRC_COMMIT: $BIN"
     echo "    (re-run with --force to rebuild)"
     exit 0
@@ -77,8 +97,13 @@ if [[ -x "$BIN" && "$FORCE" -eq 0 ]]; then
     echo "==> Cannot determine the source commit of $SUB — rebuilding rather than trusting the existing binary."
   elif [[ -z "$BUILT_COMMIT" ]]; then
     echo "==> $BIN exists but records no source commit — rebuilding so it matches $SRC_COMMIT."
-  else
+  elif [[ "$BUILT_COMMIT" != "$SRC_COMMIT" ]]; then
     echo "==> $BIN was built from $BUILT_COMMIT, but the checkout is now $SRC_COMMIT — rebuilding."
+  else
+    # Same commit, different options. A binary from before --deployment-build
+    # carries no embedded specs and cannot start the documented TTS seat, so
+    # matching the commit alone is not enough to trust it.
+    echo "==> $BIN was built at $SRC_COMMIT with different options — rebuilding for: $BUILD_ID"
   fi
 fi
 
@@ -92,12 +117,12 @@ echo "==> Building audio.cpp (CUDA) — compiles the ggml CUDA kernels, takes se
 # current directory, so it must be invoked with $SUB as CWD. Also run it via
 # bash — git records it as mode 0644 (no exec bit), so a clean submodule
 # checkout can't execute it directly.
-( cd "$SUB" && bash scripts/build_linux.sh --backend cuda --target audiocpp_cli --target audiocpp_server )
+( cd "$SUB" && bash scripts/build_linux.sh "${BUILD_ARGS[@]}" )
 
 if [[ -x "$BIN" ]]; then
   # Record provenance only after the binary exists, so a failed build cannot
   # leave a stamp that makes the next run skip.
-  if [[ -n "$SRC_COMMIT" ]]; then printf '%s\n' "$SRC_COMMIT" > "$STAMP"; else rm -f "$STAMP"; fi
+  if [[ -n "$SRC_COMMIT" ]]; then printf '%s\n%s\n' "$SRC_COMMIT" "$BUILD_ID" > "$STAMP"; else rm -f "$STAMP"; fi
   echo "==> Built: $BIN"
   echo "    Next: add your model paths to servers/audiocpp_server.local.json"
   echo "    (a task:\"tts\" entry for the TTS seat, a task:\"asr\" entry for STT)."

--- a/scripts/provision-audiocpp.sh
+++ b/scripts/provision-audiocpp.sh
@@ -12,7 +12,11 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUB="$ROOT/vendor/audio.cpp"
-BIN="$SUB/build/linux-cuda-release/bin/audiocpp_server"
+BUILD_DIR="$SUB/build/linux-cuda-release"
+BIN="$BUILD_DIR/bin/audiocpp_server"
+# Which source commit produced $BIN. Lives inside the (git-ignored) build tree,
+# so it is discarded exactly when the build output is.
+STAMP="$BUILD_DIR/.built-from-commit"
 FORCE=0
 [[ "${1:-}" == "--force" ]] && FORCE=1
 
@@ -34,10 +38,28 @@ else
 fi
 git -C "$ROOT" submodule update --init --recursive vendor/audio.cpp
 
+# Checking out a new pin does not rebuild anything: /build*/ is git-ignored, so
+# the old executable survives the update. Skipping on its mere existence would
+# keep running the previously built revision — including past the security and
+# stability fixes the new pin was chosen for. Compare commits, not presence.
+SRC_COMMIT="$(git -C "$SUB" rev-parse HEAD 2>/dev/null || true)"
+BUILT_COMMIT="$(cat "$STAMP" 2>/dev/null || true)"
+
 if [[ -x "$BIN" && "$FORCE" -eq 0 ]]; then
-  echo "==> Already built: $BIN"
-  echo "    (re-run with --force to rebuild)"
-  exit 0
+  if [[ -n "$SRC_COMMIT" && "$BUILT_COMMIT" == "$SRC_COMMIT" ]]; then
+    echo "==> Already built at $SRC_COMMIT: $BIN"
+    echo "    (re-run with --force to rebuild)"
+    exit 0
+  fi
+  # Fail closed: an unknown or mismatched provenance means rebuild. The first
+  # run after this check was introduced has no stamp, so it rebuilds once.
+  if [[ -z "$SRC_COMMIT" ]]; then
+    echo "==> Cannot determine the source commit of $SUB — rebuilding rather than trusting the existing binary."
+  elif [[ -z "$BUILT_COMMIT" ]]; then
+    echo "==> $BIN exists but records no source commit — rebuilding so it matches $SRC_COMMIT."
+  else
+    echo "==> $BIN was built from $BUILT_COMMIT, but the checkout is now $SRC_COMMIT — rebuilding."
+  fi
 fi
 
 if [[ ! -f "$SUB/scripts/build_linux.sh" ]]; then
@@ -53,6 +75,9 @@ echo "==> Building audio.cpp (CUDA) — compiles the ggml CUDA kernels, takes se
 ( cd "$SUB" && bash scripts/build_linux.sh --backend cuda --target audiocpp_cli --target audiocpp_server )
 
 if [[ -x "$BIN" ]]; then
+  # Record provenance only after the binary exists, so a failed build cannot
+  # leave a stamp that makes the next run skip.
+  if [[ -n "$SRC_COMMIT" ]]; then printf '%s\n' "$SRC_COMMIT" > "$STAMP"; else rm -f "$STAMP"; fi
   echo "==> Built: $BIN"
   echo "    Next: add your model paths to servers/audiocpp_server.local.json"
   echo "    (a task:\"tts\" entry for the TTS seat, a task:\"asr\" entry for STT)."

--- a/tests/vendor-submodule-url.test.ts
+++ b/tests/vendor-submodule-url.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -114,6 +114,113 @@ test("the provisioner syncs the submodule URL before updating, and spares standa
   // The dev/fork-sync layout is a standalone clone whose `origin` tracks
   // upstream; syncing it would clobber that remote.
   expect(script).toContain('if [[ -d "$SUB/.git" ]]');
+});
+
+test("the provisioner rebuilds when the pin moves, instead of trusting a stale binary", () => {
+  // `/build*/` is git-ignored, so checking out a new pin leaves the previously
+  // built executable in place. Skipping on mere presence would keep running the
+  // old revision — past the very fixes the new pin was chosen for. Drives the
+  // REAL script against a stub build_linux.sh, so no compiler is needed.
+  const dir = mkdtempSync(join(tmpdir(), "provision-stale-"));
+  const buildLog = join(dir, "build-invocations");
+  const commit = (cwd: string, msg: string) =>
+    git(cwd, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", msg);
+
+  // A "vendor" repo whose build script just fabricates the binary.
+  const depWork = join(dir, "dep-work");
+  git(dir, "init", "-q", depWork);
+  mkdirSync(join(depWork, "scripts"), { recursive: true });
+  writeFileSync(join(depWork, "scripts/build_linux.sh"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    'echo "build $*" >> "${BUILD_LOG:?}"',
+    "mkdir -p build/linux-cuda-release/bin",
+    "printf '#!/bin/sh\\nexit 0\\n' > build/linux-cuda-release/bin/audiocpp_server",
+    "chmod +x build/linux-cuda-release/bin/audiocpp_server",
+  ].join("\n"));
+  git(depWork, "add", "-A");
+  commit(depWork, "vendor at A");
+  const shaA = git(depWork, "rev-parse", "HEAD").out.trim();
+  const depBare = join(dir, "dep.git");
+  git(dir, "clone", "-q", "--bare", depWork, depBare);
+
+  // A superproject holding the real provisioner and that repo as a submodule.
+  const root = join(dir, "root");
+  git(dir, "init", "-q", root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  const realScript = readFileSync(new URL("../scripts/provision-audiocpp.sh", import.meta.url), "utf8");
+  writeFileSync(join(root, "scripts/provision-audiocpp.sh"), realScript, { mode: 0o755 });
+  git(root, "add", "-A");
+  commit(root, "root init");
+  expect(git(root, "-c", "protocol.file.allow=always",
+    "submodule", "add", "-q", depBare, "vendor/audio.cpp").ok).toBe(true);
+  commit(root, "add submodule at A");
+
+  const provision = (): { ok: boolean; out: string } => {
+    const r = Bun.spawnSync(["bash", join(root, "scripts/provision-audiocpp.sh")], {
+      cwd: dir,   // deliberately NOT inside root: the script resolves its own ROOT
+      env: {
+        ...process.env,
+        BUILD_LOG: buildLog,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+        // Let the script's own git calls touch the file:// submodule remote.
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "protocol.file.allow",
+        GIT_CONFIG_VALUE_0: "always",
+        GIT_TERMINAL_PROMPT: "0",
+      },
+    });
+    return { ok: r.exitCode === 0, out: `${r.stdout.toString()}${r.stderr.toString()}` };
+  };
+  const builds = (): number =>
+    (readFileSync(buildLog, "utf8").match(/^build /gm) ?? []).length;
+  const stamp = join(root, "vendor/audio.cpp/build/linux-cuda-release/.built-from-commit");
+
+  // 1. First provision builds and records what it built from.
+  const first = provision();
+  expect(first.ok).toBe(true);
+  expect(builds()).toBe(1);
+  expect(readFileSync(stamp, "utf8").trim()).toBe(shaA);
+
+  // 2. Unchanged pin: skip, no rebuild.
+  const second = provision();
+  expect(second.ok).toBe(true);
+  expect(second.out).toContain(`Already built at ${shaA}`);
+  expect(builds()).toBe(1);
+
+  // 3. Move the pin — the exact shape of repointing at a fixed upstream commit.
+  writeFileSync(join(depWork, "FIX"), "oom hardening\n");
+  git(depWork, "add", "-A");
+  commit(depWork, "vendor at B (the fix the new pin is chosen for)");
+  const shaB = git(depWork, "rev-parse", "HEAD").out.trim();
+  git(depWork, "push", "-q", depBare, "HEAD");
+  const sub = join(root, "vendor/audio.cpp");
+  git(sub, "fetch", "-q", depBare, shaB);
+  git(sub, "checkout", "-q", shaB);
+  git(root, "add", "vendor/audio.cpp");
+  commit(root, "repin to B");
+  // The stale binary really does survive the repin — that is the premise.
+  expect(existsSync(join(sub, "build/linux-cuda-release/bin/audiocpp_server"))).toBe(true);
+
+  const third = provision();
+  expect(third.ok).toBe(true);
+  expect(third.out).toContain(`was built from ${shaA}`);
+  expect(builds()).toBe(2);
+  expect(readFileSync(stamp, "utf8").trim()).toBe(shaB);
+});
+
+test("a binary with no recorded provenance is rebuilt rather than trusted", () => {
+  // Every install predating the stamp is in this state; assuming it is current
+  // would silently keep the pre-fix binary running.
+  const script = readFileSync(new URL("../scripts/provision-audiocpp.sh", import.meta.url), "utf8");
+  expect(script).toContain("records no source commit");
+  // The stamp is written only after the binary is confirmed present, so a
+  // failed build cannot make the next run skip.
+  const stampWrite = script.indexOf('> "$STAMP"');
+  const binCheck = script.lastIndexOf('if [[ -x "$BIN" ]]');
+  expect(binCheck).toBeGreaterThan(-1);
+  expect(stampWrite).toBeGreaterThan(binCheck);
 });
 
 test(".gitmodules points at a repo that still has the pinned commit's history", () => {

--- a/tests/vendor-submodule-url.test.ts
+++ b/tests/vendor-submodule-url.test.ts
@@ -210,6 +210,94 @@ test("the provisioner rebuilds when the pin moves, instead of trusting a stale b
   expect(readFileSync(stamp, "utf8").trim()).toBe(shaB);
 });
 
+const BUILD_STUB = [
+  "#!/usr/bin/env bash",
+  "set -euo pipefail",
+  'echo "build $*" >> "${BUILD_LOG:?}"',
+  "mkdir -p build/linux-cuda-release/bin",
+  "printf '#!/bin/sh\\nexit 0\\n' > build/linux-cuda-release/bin/audiocpp_server",
+  "chmod +x build/linux-cuda-release/bin/audiocpp_server",
+].join("\n");
+
+test("a standalone clone reaches a fork-only pin without losing its upstream remote", () => {
+  // The dev/fork-sync layout: vendor/audio.cpp is a standalone clone whose
+  // `origin` tracks UPSTREAM. Skipping `submodule sync` protects that remote,
+  // but `submodule update` then fetches from `origin` — which does not carry a
+  // fork-only pin — so provisioning died before the build. The pin has to be
+  // fetched by URL instead: no remote created, none rewritten.
+  const dir = mkdtempSync(join(tmpdir(), "provision-standalone-"));
+  const buildLog = join(dir, "build-invocations");
+  const commit = (cwd: string, msg: string) =>
+    git(cwd, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", msg);
+
+  // upstream has A; the fork has A + B, and B exists ONLY in the fork.
+  const upWork = join(dir, "up-work");
+  git(dir, "init", "-q", upWork);
+  mkdirSync(join(upWork, "scripts"), { recursive: true });
+  writeFileSync(join(upWork, "scripts/build_linux.sh"), BUILD_STUB);
+  git(upWork, "add", "-A");
+  commit(upWork, "upstream A");
+  const shaA = git(upWork, "rev-parse", "HEAD").out.trim();
+  const upBare = join(dir, "up.git");
+  git(dir, "clone", "-q", "--bare", upWork, upBare);
+
+  const forkWork = join(dir, "fork-work");
+  git(dir, "clone", "-q", upBare, forkWork);
+  writeFileSync(join(forkWork, "PCM"), "live pcm ingest\n");
+  git(forkWork, "add", "-A");
+  commit(forkWork, "fork-only B");
+  const shaB = git(forkWork, "rev-parse", "HEAD").out.trim();
+  git(forkWork, "branch", "-M", "cicero-integration");
+  const forkBare = join(dir, "fork.git");
+  git(dir, "clone", "-q", "--bare", forkWork, forkBare);
+
+  // Superproject: the real provisioner, .gitmodules naming the fork, gitlink at B.
+  const root = join(dir, "root");
+  git(dir, "init", "-q", root);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(
+    join(root, "scripts/provision-audiocpp.sh"),
+    readFileSync(new URL("../scripts/provision-audiocpp.sh", import.meta.url), "utf8"),
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    join(root, ".gitmodules"),
+    `[submodule "vendor/audio.cpp"]\n\tpath = vendor/audio.cpp\n\turl = ${forkBare}\n\tbranch = cicero-integration\n`,
+  );
+  git(root, "add", "-A");
+  commit(root, "root with provisioner");
+  git(root, "update-index", "--add", "--cacheinfo", `160000,${shaB},vendor/audio.cpp`);
+  commit(root, "pin to the fork-only commit");
+
+  // vendor/audio.cpp as a STANDALONE clone of upstream, detached at A, no B.
+  mkdirSync(join(root, "vendor"), { recursive: true });
+  git(root, "clone", "-q", upBare, join(root, "vendor/audio.cpp"));
+  const sub = join(root, "vendor/audio.cpp");
+  git(sub, "checkout", "-q", "--detach", shaA);
+  expect(git(sub, "cat-file", "-e", `${shaB}^{commit}`).ok).toBe(false); // genuinely absent
+
+  const r = Bun.spawnSync(["bash", join(root, "scripts/provision-audiocpp.sh")], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      BUILD_LOG: buildLog,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "protocol.file.allow",
+      GIT_CONFIG_VALUE_0: "always",
+      GIT_TERMINAL_PROMPT: "0",
+    },
+  });
+  const out = `${r.stdout.toString()}${r.stderr.toString()}`;
+  expect({ ok: r.exitCode === 0, out }).toMatchObject({ ok: true });
+  // The pin is now reachable and checked out...
+  expect(git(sub, "rev-parse", "HEAD").out.trim()).toBe(shaB);
+  // ...and the upstream-tracking remote the sync pipeline reads is untouched.
+  expect(git(sub, "remote", "get-url", "origin").out.trim()).toBe(upBare);
+  expect((readFileSync(buildLog, "utf8").match(/^build /gm) ?? []).length).toBe(1);
+});
+
 test("a binary with no recorded provenance is rebuilt rather than trusted", () => {
   // Every install predating the stamp is in this state; assuming it is current
   // would silently keep the pre-fix binary running.

--- a/tests/vendor-submodule-url.test.ts
+++ b/tests/vendor-submodule-url.test.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Repointing `.gitmodules` at the maintained fork only helps a FRESH clone.
+ * A checkout that initialized the submodule under the old URL keeps that URL in
+ * `.git/config`, because `submodule update --init` initializes missing config
+ * but never overwrites what is already there. It then tries to fetch the newly
+ * pinned commit from a repo that does not contain it and dies before the build.
+ *
+ * These tests use real git against local repositories — no network — to pin the
+ * mechanism, and then tie it to the provisioning script that operators run.
+ */
+
+const git = (cwd: string, ...args: string[]): { ok: boolean; out: string } => {
+  const r = Bun.spawnSync(["git", ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",   // ignore the developer's own git config
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_ALLOW_PROTOCOL: "file",
+      GIT_TERMINAL_PROMPT: "0",
+    },
+  });
+  return { ok: r.exitCode === 0, out: `${r.stdout.toString()}${r.stderr.toString()}` };
+};
+
+/** A bare repo with one commit; returns its path and that commit's sha. */
+function seedRemote(dir: string, name: string, file: string): { path: string; sha: string } {
+  const work = join(dir, `${name}-work`);
+  const bare = join(dir, `${name}.git`);
+  git(dir, "init", "-q", work);
+  writeFileSync(join(work, file), "x\n");
+  git(work, "add", "-A");
+  git(work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", `${name} first`);
+  git(dir, "clone", "-q", "--bare", work, bare);
+  const sha = git(work, "rev-parse", "HEAD").out.trim();
+  return { path: bare, sha };
+}
+
+test("a submodule initialized under the old URL needs sync to reach the new pin", () => {
+  const dir = mkdtempSync(join(tmpdir(), "submodule-url-"));
+
+  // "archived" holds only the original commit; "fork" holds an extra one that
+  // exists ONLY there — the situation after repinning at a fork-only commit.
+  const archived = seedRemote(dir, "archived", "old.txt");
+  const forkWork = join(dir, "fork-work");
+  const fork = join(dir, "fork.git");
+  git(dir, "clone", "-q", archived.path, forkWork);
+  writeFileSync(join(forkWork, "new.txt"), "y\n");
+  git(forkWork, "add", "-A");
+  git(forkWork, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "fork-only commit");
+  const forkOnlySha = git(forkWork, "rev-parse", "HEAD").out.trim();
+  git(dir, "clone", "-q", "--bare", forkWork, fork);
+
+  // A superproject that added the submodule from the archived URL and
+  // initialized it there — i.e. every already-provisioned install.
+  const sup = join(dir, "super");
+  git(dir, "init", "-q", sup);
+  writeFileSync(join(sup, "README"), "super\n");
+  git(sup, "add", "-A");
+  git(sup, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init");
+  const added = git(sup, "-c", "protocol.file.allow=always", "submodule", "add", "-q", archived.path, "vendor/dep");
+  expect(added.ok).toBe(true);
+  git(sup, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "add submodule");
+  expect(git(sup, "config", "--get", "submodule.vendor/dep.url").out.trim()).toBe(archived.path);
+
+  // Now the repoint: .gitmodules points at the fork, and the gitlink moves to a
+  // commit that only the fork has.
+  const modules = join(sup, ".gitmodules");
+  writeFileSync(modules, readFileSync(modules, "utf8").replace(archived.path, fork));
+  git(join(sup, "vendor/dep"), "fetch", "-q", fork, forkOnlySha);
+  git(join(sup, "vendor/dep"), "checkout", "-q", forkOnlySha);
+  git(sup, "add", "-A");
+  git(sup, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "repoint + repin");
+
+  // Drop the fetched object so the pin genuinely has to come from a remote,
+  // reproducing a checkout that never had the fork-only commit locally.
+  const fresh = join(dir, "fresh");
+  git(dir, "-c", "protocol.file.allow=always", "clone", "-q", sup, fresh);
+  const freshSub = join(fresh, "vendor/dep");
+  git(fresh, "-c", "protocol.file.allow=always", "submodule", "init");
+  // Simulate the pre-existing install: force the stale URL into .git/config.
+  git(fresh, "config", "submodule.vendor/dep.url", archived.path);
+
+  // What the provisioner used to do, alone: --init leaves the stale URL, so the
+  // fork-only pin cannot be fetched.
+  const initOnly = git(fresh, "-c", "protocol.file.allow=always",
+    "submodule", "update", "--init", "--recursive", "vendor/dep");
+  expect(initOnly.ok).toBe(false);
+  // Fail for the RIGHT reason: the stale remote simply does not have the pin.
+  expect(initOnly.out).toContain(`did not contain ${forkOnlySha}`);
+  expect(git(fresh, "config", "--get", "submodule.vendor/dep.url").out.trim()).toBe(archived.path);
+
+  // With sync first, .git/config follows .gitmodules and the pin resolves.
+  const synced = git(fresh, "submodule", "sync", "--recursive", "vendor/dep");
+  expect(synced.ok).toBe(true);
+  expect(git(fresh, "config", "--get", "submodule.vendor/dep.url").out.trim()).toBe(fork);
+  const afterSync = git(fresh, "-c", "protocol.file.allow=always",
+    "submodule", "update", "--init", "--recursive", "vendor/dep");
+  expect(afterSync.ok).toBe(true);
+  expect(git(freshSub, "rev-parse", "HEAD").out.trim()).toBe(forkOnlySha);
+});
+
+test("the provisioner syncs the submodule URL before updating, and spares standalone clones", () => {
+  const script = readFileSync(new URL("../scripts/provision-audiocpp.sh", import.meta.url), "utf8");
+  const sync = script.indexOf("submodule sync");
+  const update = script.indexOf("submodule update --init");
+  expect(sync).toBeGreaterThan(-1);
+  expect(sync).toBeLessThan(update);
+  // The dev/fork-sync layout is a standalone clone whose `origin` tracks
+  // upstream; syncing it would clobber that remote.
+  expect(script).toContain('if [[ -d "$SUB/.git" ]]');
+});
+
+test(".gitmodules points at a repo that still has the pinned commit's history", () => {
+  const modules = readFileSync(new URL("../.gitmodules", import.meta.url), "utf8");
+  expect(modules).toContain("5uck1ess/audio.cpp-fork");
+  // The archived repo is frozen behind the runtime Cicero builds.
+  expect(modules).not.toContain("github.com/5uck1ess/audio.cpp\n");
+});

--- a/tests/vendor-submodule-url.test.ts
+++ b/tests/vendor-submodule-url.test.ts
@@ -176,12 +176,18 @@ test("the provisioner rebuilds when the pin moves, instead of trusting a stale b
   const builds = (): number =>
     (readFileSync(buildLog, "utf8").match(/^build /gm) ?? []).length;
   const stamp = join(root, "vendor/audio.cpp/build/linux-cuda-release/.built-from-commit");
+  const stampLines = (): string[] => readFileSync(stamp, "utf8").split("\n").filter(Boolean);
 
-  // 1. First provision builds and records what it built from.
+  // 1. First provision builds and records what it built from — commit AND options.
   const first = provision();
   expect(first.ok).toBe(true);
   expect(builds()).toBe(1);
-  expect(readFileSync(stamp, "utf8").trim()).toBe(shaA);
+  expect(stampLines()[0]).toBe(shaA);
+  expect(stampLines()[1]).toContain("--deployment-build");
+  // The catalog must be compiled in: a model directory carries weights only, so a
+  // non-deployment binary cannot resolve pocket_tts's spec from any path Cicero
+  // starts it from, and exits before serving.
+  expect(readFileSync(buildLog, "utf8")).toContain("--deployment-build");
 
   // 2. Unchanged pin: skip, no rebuild.
   const second = provision();
@@ -207,7 +213,25 @@ test("the provisioner rebuilds when the pin moves, instead of trusting a stale b
   expect(third.ok).toBe(true);
   expect(third.out).toContain(`was built from ${shaA}`);
   expect(builds()).toBe(2);
-  expect(readFileSync(stamp, "utf8").trim()).toBe(shaB);
+  expect(stampLines()[0]).toBe(shaB);
+
+  // 4. Same pin, but the binary predates the current build options. Matching the
+  // commit is not enough to trust it: a binary built before --deployment-build
+  // has no embedded spec catalog and cannot start the documented TTS seat, so an
+  // existing install must rebuild rather than be declared current.
+  writeFileSync(stamp, `${shaB}\n--backend cuda --target audiocpp_server\n`);
+  const fourth = provision();
+  expect(fourth.ok).toBe(true);
+  expect(fourth.out).toContain("built at");
+  expect(fourth.out).toContain("with different options");
+  expect(builds()).toBe(3);
+  expect(stampLines()[1]).toContain("--deployment-build");
+
+  // 5. And with the options now recorded, it settles back to skipping.
+  const fifth = provision();
+  expect(fifth.ok).toBe(true);
+  expect(fifth.out).toContain(`Already built at ${shaB}`);
+  expect(builds()).toBe(3);
 });
 
 const BUILD_STUB = [


### PR DESCRIPTION
The submodule URL in `.gitmodules` was written once, in the public-release
squash (`41348a5`), and pointed at `5uck1ess/audio.cpp` ever since. That repo is
now archived and frozen well behind the runtime Cicero builds.

## Why this went unnoticed

`vendor/audio.cpp` on the dev box is a **standalone clone with its own `.git`
directory**, not a gitlink into `.git/modules/`. Its remotes were repointed by
hand (`origin` → upstream `0xShug0/audio.cpp`, `fork` → `audio.cpp-fork`), and
git never propagates that direction back to `.gitmodules` — `submodule sync`
only pushes `.gitmodules` → `.git/config`.

`provision-audiocpp.sh` runs `git submodule update --init`, which reuses an
existing clone and never consults the recorded URL. So the stale URL only
affected a **fresh clone** — a new operator, never the dev box.

## The change

1. Repoint at `5uck1ess/audio.cpp-fork`, the repo the daily upstream-sync job
   maintains, and track its `cicero-integration` branch.
2. Repin the gitlink to `c0d1c9f` — the runtime this box actually builds.
3. Run `git submodule sync` in the provisioner before `update --init`, so an
   already-initialized checkout can follow the repoint at all.

Step 3 is not optional once step 2 lands, and that is a correction to this PR's
original description, which claimed the branch field was untouched and listed
the sync as a deliberately deferred follow-up. Both statements were made when
this branch changed only the URL and kept pin `b81ea93`.

## Why sync became mandatory

`submodule update --init` initializes *missing* config; it never overwrites a
URL already present in `.git/config`. Any checkout that initialized the
submodule before this change keeps the archived URL. With the old pin that was
harmless — `b81ea93` exists in the archived repo, so the stale URL still
resolved. Repinning to `c0d1c9f`, which exists **only** in the fork, turns it
fatal:

```
fatal: remote error: upload-pack: not our ref c0d1c9f...
fatal: Fetched in submodule path 'vendor/audio.cpp', but it did not contain c0d1c9f...
```

The sync is **skipped when `vendor/audio.cpp` is a standalone clone** (its own
`.git` directory rather than a gitlink file). That is the fork-sync development
layout, whose `origin` deliberately tracks upstream; an unconditional sync would
clobber it and break the daily sync pipeline that reads it. This is the exact
hazard the original description raised — the guard is the answer to it, rather
than deferring the sync.

## Verification

- `tests/vendor-submodule-url.test.ts` reproduces the failure and the fix with
  real git against local bare repos, no network: a submodule initialized under
  the old URL, a gitlink repinned to a commit only the new remote has,
  `update --init` failing with that exact `did not contain <sha>` message, then
  succeeding after `sync`. Plus guards that the script syncs before updating,
  spares standalone clones, and that `.gitmodules` names the fork.
- Pinned gitlink `c0d1c9f` is present in `5uck1ess/audio.cpp-fork` and absent
  from the archived repo — verified by ref ancestry.
- `bun test`: 2041 pass, same 3 failures + 1 error as `origin/main`
  (`terminal-send-errors`, `cli/status` — both reproduced on an unmodified
  `origin/main` worktree). `bun run typecheck` and `git diff --check` clean.
- Not verified: an end-to-end fresh clone plus a full `provision-audiocpp.sh`
  CUDA build. The submodule mechanics are covered by the test above; the
  compile is not.

## Deliberately not in this PR

The review's model-spec finding: a normal (non-`--deployment-build`) build does
not compile model specs into the runtime, and external discovery searches beside
the model and up the process CWD's ancestors — never
`vendor/audio.cpp/model_specs` when Cicero starts elsewhere. Real, but the
`AUDIOCPP_DEPLOYMENT_BUILD` option and its `OFF` default are byte-identical at
the old pin `b81ea93`, so this branch cannot have introduced it, and a GGUF that
embeds its own spec resolves without any external file. Tracked separately
rather than bundled into a URL fix.


---

## Third change (after the second review)

Making the source follow the pin exposed that the binary does not. `/build*/` is
git-ignored, so checking out a new pin leaves the previously built
`audiocpp_server` in place, and the provisioner exited on its mere presence — so
an existing install would follow the repoint in source only and keep launching a
binary built from `b81ea93`, without the `FlowLMStepRuntime` null checks
`c0d1c9f` adds. That is the GGML_ASSERT/SIGABRT this box has hit under tight
VRAM; supervision restarts the server but does not save the in-flight request.

The skip now compares commits instead of checking presence: the build records
its source commit in `build/linux-cuda-release/.built-from-commit`, inside the
ignored build tree so it is discarded exactly when the output is, and a mismatch
rebuilds. It fails closed — an unreadable source commit or a missing stamp
rebuilds rather than assuming the binary is current, and the stamp is written
only after the binary is confirmed present so a failed build cannot make the
next run skip.

**Operator consequence:** every install predating this check — including the dev
box — rebuilds once on its next `provision-audiocpp.sh` run. There is no way to
know what an unstamped binary was built from, so that is the intended trade.

**Added verification:** the test file now drives the *real* provisioner against a
stub `build_linux.sh` (no compiler, no network) through build → skip on an
unchanged pin → rebuild after the gitlink moves, asserting the build ran once,
then once, then twice, that the stamp tracks the pin, and that the stale binary
genuinely survives the repin. Both new tests fail against the previous
presence-only script. `bun test`: 2043 pass, same 3 failures + 1 error as
`origin/main`.


---

## The pin move needed the build to embed model specs

`be67aa5`. The new pin makes Pocket-TTS resolve a model-spec file instead of
building its resource bundle from the model directory, and nothing in the
documented setup supplies one — the fork's model manager fetches weights only,
the spec lives at `vendor/audio.cpp/model_specs/`, and audio.cpp searches beside
the model, in the model's parent, and under its own CWD's ancestors. Cicero
spawns the server with neither a CWD nor `--model-spec-override`, so a
provisioned build exited 1 with `model contract spec not found for family
'pocket_tts'` before serving.

The provisioner now builds with `--deployment-build`, compiling the catalog into
the binary; `default_package_spec_path` consults it before the disk search that
throws. The build stamp records the option set next to the commit, because
otherwise an existing pre-flag binary would match on commit alone, be declared
current, and stay broken.

This did not show up on the maintainer's box because that install resolves the
spec through an untracked `model_specs` symlink at the project root plus a server
started from the repo root — neither of which a fresh clone has.

**Not smoke-tested:** no live CUDA `--deployment-build` rebuild-and-start was run
(it means recompiling the CUDA kernels and taking the live TTS seat's GPU). The
chain is verified by code path and by `build_linux.sh`'s flag handling.
