### PR TITLE
fix(windows): unblock local startup, and share one history across surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,26 @@ jobs:
       - run: python3 -m unittest discover -s sidecars/telegram-call -p 'test_*.py'
       - run: uv run --python 3.11 --with-requirements requirements/telegram-call.txt python sidecars/telegram-call/native_contract.py
 
+  # The `test` job above runs on Linux, where every win32-only assertion is
+  # skipped — so the Windows paths (command-shim resolution, the prompt staying
+  # off a shim's command line, FlushFileBuffers needing write access) had no
+  # runner at all and could only break silently. A focused file list rather than
+  # the whole suite: `bun test` is red on Windows for unrelated reasons (POSIX
+  # signalling in the process-tree tests, a Bun `node:net` BlockList panic), and
+  # this job is meant to gate the platform behavior we actually claim.
+  windows-runtime:
+    name: Windows runtime paths
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - name: Test brain spawning, generated TLS, and history trimming on Windows
+        run: bun test tests/brain-subprocess-cli.test.ts tests/web-voice/tls.test.ts tests/web-voice/history.test.ts
+
   python-sidecars:
     name: Python sidecars (${{ matrix.python-version }}, ${{ matrix.resolution }})
     runs-on: ubuntu-latest

--- a/src/brain/subprocess-cli.ts
+++ b/src/brain/subprocess-cli.ts
@@ -22,6 +22,42 @@ export interface SubprocessCLIBrainConfig {
 }
 
 export type TurnProcess = OwnedProcess;
+
+/**
+ * The child's PATH, however it happens to be spelled. Windows environment
+ * blocks are case-insensitive, so an env assembled by spreading `config.env`
+ * over `process.env` can carry both `Path` and `PATH`. The last key wins,
+ * which matches that spread order: an explicitly configured PATH overrides
+ * the inherited one regardless of the casing either side used.
+ */
+export function pathFromEnv(env: Record<string, string | undefined>): string | undefined {
+  let value: string | undefined;
+  for (const [key, candidate] of Object.entries(env)) {
+    if (key.toLowerCase() === "path") value = candidate;
+  }
+  return value;
+}
+
+/**
+ * Windows CreateProcess does not search PATH for the command shims (`foo.cmd`,
+ * `foo.bat`) that npm-style installers put there, so a bare binary name a
+ * terminal resolves fine fails to spawn. Resolve it against the child's own
+ * PATH first, and fall back to the raw name so a miss keeps the previous
+ * behavior and lets the spawn report its own error.
+ *
+ * `platform` and `which` are injected so the Windows branch stays exercisable
+ * from a POSIX CI run — the real Windows shim lookup still needs Windows.
+ */
+export function resolveCommandBinary(
+  binary: string,
+  env: Record<string, string | undefined>,
+  platform: string = process.platform,
+  which: typeof Bun.which = Bun.which,
+): string {
+  if (platform !== "win32") return binary;
+  return which(binary, { PATH: pathFromEnv(env) }) ?? binary;
+}
+
 const CANCEL_GRACE_MS = 500;
 const CANCEL_REAP_TIMEOUT_MS = 2_000;
 const OUTPUT_CLOSE_EXIT_GRACE_MS = 500;
@@ -137,12 +173,7 @@ export class SubprocessCLIBrain implements Brain {
   protected onTurnComplete(): void {}
 
   private resolvedBinary(env: Record<string, string | undefined>): string {
-    if (process.platform !== "win32") return this.config.binary;
-    let path: string | undefined;
-    for (const [key, value] of Object.entries(env)) {
-      if (key.toLowerCase() === "path") path = value;
-    }
-    return Bun.which(this.config.binary, { PATH: path }) ?? this.config.binary;
+    return resolveCommandBinary(this.config.binary, env);
   }
 
   private spawnProc(message: string, options: BrainTurnOptions) {

--- a/src/brain/subprocess-cli.ts
+++ b/src/brain/subprocess-cli.ts
@@ -58,6 +58,36 @@ export function resolveCommandBinary(
   return which(binary, { PATH: pathFromEnv(env) }) ?? binary;
 }
 
+/**
+ * Windows resolves a bare command name to a `.cmd`/`.bat` shim, and those run
+ * through `cmd.exe` rather than being executed directly.
+ */
+export function isBatchShim(binary: string): boolean {
+  return /\.(cmd|bat)$/i.test(binary);
+}
+
+/**
+ * Whether a turn's prompt must be piped rather than appended to argv.
+ *
+ * `cmd.exe` re-parses the command line it is handed: `%VAR%` expands, and `&`,
+ * `|`, `<`, `>`, `^` can end the command and begin another (the CVE-2024-24576
+ * class; the pinned Bun does not escape them). A prompt is untrusted — it comes
+ * from STT, the web client, and Telegram — so once shim resolution has produced
+ * a batch file the prompt cannot travel as a command-line value. stdin keeps it
+ * off the command line entirely, which is also why `promptViaStdin` brains pipe.
+ *
+ * Gated on `platform` so POSIX keeps the argv path even for a binary whose name
+ * happens to end in `.cmd`; there is no cmd.exe there to reinterpret anything.
+ */
+export function promptGoesToStdin(
+  binary: string,
+  promptViaStdin: boolean | undefined,
+  platform: string = process.platform,
+): boolean {
+  if (promptViaStdin === true) return true;
+  return platform === "win32" && isBatchShim(binary);
+}
+
 const CANCEL_GRACE_MS = 500;
 const CANCEL_REAP_TIMEOUT_MS = 2_000;
 const OUTPUT_CLOSE_EXIT_GRACE_MS = 500;
@@ -176,13 +206,16 @@ export class SubprocessCLIBrain implements Brain {
     return resolveCommandBinary(this.config.binary, env);
   }
 
-  private spawnProc(message: string, options: BrainTurnOptions) {
-    const fullMessage = this.buildPrompt(message, options.systemContext);
+  /**
+   * The one spawn path for a turn, so the argv-vs-stdin decision cannot drift
+   * between the configured args and an explicit arg list. Only the prompt moves
+   * — `args` stay on the command line, since they come from operator config.
+   */
+  private spawnPrompt(args: string[], fullMessage: string) {
     const env = this.buildEnv();
     const binary = this.resolvedBinary(env);
-    const args = this.argsForTurn();
 
-    if (this.config.promptViaStdin) {
+    if (promptGoesToStdin(binary, this.config.promptViaStdin)) {
       return spawnOwnedProcess([binary, ...args], {
         stdout: "pipe",
         stderr: "pipe",
@@ -200,19 +233,17 @@ export class SubprocessCLIBrain implements Brain {
     });
   }
 
+  private spawnProc(message: string, options: BrainTurnOptions) {
+    return this.spawnPrompt(this.argsForTurn(), this.buildPrompt(message, options.systemContext));
+  }
+
   /**
    * Spawn the binary with an explicit arg list (e.g. a JSON/streaming mode for
    * progress narration) instead of the configured `args`. Same env + stdin
    * handling as {@link spawnProc}.
    */
   protected spawnWithArgs(args: string[], message: string, systemContext?: string) {
-    const env = this.buildEnv();
-    return spawnOwnedProcess([this.resolvedBinary(env), ...args, this.buildPrompt(message, systemContext)], {
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-      env,
-    });
+    return this.spawnPrompt(args, this.buildPrompt(message, systemContext));
   }
 
   async send(message: string, options: BrainTurnOptions = {}): Promise<string> {

--- a/src/brain/subprocess-cli.ts
+++ b/src/brain/subprocess-cli.ts
@@ -136,10 +136,19 @@ export class SubprocessCLIBrain implements Brain {
   /** Called after a turn's subprocess exits 0 — hook for session tracking. */
   protected onTurnComplete(): void {}
 
+  private resolvedBinary(env: Record<string, string | undefined>): string {
+    if (process.platform !== "win32") return this.config.binary;
+    let path: string | undefined;
+    for (const [key, value] of Object.entries(env)) {
+      if (key.toLowerCase() === "path") path = value;
+    }
+    return Bun.which(this.config.binary, { PATH: path }) ?? this.config.binary;
+  }
+
   private spawnProc(message: string, options: BrainTurnOptions) {
     const fullMessage = this.buildPrompt(message, options.systemContext);
     const env = this.buildEnv();
-    const { binary } = this.config;
+    const binary = this.resolvedBinary(env);
     const args = this.argsForTurn();
 
     if (this.config.promptViaStdin) {
@@ -167,7 +176,7 @@ export class SubprocessCLIBrain implements Brain {
    */
   protected spawnWithArgs(args: string[], message: string, systemContext?: string) {
     const env = this.buildEnv();
-    return spawnOwnedProcess([this.config.binary, ...args, this.buildPrompt(message, systemContext)], {
+    return spawnOwnedProcess([this.resolvedBinary(env), ...args, this.buildPrompt(message, systemContext)], {
       stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -882,6 +882,11 @@ export class CiceroDaemon {
     };
     this.brain.setCallMeHandler?.(dialBack);
 
+    // ONE history for every surface that records a turn. Separate instances
+    // over the same file each keep their own append chain, so one instance's
+    // trim rewrite can drop lines another just appended — and TurnHistory's
+    // cached line count assumes a single writer. Built lazily: a daemon with
+    // neither Telegram nor web voice never touches the file.
     let conversationHistory: TurnHistory | undefined;
     const history = () => conversationHistory ??= new TurnHistory(
       join(homedir(), ".cicero", "web-voice", "history.jsonl"),

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -882,13 +882,18 @@ export class CiceroDaemon {
     };
     this.brain.setCallMeHandler?.(dialBack);
 
+    let conversationHistory: TurnHistory | undefined;
+    const history = () => conversationHistory ??= new TurnHistory(
+      join(homedir(), ".cicero", "web-voice", "history.jsonl"),
+    );
+
     if (this.config.notify?.telegram) {
       // Since Jul 10 the bot is the office's TEXT surface (the tgcall userbot
       // keeps only calls): "log …" hits the health record instantly, "call me"
       // spools a dial-back for the tgcall sidecar, and anything else is a
       // chat turn against the same brain the voice surfaces reach — recorded
       // in the shared history so voice sessions resume with it.
-      const tgHistory = new TurnHistory(join(homedir(), ".cicero", "web-voice", "history.jsonl"));
+      const tgHistory = history();
       // Semantic fallback for dial-back phrasings the lexical pattern misses
       // ("get ada on the horn") — the same small local model the
       // switchboard uses for spoken transfers. Lexical-only without a
@@ -929,8 +934,7 @@ export class CiceroDaemon {
       const resumeTurns = this.config.web_voice?.resume_turns ?? 10;
       if (this.config.web_voice?.enabled && resumeTurns > 0) {
         try {
-          const history = new TurnHistory(join(homedir(), ".cicero", "web-voice", "history.jsonl"));
-          const primer = buildResumePrimer(await history.recent(resumeTurns));
+          const primer = buildResumePrimer(await history().recent(resumeTurns));
           if (primer) warmMsg = primer;
         } catch { /* no history — plain warmup */ }
       }
@@ -1050,7 +1054,7 @@ export class CiceroDaemon {
       }
       this.assertStartupActive();
       assertWebTlsPolicy(webHost, tls, tlsExplicitlyDisabled);
-      const webHistory = new TurnHistory(join(homedir(), ".cicero", "web-voice", "history.jsonl"));
+      const webHistory = history();
       // Every spoken sentence funnels through here — the one place to strip
       // Markdown/typography so a voice never says "dash" or glitches on an
       // em-dash. A sentence that is pure markup flattens to nothing and is

--- a/src/sidecar/codex-hook.ts
+++ b/src/sidecar/codex-hook.ts
@@ -39,11 +39,14 @@ async function readHookBody(
 ): Promise<string> {
   const reader = input.getReader();
   const chunks: Uint8Array[] = [];
-  const signal = AbortSignal.timeout(timeoutMs);
+  const controller = new AbortController();
+  const deadline = setTimeout(() => {
+    controller.abort(new DOMException("Codex hook input timed out", "TimeoutError"));
+  }, timeoutMs);
   let total = 0;
   try {
     while (true) {
-      const result = await readBeforeDeadline(reader, signal);
+      const result = await readBeforeDeadline(reader, controller.signal);
       if (result.done) break;
       const value = result.value;
       if (!value || value.byteLength === 0) continue;
@@ -67,6 +70,7 @@ async function readHookBody(
     });
     throw error;
   } finally {
+    clearTimeout(deadline);
     reader.releaseLock();
   }
 }

--- a/src/web-voice/history.ts
+++ b/src/web-voice/history.ts
@@ -72,6 +72,16 @@ export class TurnHistory {
     }
   }
 
+  /**
+   * Trim without rereading the whole log after every turn. The cached count is
+   * only sound while this instance is the file's sole writer — the daemon
+   * therefore shares ONE TurnHistory across Telegram, warmup, and web voice
+   * rather than opening one per surface. A writer outside this process would
+   * make the count read low and let the file overshoot MAX_LINES until our own
+   * appends cross the threshold; the reread below then resyncs it. Every miss
+   * (first append, threshold crossed, failed write) falls back to the count on
+   * disk, so the cache can only ever delay a trim, never skip one.
+   */
   private async trimIfNeeded(): Promise<void> {
     if (this.lineCount !== null) {
       this.lineCount += 1;

--- a/src/web-voice/history.ts
+++ b/src/web-voice/history.ts
@@ -28,6 +28,7 @@ const KEEP_LINES = 500;   // … rewrite keeping this many
 export class TurnHistory {
   private pending: Promise<void> = Promise.resolve();
   private available = true;
+  private lineCount: number | null = null;
 
   constructor(private file: string) {
     try {
@@ -72,8 +73,14 @@ export class TurnHistory {
   }
 
   private async trimIfNeeded(): Promise<void> {
+    if (this.lineCount !== null) {
+      this.lineCount += 1;
+      if (this.lineCount <= MAX_LINES) return;
+    }
     const lines = (await readFile(this.file, "utf8")).split("\n").filter(Boolean);
-    if (lines.length <= MAX_LINES) return;
+    this.lineCount = lines.length;
+    if (this.lineCount <= MAX_LINES) return;
     await writeFile(this.file, lines.slice(-KEEP_LINES).join("\n") + "\n", { mode: PRIVATE_FILE_MODE });
+    this.lineCount = KEEP_LINES;
   }
 }

--- a/src/web-voice/tls.ts
+++ b/src/web-voice/tls.ts
@@ -129,7 +129,7 @@ async function assertOwnedRegularPair(certPath: string, keyPath: string): Promis
 }
 
 async function syncFile(path: string): Promise<void> {
-  const handle = await open(path, "r");
+  const handle = await open(path, "r+");
   try {
     await handle.sync();
   } finally {

--- a/tests/brain-subprocess-cli.test.ts
+++ b/tests/brain-subprocess-cli.test.ts
@@ -1,4 +1,7 @@
 import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import {
   awaitOwnedTurnExit,
   SubprocessCLIBrain,
@@ -10,6 +13,33 @@ test("SubprocessCLIBrain spawns the configured binary with prompt", async () => 
   await brain.start();
   const out = await brain.send("hello");
   expect(out).toContain("hello");
+});
+
+test.skipIf(process.platform !== "win32")("resolves Windows PATH command shims before spawning", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "cicero-brain-shim-"));
+  try {
+    writeFileSync(join(directory, "cicero-brain-shim.cmd"), "@echo off\r\necho %*\r\n");
+    class InspectBrain extends SubprocessCLIBrain {
+      spawnExplicit() {
+        return this.spawnWithArgs(["--stream"], "hello");
+      }
+    }
+    const brain = new InspectBrain({
+      name: "test",
+      binary: "cicero-brain-shim",
+      args: ["--print"],
+      env: { PATH: `${directory}${delimiter}${process.env.PATH ?? ""}` },
+      rememberTurns: false,
+    });
+
+    expect(await brain.send("hello")).toContain("--print hello");
+    const explicit = brain.spawnExplicit();
+    const output = await new Response(explicit.stdout).text();
+    expect(await awaitOwnedTurnExit(explicit)).toBe(0);
+    expect(output).toContain("--stream hello");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("injected context is prepended once and completed turns become bounded history", () => {

--- a/tests/brain-subprocess-cli.test.ts
+++ b/tests/brain-subprocess-cli.test.ts
@@ -2,9 +2,12 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
+import { chmodSync } from "node:fs";
 import {
   awaitOwnedTurnExit,
+  isBatchShim,
   pathFromEnv,
+  promptGoesToStdin,
   resolveCommandBinary,
   SubprocessCLIBrain,
   type TurnProcess,
@@ -72,6 +75,68 @@ test.skipIf(process.platform !== "win32")("resolves Windows PATH command shims b
     const output = await new Response(explicit.stdout).text();
     expect(await awaitOwnedTurnExit(explicit)).toBe(0);
     expect(output).toContain("--stream hello");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+// A Windows `.cmd`/`.bat` shim runs through cmd.exe, which reinterprets argv
+// (CVE-2024-24576). A turn's prompt is untrusted, so it must never be a command
+// -line value on that path. The decision is pure so it is exercised off Windows.
+test("a batch shim is recognized by extension, case-insensitively", () => {
+  expect(isBatchShim("C:\\shims\\codex.cmd")).toBe(true);
+  expect(isBatchShim("C:\\shims\\CODEX.CMD")).toBe(true);
+  expect(isBatchShim("C:\\shims\\run.bat")).toBe(true);
+  // A real executable carries no cmd.exe parsing, and a name that merely
+  // contains "cmd" is not a shim.
+  expect(isBatchShim("codex")).toBe(false);
+  expect(isBatchShim("C:\\bin\\codex.exe")).toBe(false);
+  expect(isBatchShim("/usr/bin/cmdtool")).toBe(false);
+});
+
+test("the prompt is routed to stdin for a Windows shim, and POSIX is left alone", () => {
+  // An explicitly configured stdin brain (qwen/gemini) always pipes.
+  expect(promptGoesToStdin("qwen", true, "linux")).toBe(true);
+  // The argv brains (codex/claude) must switch to stdin once resolution has
+  // handed them a shim.
+  expect(promptGoesToStdin("C:\\shims\\codex.cmd", undefined, "win32")).toBe(true);
+  // A real Windows executable keeps the existing argv path.
+  expect(promptGoesToStdin("C:\\bin\\codex.exe", undefined, "win32")).toBe(false);
+  // POSIX behavior must be unchanged even for an operator who configured a
+  // binary that happens to end in .cmd — there is no cmd.exe to reinterpret it.
+  expect(promptGoesToStdin("/opt/bin/weird.cmd", undefined, "linux")).toBe(false);
+});
+
+/** A probe that reports how it received its argv and stdin. */
+function writeProbe(directory: string, name: string): string {
+  const path = join(directory, name);
+  writeFileSync(path, '#!/bin/sh\necho "ARGS:$*"\necho "STDIN:$(cat)"\n');
+  chmodSync(path, 0o755);
+  return path;
+}
+
+test.skipIf(process.platform === "win32")("spawnWithArgs pipes the prompt instead of putting it in argv", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "cicero-stdin-probe-"));
+  try {
+    class InspectBrain extends SubprocessCLIBrain {
+      spawnExplicit(message: string) { return this.spawnWithArgs(["--stream"], message); }
+    }
+    // The progress path ignored promptViaStdin and always appended the prompt to
+    // argv, so a stdin brain still leaked its prompt onto the command line.
+    const brain = new InspectBrain({
+      name: "test",
+      binary: writeProbe(directory, "probe.sh"),
+      args: ["--print"],
+      promptViaStdin: true,
+      rememberTurns: false,
+    });
+
+    const proc = brain.spawnExplicit("secret prompt");
+    const output = await new Response(proc.stdout).text();
+    expect(await awaitOwnedTurnExit(proc)).toBe(0);
+    expect(output).toContain("STDIN:secret prompt");
+    expect(output).toContain("ARGS:--stream");
+    expect(output).not.toContain("ARGS:--stream secret prompt");
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/tests/brain-subprocess-cli.test.ts
+++ b/tests/brain-subprocess-cli.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import {
   awaitOwnedTurnExit,
+  pathFromEnv,
+  resolveCommandBinary,
   SubprocessCLIBrain,
   type TurnProcess,
 } from "../src/brain/subprocess-cli";
@@ -13,6 +15,39 @@ test("SubprocessCLIBrain spawns the configured binary with prompt", async () => 
   await brain.start();
   const out = await brain.send("hello");
   expect(out).toContain("hello");
+});
+
+// The shim lookup itself needs Windows, but its decision logic must not go
+// unexercised on a POSIX CI run — these drive the win32 branch with an
+// injected platform and `which`.
+test("PATH lookup is case-insensitive and the last spelling wins", () => {
+  expect(pathFromEnv({ PATH: "/usr/bin" })).toBe("/usr/bin");
+  expect(pathFromEnv({ Path: "C:\\tools" })).toBe("C:\\tools");
+  // buildEnv() spreads config.env last, so a configured PATH must beat the
+  // inherited one whichever casing each side used.
+  expect(pathFromEnv({ Path: "C:\\inherited", PATH: "C:\\configured" })).toBe("C:\\configured");
+  expect(pathFromEnv({ PATH: "C:\\inherited", Path: "C:\\configured" })).toBe("C:\\configured");
+  expect(pathFromEnv({ HOME: "/root" })).toBeUndefined();
+});
+
+test("command resolution is a no-op off Windows and resolves shims on it", () => {
+  const seen: Array<{ command: string; PATH?: string }> = [];
+  const which = ((command: string, options?: { PATH?: string }) => {
+    seen.push({ command, PATH: options?.PATH });
+    return command === "codex" ? "C:\\shims\\codex.cmd" : null;
+  }) as typeof Bun.which;
+
+  // POSIX spawns already search PATH — the binary must pass through untouched
+  // and cost nothing.
+  expect(resolveCommandBinary("codex", { PATH: "/usr/bin" }, "linux", which)).toBe("codex");
+  expect(seen).toHaveLength(0);
+
+  expect(resolveCommandBinary("codex", { Path: "C:\\shims" }, "win32", which)).toBe("C:\\shims\\codex.cmd");
+  expect(seen).toEqual([{ command: "codex", PATH: "C:\\shims" }]);
+
+  // An unresolvable name falls back to the raw binary so the spawn reports the
+  // failure itself instead of this layer inventing one.
+  expect(resolveCommandBinary("missing", { Path: "C:\\shims" }, "win32", which)).toBe("missing");
 });
 
 test.skipIf(process.platform !== "win32")("resolves Windows PATH command shims before spawning", async () => {

--- a/tests/brain-subprocess-cli.test.ts
+++ b/tests/brain-subprocess-cli.test.ts
@@ -53,13 +53,16 @@ test("command resolution is a no-op off Windows and resolves shims on it", () =>
   expect(resolveCommandBinary("missing", { Path: "C:\\shims" }, "win32", which)).toBe("missing");
 });
 
-test.skipIf(process.platform !== "win32")("resolves Windows PATH command shims before spawning", async () => {
+test.skipIf(process.platform !== "win32")("a resolved Windows shim is spawned, and the prompt never reaches its command line", async () => {
   const directory = mkdtempSync(join(tmpdir(), "cicero-brain-shim-"));
   try {
-    writeFileSync(join(directory, "cicero-brain-shim.cmd"), "@echo off\r\necho %*\r\n");
+    // Reports the argv cmd.exe actually parsed, then drains stdin so the write
+    // side never sees a closed pipe. `more` exits 0 whether or not it read
+    // anything, keeping the turn's exit status about the spawn.
+    writeFileSync(join(directory, "cicero-brain-shim.cmd"), "@echo off\r\necho ARGS:%*\r\nmore >nul 2>&1\r\n");
     class InspectBrain extends SubprocessCLIBrain {
-      spawnExplicit() {
-        return this.spawnWithArgs(["--stream"], "hello");
+      spawnExplicit(message: string) {
+        return this.spawnWithArgs(["--stream"], message);
       }
     }
     const brain = new InspectBrain({
@@ -70,11 +73,21 @@ test.skipIf(process.platform !== "win32")("resolves Windows PATH command shims b
       rememberTurns: false,
     });
 
-    expect(await brain.send("hello")).toContain("--print hello");
-    const explicit = brain.spawnExplicit();
+    // Reaching a shim's command line, `%PATH%` would expand and `&` would start
+    // a second command. Both spawn paths must keep the prompt off it entirely;
+    // that it still arrives intact over stdin is covered on POSIX above, where
+    // CI can actually run it.
+    const prompt = "hello %PATH% & echo INJECTED";
+    const sent = await brain.send(prompt);
+    expect(sent).toContain("ARGS:--print");
+    expect(sent).not.toContain("hello");
+    expect(sent).not.toContain("INJECTED");
+
+    const explicit = brain.spawnExplicit(prompt);
     const output = await new Response(explicit.stdout).text();
     expect(await awaitOwnedTurnExit(explicit)).toBe(0);
-    expect(output).toContain("--stream hello");
+    expect(output).toContain("ARGS:--stream");
+    expect(output).not.toContain("hello");
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/tests/voice-cli.test.ts
+++ b/tests/voice-cli.test.ts
@@ -30,7 +30,7 @@ function writeFixtureWav(path: string): void {
 
 async function cli(home: string, ...args: string[]): Promise<{ code: number; out: string; err: string }> {
   const proc = Bun.spawn(["bun", INDEX, "voice", ...args], {
-    env: { ...process.env, HOME: home },
+    env: { ...process.env, HOME: home, USERPROFILE: home },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/tests/web-voice/history.test.ts
+++ b/tests/web-voice/history.test.ts
@@ -49,6 +49,24 @@ test("file is trimmed once it exceeds the cap", async () => {
   expect(got[got.length - 1].user).toBe("u1004"); // newest survives
 });
 
+// The cached line count skips a full reread per turn, so it must never let an
+// already-oversized file through: a fresh instance starts with no count and has
+// to resync from disk on its very first append.
+test("an oversized file inherited from a previous run is trimmed on the first append", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "cicero-hist-inherited-"));
+  const file = join(dir, "history.jsonl");
+  const existing = Array.from({ length: 1200 }, (_, i) => JSON.stringify({ t: i, user: "old" + i, reply: "r" }));
+  writeFileSync(file, existing.join("\n") + "\n", { mode: 0o600 });
+
+  const h = new TurnHistory(file);
+  await h.append({ t: 9999, user: "new", reply: "r" });
+
+  const got = await h.recent(2000);
+  expect(got.length).toBeLessThanOrEqual(505);
+  expect(got[got.length - 1].user).toBe("new");
+  rmSync(dir, { recursive: true, force: true });
+});
+
 test.skipIf(process.platform === "win32")("history directory and file are private, including existing data", async () => {
   const dir = mkdtempSync(join(tmpdir(), "cicero-hist-mode-"));
   const file = join(dir, "history.jsonl");


### PR DESCRIPTION
Carries forward @dallascrilley's work from #49, which has been sitting in draft. His commit is preserved here with original authorship; the second commit is the follow-up I described in [my review](https://github.com/5uck1ess/cicero/pull/49#issuecomment-5093339314), rebased onto current `main`.

Opening this so the work can land rather than go stale — #49 stays open, and if Dallas marks it ready I'm happy to close this in favor of his.

## What lands

Four independent fixes, three of them Windows-specific:

- **`subprocess-cli.ts` — resolve PATH command shims before spawning.** Windows `CreateProcess` does not search `PATH` for the `.cmd`/`.bat` shims npm-style installers write, so a bare binary name that resolves fine in a terminal fails to spawn. Resolved against the child's own PATH, falling back to the raw name so a miss keeps the previous behavior and lets the spawn report its own error.
- **`tls.ts` — open with `"r+"` before `fsync`.** Windows `FlushFileBuffers` needs write access. Scoped to the generation path, on files we just wrote and `chmod`'d, so it cannot hit an operator-supplied read-only cert.
- **`codex-hook.ts` — clear the input deadline on success.** `AbortSignal.timeout` never clears, which keeps a short-lived hook process alive on its timer. Replaced with an owned `AbortController` + `clearTimeout` in `finally`.
- **`voice-cli.test.ts` — set `USERPROFILE` alongside `HOME`.** `homedir()` reads `USERPROFILE` on Windows, so the test was writing fixtures into the real operator profile.

And one that is not a Windows fix but is worth having on its own:

- **`daemon.ts` — one shared `TurnHistory` across every surface that records a turn.** Telegram, warmup, and web voice each constructed their own instance over the same file, so each kept its own append chain and one instance's trim rewrite could silently drop lines another had just appended. Now built lazily and shared, so a daemon with neither Telegram nor web voice still never touches the file. `history.ts` caches its line count on top of that, which removes a full reread per turn.

## What the follow-up commit adds

Addressing three points from the #49 review:

1. **The shim resolution now has CI coverage.** It was the headline change but sat entirely behind `test.skipIf(process.platform !== "win32")`, so it never executed on our Linux CI. Extracted `resolveCommandBinary`/`pathFromEnv` with injectable `platform` and `which`, so the win32 decision logic is exercised on any OS. The real shim lookup still needs Windows and that test stays skipped there.
2. **The PATH pick is now stated and tested.** It takes the last env key that lowercases to `"path"`, which gives a configured `PATH` precedence over an inherited `Path` — but only because `buildEnv()` spreads `config.env` last and JS preserves insertion order. That was load-bearing and undocumented; it now has a comment and a regression covering both casing orders.
3. **The `lineCount` cache is documented as single-writer at both ends,** since its soundness is exactly what the `daemon.ts` change buys. Added a regression that a fresh `TurnHistory` inheriting an oversized file resyncs and trims on its first append — the cache can only ever delay a trim, never skip one.

## Verification

Run on Linux against this branch:

- `bun run typecheck` — clean
- `git diff --check` — clean
- `bun test` — 2047 pass / 6 skip / 2 fail

The 2 failures are pre-existing and environmental (ANSI colour leaking into asserted stderr in `terminal-send-errors` and `cli/status`). Confirmed identical on `main` at `0ca77a4` by running the same two files there. No regressions from this diff.

Not verified here, honestly labeled: the Windows runtime paths themselves. The shim lookup, the `FlushFileBuffers` behavior, and the `USERPROFILE` fix all need a real Windows box — @dallascrilley reported a live installed-stack smoke on #49 (HTTPS `/health` and `/ready` 200, providers reachable), and that remains the only Windows evidence. CI here proves the decision logic and the platform-independent history fix, not the OS behavior.
