### PR TITLE
feat(brain): summarize old history in the background instead of dropping it

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -144,6 +144,18 @@ brain:
   max_response_bytes: 2097152
   max_pending_turns: 32
 
+  # Background history compaction (off by default). Cicero replays a bounded
+  # transcript to the brain; past the cap the oldest turns are simply dropped and
+  # the conversation quietly forgets its beginning. Enabled, the older half is
+  # summarized by a small local model in the background instead, and the full
+  # turns keep serving prompts until that summary lands. If the summarizer is
+  # slow or down it falls back to dropping them, so this can never stall a turn.
+  # Omit the URL here to reuse web_voice.tldr.summarizer_url.
+  # history_compaction:
+  #   enabled: true
+  #   summarizer_url: http://127.0.0.1:8080/v1
+  #   summarizer_model: your-small-model
+
   # Optional: "think hard about …" escalates that one turn to a heavier agent.
   escalate:
     binary: hermes

--- a/docs/brains.md
+++ b/docs/brains.md
@@ -127,6 +127,49 @@ of every escaped or reparented descendant. ACP turns receive the caller's signal
 cancellation, return the interrupted consumer promptly, and keep the session
 lock closed until cancellation settles or the session is restarted fail-closed.
 
+## Background history compaction
+
+The retained transcript is bounded: 12 turns or 32,000 characters, whichever
+comes first. By default, crossing that cap drops the oldest turns, so a long
+conversation quietly forgets how it started. This affects every adapter that
+replays Cicero-managed history — including `claude-code`, which uses it by
+default — but not stateful sessions (ACP, tab-inject, resumed Codex lanes),
+which keep their history in the agent itself.
+
+Compaction replaces that silent drop with a summary:
+
+```yaml
+brain:
+  history_compaction:
+    enabled: true
+    summarizer_url: http://127.0.0.1:8080/v1   # OpenAI-compatible
+    summarizer_model: your-small-model
+```
+
+Omit `summarizer_url` to reuse `web_voice.tldr.summarizer_url`. With neither set,
+compaction stays off and `cicero doctor` says so rather than failing to start.
+
+When the cap is crossed, the older half is sent to that endpoint in the
+background while the conversation continues against the **full, un-compacted**
+history. Once the summary returns, those turns are replaced by it and it is
+carried in every later prompt under "Summary of earlier conversation:". A
+following compaction is given the current summary and folds into it, so the
+history holds one running summary rather than a growing stack.
+
+The bounds matter more than the feature:
+
+- One compaction at a time. A second trigger while one is in flight is a no-op.
+- 30-second absolute deadline; the summary itself is capped at 4,000 characters.
+- History may overrun to twice its normal cap while a compaction runs, and no
+  further — a summarizer that never answers cannot grow the transcript.
+- Any failure (timeout, endpoint down, empty response) falls back to today's
+  eviction and logs why. It is retried on the next crossing, so recovery does
+  not need a restart.
+- `restart()` discards a compaction already in flight rather than letting it
+  attach a summary of the conversation you just cleared.
+
+Because it runs in the background, a compaction never adds latency to a turn.
+
 ## Progress narration
 
 When an agent can stream structured events — **`codex`** (`exec --json`) and **`claude-code`** (`--output-format stream-json`) — Cicero speaks a running summary of what it's *doing*: its plan, the commands it runs ("Running ls.", "Editing auth.ts."), and the final answer — so you hear it work, not just the end result. On by default; disable with `brain: { narrate_progress: false }`. Brains without event streaming fall back to speaking their answer.

--- a/docs/brains.md
+++ b/docs/brains.md
@@ -159,14 +159,22 @@ history holds one running summary rather than a growing stack.
 The bounds matter more than the feature:
 
 - One compaction at a time. A second trigger while one is in flight is a no-op.
-- 30-second absolute deadline; the summary itself is capped at 4,000 characters.
+- A turn is only retired if its text actually fit in the request. A batch that
+  would overflow is made smaller rather than sent truncated, so compaction never
+  deletes something it did not summarize.
+- The summarizer request times out after 15 seconds, and the compaction as a
+  whole is abandoned after 30 whether or not the summarizer honors the
+  cancellation. The retained summary is capped at 4,000 characters and counts
+  toward the transcript's own character ceiling.
 - History may overrun to twice its normal cap while a compaction runs, and no
-  further — a summarizer that never answers cannot grow the transcript.
+  further — a summarizer that never answers cannot grow the transcript. It is
+  trimmed back to the normal cap as soon as the compaction settles.
 - Any failure (timeout, endpoint down, empty response) falls back to today's
   eviction and logs why. It is retried on the next crossing, so recovery does
   not need a restart.
 - `restart()` discards a compaction already in flight rather than letting it
-  attach a summary of the conversation you just cleared.
+  attach a summary of the conversation you just cleared, and daemon shutdown
+  cancels one that is still in the air.
 
 Because it runs in the background, a compaction never adds latency to a turn.
 

--- a/docs/brains.md
+++ b/docs/brains.md
@@ -149,6 +149,14 @@ brain:
 Omit `summarizer_url` to reuse `web_voice.tldr.summarizer_url`. With neither set,
 compaction stays off and `cicero doctor` says so rather than failing to start.
 
+It is a **base** URL — Cicero appends `/chat/completions` to it — so it must not
+carry a query string or fragment. A URL like `…/v1?token=abc` would become
+`…/v1?token=abc/chat/completions`, silently requesting `/v1` with a mangled
+token, so Cicero refuses it at startup instead. Endpoints that authenticate by
+query parameter need a gateway that accepts a header; the same rule applies to
+every configured base URL (`brain.base_url`, a provider's `baseUrl`,
+`web_voice.tldr.summarizer_url`).
+
 When the cap is crossed, the older half is sent to that endpoint in the
 background while the conversation continues against the **full, un-compacted**
 history. Once the summary returns, those turns are replaced by it and it is

--- a/docs/brains.md
+++ b/docs/brains.md
@@ -164,8 +164,8 @@ The bounds matter more than the feature:
   deletes something it did not summarize.
 - The summarizer request times out after 15 seconds, and the compaction as a
   whole is abandoned after 30 whether or not the summarizer honors the
-  cancellation. The retained summary is capped at 4,000 characters and counts
-  toward the transcript's own character ceiling.
+  cancellation. The retained summary is capped at 4,000 characters — inclusive
+  of its truncation marker — and counts toward the transcript's own ceiling.
 - History may overrun to twice its normal cap while a compaction runs, and no
   further — a summarizer that never answers cannot grow the transcript. It is
   trimmed back to the normal cap as soon as the compaction settles.

--- a/src/backends/http-transfer.ts
+++ b/src/backends/http-transfer.ts
@@ -145,7 +145,16 @@ export async function readBoundedJson<T>(
   label = "provider JSON response",
 ): Promise<T> {
   const bytes = await readBoundedBytes(response, maxBytes, label);
-  return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  } catch {
+    // The runtime's own parse error quotes the offending token, so a 200 that is
+    // not JSON at all — an HTML error page, a captive-portal notice, a proxy
+    // echoing a credential — lands verbatim inside an Error that callers log to
+    // the console and publish to the dashboard. Provider bodies are untrusted
+    // input: report the failure, never the content.
+    throw new Error(`${label} was not valid JSON`);
+  }
 }
 
 /** Read bounded binary output and return an exact-size ArrayBuffer. */

--- a/src/brain/history-compactor.ts
+++ b/src/brain/history-compactor.ts
@@ -1,5 +1,5 @@
 import { discardResponseBody, providerSignal, readBoundedJson, PROVIDER_TIMEOUT_MS } from "../backends/http-transfer";
-import type { HistoryCompactor } from "./turn-context";
+import { MAX_COMPACT_BATCH_CHARS, MAX_SUMMARY_CHARS, type HistoryCompactor } from "./turn-context";
 
 /** One small-model completion against an OpenAI-compatible endpoint. */
 export type SummarizerComplete = (prompt: string, maxTokens: number, signal?: AbortSignal) => Promise<string>;
@@ -47,8 +47,14 @@ export function createSummarizerComplete(config: SummarizerEndpoint | undefined)
 
 /** Tokens allowed for one compaction. Roughly tracks MAX_SUMMARY_CHARS. */
 const COMPACTION_MAX_TOKENS = 700;
-/** Bound on what is sent up: this is conversation text, and the endpoint is small. */
-const MAX_PROMPT_CHARS = 24_000;
+/**
+ * Defensive ceiling on the request body. Derived from the caller's own bounds
+ * rather than picked: the turn context sizes each batch to
+ * MAX_COMPACT_BATCH_CHARS and carries at most MAX_SUMMARY_CHARS forward, so a
+ * well-formed call always fits and this never truncates. It exists only so a
+ * caller passing something unbounded cannot post an unbounded body.
+ */
+const MAX_PROMPT_CHARS = MAX_COMPACT_BATCH_CHARS + MAX_SUMMARY_CHARS + 4_000;
 
 function buildPrompt(turns: readonly { user: string; assistant: string }[], previousSummary: string | null): string {
   const transcript = turns

--- a/src/brain/history-compactor.ts
+++ b/src/brain/history-compactor.ts
@@ -1,0 +1,83 @@
+import { discardResponseBody, providerSignal, readBoundedJson, PROVIDER_TIMEOUT_MS } from "../backends/http-transfer";
+import type { HistoryCompactor } from "./turn-context";
+
+/** One small-model completion against an OpenAI-compatible endpoint. */
+export type SummarizerComplete = (prompt: string, maxTokens: number, signal?: AbortSignal) => Promise<string>;
+
+export interface SummarizerEndpoint {
+  summarizer_url?: string;
+  summarizer_model?: string;
+}
+
+/**
+ * Build the shared small-model completion helper.
+ *
+ * The TLDR speech gate, the call-minutes writer, and history compaction all
+ * talk to the same local endpoint; this is that one client. Returns undefined
+ * when no URL is configured, which every caller treats as "feature off".
+ */
+export function createSummarizerComplete(config: SummarizerEndpoint | undefined): SummarizerComplete | undefined {
+  const base = config?.summarizer_url;
+  if (!base) return undefined;
+  const url = `${base.replace(/\/$/, "")}/chat/completions`;
+  const model = config?.summarizer_model ?? "";
+  return async (prompt: string, maxTokens: number, signal?: AbortSignal): Promise<string> => {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model,
+        max_tokens: maxTokens,
+        reasoning_effort: "none",
+        messages: [{ role: "user", content: prompt }],
+      }),
+      signal: providerSignal(PROVIDER_TIMEOUT_MS.summarizer, signal),
+    });
+    if (!res.ok) {
+      await discardResponseBody(res);
+      // The URL may carry credentials; the status alone is what is safe to surface.
+      throw new Error(`summarizer ${res.status}`);
+    }
+    const data = await readBoundedJson<{ choices?: Array<{ message?: { content?: string } }> }>(res);
+    const line = data.choices?.[0]?.message?.content?.trim();
+    if (!line) throw new Error("summarizer returned nothing");
+    return line;
+  };
+}
+
+/** Tokens allowed for one compaction. Roughly tracks MAX_SUMMARY_CHARS. */
+const COMPACTION_MAX_TOKENS = 700;
+/** Bound on what is sent up: this is conversation text, and the endpoint is small. */
+const MAX_PROMPT_CHARS = 24_000;
+
+function buildPrompt(turns: readonly { user: string; assistant: string }[], previousSummary: string | null): string {
+  const transcript = turns
+    .map((turn) => `User: ${turn.user}\nAssistant: ${turn.assistant}`)
+    .join("\n\n");
+  const sections = [
+    "You are compacting the earlier part of a conversation so it can be carried forward in limited space.",
+    "Write a single dense paragraph in the third person recording what was discussed, what was decided, and any facts, names, paths, or numbers that later turns would need. Do not add commentary, headings, or markdown. Do not invent anything.",
+  ];
+  if (previousSummary) {
+    sections.push(
+      `This is the summary of everything before the excerpt below. Fold it together with the excerpt into ONE paragraph — do not simply append:\n${previousSummary}`,
+    );
+  }
+  sections.push(`Excerpt to fold in:\n${transcript}`);
+  const prompt = sections.join("\n\n");
+  return prompt.length <= MAX_PROMPT_CHARS
+    ? prompt
+    : `${prompt.slice(0, MAX_PROMPT_CHARS)}\n[excerpt truncated]`;
+}
+
+/**
+ * Adapt the summarizer endpoint into the compactor the turn context expects.
+ * Returns undefined when no endpoint is configured — the context then evicts
+ * exactly as it always has.
+ */
+export function createHistoryCompactor(config: SummarizerEndpoint | undefined): HistoryCompactor | undefined {
+  const complete = createSummarizerComplete(config);
+  if (!complete) return undefined;
+  return ({ turns, previousSummary }, signal) =>
+    complete(buildPrompt(turns, previousSummary), COMPACTION_MAX_TOKENS, signal);
+}

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -53,11 +53,24 @@ export type HistoryCompactor = (
  */
 let defaultCompactor: HistoryCompactor | null = null;
 
-/** Register the daemon-wide compactor. Returns a disposer that restores the previous one. */
+/**
+ * Register the daemon-wide compactor. Returns a disposer that unregisters it.
+ *
+ * The disposer only clears the compactor it installed. Restoring whatever was
+ * there before would let an out-of-order release clobber a newer registration —
+ * a daemon restart re-registers before the old instance finishes stopping.
+ * Calling the disposer twice, or after someone else has registered, is a no-op.
+ */
 export function setDefaultHistoryCompactor(compactor: HistoryCompactor | null): () => void {
-  const previous = defaultCompactor;
   defaultCompactor = compactor;
-  return () => { defaultCompactor = previous; };
+  return () => {
+    if (defaultCompactor === compactor) defaultCompactor = null;
+  };
+}
+
+/** Whether a daemon-wide compactor is currently registered. */
+export function hasDefaultHistoryCompactor(): boolean {
+  return defaultCompactor !== null;
 }
 
 /**

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -234,6 +234,8 @@ export class BrainTurnContext {
         expire(new Error(`compaction exceeded ${this.compactionTimeoutMs}ms`));
       }, this.compactionTimeoutMs);
       try {
+        // race() subscribes to both, so a compactor that rejects after the
+        // deadline already won is handled and ignored, not unhandled.
         const result = await Promise.race([
           compactor({ turns: batch, previousSummary }, controller.signal),
           deadline,

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -1,3 +1,5 @@
+import { log } from "../logger";
+
 export type BrainChatMessage = { role: "system" | "user" | "assistant"; content: string };
 
 const MAX_PENDING_ENTRIES = 50;
@@ -6,11 +8,56 @@ const MAX_HISTORY_TURNS = 12;
 const MAX_HISTORY_CHARS = 32_000;
 export const MAX_SYSTEM_CONTEXT_CHARS = 2_048;
 
+/**
+ * How far history may overrun its normal cap while a compaction is in flight.
+ * Without a compactor this is never used and eviction behaves exactly as before.
+ */
+const COMPACTION_OVERRUN_FACTOR = 2;
+/** Turns handed to the compactor when the cap is crossed — the older half. */
+const COMPACT_BATCH_TURNS = Math.floor(MAX_HISTORY_TURNS / 2);
+/** Bound on the returned summary; it is model output being retained. */
+export const MAX_SUMMARY_CHARS = 4_000;
+/** Absolute deadline for one compaction. */
+const COMPACTION_TIMEOUT_MS = 30_000;
+
 const SYSTEM_CONTEXT_LABEL =
   "Host operational context for this invocation only (not conversation memory):";
+const SUMMARY_LABEL = "Summary of earlier conversation:";
 
 function tail(value: string, max: number): string {
   return value.length <= max ? value : `[earlier content truncated]\n${value.slice(-max)}`;
+}
+
+interface HistoryTurn { user: string; assistant: string }
+
+/**
+ * Summarizes a span of conversation into one paragraph. Receives the turns
+ * being retired plus the previous summary (if the history has been compacted
+ * before), so successive compactions fold into a single running summary rather
+ * than a growing stack of them.
+ */
+export type HistoryCompactor = (
+  input: { turns: readonly HistoryTurn[]; previousSummary: string | null },
+  signal: AbortSignal,
+) => Promise<string>;
+
+/**
+ * Process-wide compactor, consulted by any context without an explicit one.
+ *
+ * Each brain adapter constructs its own BrainTurnContext privately, so there is
+ * no single instance to configure. The compactor is a daemon-wide resource
+ * anyway — one summarizer endpoint shared by every lane — so it is registered
+ * once at startup rather than threaded through eight constructors and every
+ * brain wrapper (which is the forwarding trap that silently drops optional
+ * capabilities).
+ */
+let defaultCompactor: HistoryCompactor | null = null;
+
+/** Register the daemon-wide compactor. Returns a disposer that restores the previous one. */
+export function setDefaultHistoryCompactor(compactor: HistoryCompactor | null): () => void {
+  const previous = defaultCompactor;
+  defaultCompactor = compactor;
+  return () => { defaultCompactor = previous; };
 }
 
 /**
@@ -19,10 +66,46 @@ function tail(value: string, max: number): string {
  * Injected context is one-shot: it rides the next actual model/agent turn and
  * is consumed when that turn starts. Stateless adapters may also retain a
  * bounded transcript; stateful sessions disable transcript replay.
+ *
+ * The transcript is bounded. By default the oldest turns are simply dropped, so
+ * a long conversation silently forgets its beginning. Given a compactor, the
+ * older half is summarized in the BACKGROUND instead: the full turns keep
+ * serving prompts until the summary lands, then they are replaced by it. If the
+ * compactor is slow or fails, eviction still applies at a hard ceiling — the
+ * transcript can never grow without bound.
  */
 export class BrainTurnContext {
   private pending: string[] = [];
-  private history: Array<{ user: string; assistant: string }> = [];
+  private history: HistoryTurn[] = [];
+  private summary: string | null = null;
+  /**
+   * Tri-state. `undefined` = never configured, so the process-wide default
+   * applies; `null` = explicitly turned off for this context, which must NOT
+   * silently fall back to the default.
+   */
+  private compactor: HistoryCompactor | null | undefined = undefined;
+  /** In-flight compaction. Single-flight: a second trigger is a no-op. */
+  private compacting: Promise<void> | null = null;
+  /** Bumped by clear(); a compaction that started under an older one is stale. */
+  private generation = 0;
+
+  /**
+   * Enable background compaction. Without this the context evicts exactly as it
+   * always has, so this is purely additive.
+   */
+  setCompactor(compactor: HistoryCompactor | null): void {
+    this.compactor = compactor;
+  }
+
+  /** The instance compactor if one was set (including an explicit off), else the daemon-wide default. */
+  private get activeCompactor(): HistoryCompactor | null {
+    return this.compactor === undefined ? defaultCompactor : this.compactor;
+  }
+
+  /** Awaits an in-flight compaction. For shutdown drains and tests. */
+  settled(): Promise<void> {
+    return this.compacting ?? Promise.resolve();
+  }
 
   inject(context: string): void {
     const value = context.trim();
@@ -35,6 +118,10 @@ export class BrainTurnContext {
   clear(): void {
     this.pending = [];
     this.history = [];
+    this.summary = null;
+    // Invalidate any compaction already in flight. Without this it would land
+    // afterwards and reattach a summary of the conversation we just cleared.
+    this.generation += 1;
   }
 
   get pendingSize(): number {
@@ -52,13 +139,82 @@ export class BrainTurnContext {
     const reply = assistant.trim();
     if (!reply) return;
     this.history.push({ user: tail(user.trim(), 4_000), assistant: tail(reply, 8_000) });
-    if (this.history.length > MAX_HISTORY_TURNS) this.history = this.history.slice(-MAX_HISTORY_TURNS);
+
+    // With a compactor, crossing the cap starts a background summarisation and
+    // the transcript is allowed to overrun until it lands. Without one, or once
+    // the overrun ceiling is reached, the oldest turns are dropped as before.
+    if (this.activeCompactor && this.overCap()) this.beginCompaction();
+    const turnLimit = this.limit(MAX_HISTORY_TURNS);
+    const charLimit = this.limit(MAX_HISTORY_CHARS);
+    if (this.history.length > turnLimit) this.history = this.history.slice(-turnLimit);
     const chars = () => this.history.reduce((n, turn) => n + turn.user.length + turn.assistant.length, 0);
-    while (chars() > MAX_HISTORY_CHARS && this.history.length > 1) this.history.shift();
+    while (chars() > charLimit && this.history.length > 1) this.history.shift();
+  }
+
+  /** The effective ceiling: relaxed only while a compaction is actually running. */
+  private limit(base: number): number {
+    return this.compacting ? base * COMPACTION_OVERRUN_FACTOR : base;
+  }
+
+  private overCap(): boolean {
+    if (this.history.length > MAX_HISTORY_TURNS) return true;
+    return this.history.reduce((n, turn) => n + turn.user.length + turn.assistant.length, 0) > MAX_HISTORY_CHARS;
+  }
+
+  private beginCompaction(): void {
+    if (this.compacting) return; // single-flight
+    const compactor = this.activeCompactor;
+    if (!compactor) return;
+    // Capture the exact turn OBJECTS being retired. Indices are not safe: new
+    // turns arrive while this runs, and the hard ceiling may evict underneath.
+    const batch = this.history.slice(0, Math.min(COMPACT_BATCH_TURNS, this.history.length - 1));
+    if (batch.length === 0) return;
+    const previousSummary = this.summary;
+    const generation = this.generation;
+
+    const run = async (): Promise<void> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), COMPACTION_TIMEOUT_MS);
+      try {
+        const result = await compactor({ turns: batch, previousSummary }, controller.signal);
+        const summary = result.trim();
+        if (!summary) throw new Error("compactor returned nothing");
+        if (generation !== this.generation) return; // cleared while we were running
+        this.applyCompaction(batch, summary);
+      } catch (error: unknown) {
+        // Falling back to eviction is the correct failure mode: the transcript
+        // stays bounded, we just lose the older turns as we always did.
+        log("info", `History compaction failed, falling back to eviction: ${error instanceof Error ? error.message : String(error)}`);
+      } finally {
+        clearTimeout(timer);
+      }
+    };
+
+    // `tracked` must be the promise the field holds, not `run()`'s promise:
+    // comparing against the un-chained one never matches, so the latch would
+    // never clear and only the FIRST compaction would ever run.
+    const tracked: Promise<void> = run().finally(() => {
+      if (this.compacting === tracked) this.compacting = null;
+    });
+    this.compacting = tracked;
+    // Observed by settled(); never left as an unhandled rejection.
+    void tracked.catch(() => { /* run() already handled it */ });
+  }
+
+  /**
+   * Swap the summarized turns out, if they are still present. A turn already
+   * evicted by the hard ceiling is simply not found — the summary still covers
+   * it, so nothing is lost by that.
+   */
+  private applyCompaction(batch: readonly HistoryTurn[], summary: string): void {
+    const retired = new Set<HistoryTurn>(batch);
+    this.history = this.history.filter((turn) => !retired.has(turn));
+    this.summary = tail(summary, MAX_SUMMARY_CHARS);
   }
 
   buildTextPrompt(message: string, includeHistory: boolean, systemContext?: string): string {
     const sections: string[] = [];
+    if (includeHistory && this.summary) sections.push(`${SUMMARY_LABEL}\n${this.summary}`);
     if (includeHistory && this.history.length > 0) {
       sections.push(
         "Conversation so far:\n" + this.history
@@ -78,6 +234,7 @@ export class BrainTurnContext {
   buildChatMessages(message: string, systemPrompt?: string, systemContext?: string): BrainChatMessage[] {
     const messages: BrainChatMessage[] = [];
     if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
+    if (this.summary) messages.push({ role: "system", content: `${SUMMARY_LABEL}\n${this.summary}` });
     const operational = boundedSystemContext(systemContext);
     if (operational) messages.push({ role: "system", content: `${SYSTEM_CONTEXT_LABEL}\n${operational}` });
     const pending = this.takePending();

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -143,8 +143,15 @@ export class BrainTurnContext {
   }
 
   /** Awaits an in-flight compaction. For shutdown drains and tests. */
-  settled(): Promise<void> {
-    return this.compacting ?? Promise.resolve();
+  async settled(): Promise<void> {
+    // A compaction can start a follow-up pass from its own teardown, so awaiting
+    // one latch is not the same as awaiting compaction. Drain until the latch
+    // stops being replaced, or a caller resumes with work still in flight.
+    while (this.compacting) {
+      const current = this.compacting;
+      await current;
+      if (this.compacting === current) break;
+    }
   }
 
   inject(context: string): void {
@@ -235,6 +242,7 @@ export class BrainTurnContext {
     if (batch.length === 0) return;
     const previousSummary = this.summary;
     const generation = this.generation;
+    let compacted = false;
 
     const run = async (): Promise<void> => {
       const controller = new AbortController();
@@ -258,6 +266,7 @@ export class BrainTurnContext {
         if (!summary) throw new Error("compactor returned nothing");
         if (generation !== this.generation) return; // cleared while we were running
         this.applyCompaction(batch, summary);
+        compacted = true;
       } catch (error: unknown) {
         // Falling back to eviction is the correct failure mode: the transcript
         // stays bounded, we just lose the older turns as we always did.
@@ -272,10 +281,22 @@ export class BrainTurnContext {
     // never clear and only the FIRST compaction would ever run.
     const tracked: Promise<void> = run().finally(() => {
       if (this.compacting === tracked) this.compacting = null;
+      // Turns that arrived DURING the run were never in the batch, so a
+      // compaction can succeed and still leave the history over the normal
+      // ceiling. Trimming straight to that ceiling deleted those turns without
+      // ever summarizing them — precisely the loss compaction exists to
+      // prevent. Summarize them in a follow-up pass instead.
+      //
+      // Only after a SUCCESSFUL run: chaining after a failure would retry the
+      // same batch against the same broken summarizer forever. Termination is
+      // structural — every batch leaves at least one turn behind, so the chain
+      // stops as soon as there is nothing left to retire.
+      if (compacted && this.overCap()) this.beginCompaction();
       // Only now, with the latch cleared, does limit() report the normal
       // ceiling again. Trim here so a failed compaction lands back at the
       // documented bound immediately instead of sitting at 2x until the next
-      // turn happens to arrive.
+      // turn happens to arrive. A chained compaction above re-relaxes it, so
+      // this evicts only when nothing is going to summarize them.
       this.enforceLimits();
     });
     this.compacting = tracked;

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -15,6 +15,13 @@ export const MAX_SYSTEM_CONTEXT_CHARS = 2_048;
 const COMPACTION_OVERRUN_FACTOR = 2;
 /** Turns handed to the compactor when the cap is crossed — the older half. */
 const COMPACT_BATCH_TURNS = Math.floor(MAX_HISTORY_TURNS / 2);
+/**
+ * Character budget for one batch. A turn is only retired if it actually fit in
+ * the request, so a batch that would overflow the prompt is made smaller rather
+ * than sent truncated — retiring a turn whose text never reached the summarizer
+ * would delete exactly the content this feature exists to preserve.
+ */
+export const MAX_COMPACT_BATCH_CHARS = 20_000;
 /** Bound on the returned summary; it is model output being retained. */
 export const MAX_SUMMARY_CHARS = 4_000;
 /** Absolute deadline for one compaction. */
@@ -101,6 +108,12 @@ export class BrainTurnContext {
   private compacting: Promise<void> | null = null;
   /** Bumped by clear(); a compaction that started under an older one is stale. */
   private generation = 0;
+  private readonly compactionTimeoutMs: number;
+
+  /** `compactionTimeoutMs` is injectable so the deadline path is testable without a 30s test. */
+  constructor(options?: { compactionTimeoutMs?: number }) {
+    this.compactionTimeoutMs = options?.compactionTimeoutMs ?? COMPACTION_TIMEOUT_MS;
+  }
 
   /**
    * Enable background compaction. Without this the context evicts exactly as it
@@ -157,11 +170,25 @@ export class BrainTurnContext {
     // the transcript is allowed to overrun until it lands. Without one, or once
     // the overrun ceiling is reached, the oldest turns are dropped as before.
     if (this.activeCompactor && this.overCap()) this.beginCompaction();
+    this.enforceLimits();
+  }
+
+  /** Drop the oldest turns until the transcript is back under its ceiling. */
+  private enforceLimits(): void {
     const turnLimit = this.limit(MAX_HISTORY_TURNS);
     const charLimit = this.limit(MAX_HISTORY_CHARS);
     if (this.history.length > turnLimit) this.history = this.history.slice(-turnLimit);
-    const chars = () => this.history.reduce((n, turn) => n + turn.user.length + turn.assistant.length, 0);
-    while (chars() > charLimit && this.history.length > 1) this.history.shift();
+    while (this.retainedChars() > charLimit && this.history.length > 1) this.history.shift();
+  }
+
+  /**
+   * Everything this context would replay: the verbatim turns plus the running
+   * summary. The summary counts, or the documented ceiling would be a lie by
+   * however large the summary happens to be.
+   */
+  private retainedChars(): number {
+    const turns = this.history.reduce((n, turn) => n + turn.user.length + turn.assistant.length, 0);
+    return turns + (this.summary?.length ?? 0);
   }
 
   /** The effective ceiling: relaxed only while a compaction is actually running. */
@@ -171,7 +198,7 @@ export class BrainTurnContext {
 
   private overCap(): boolean {
     if (this.history.length > MAX_HISTORY_TURNS) return true;
-    return this.history.reduce((n, turn) => n + turn.user.length + turn.assistant.length, 0) > MAX_HISTORY_CHARS;
+    return this.retainedChars() > MAX_HISTORY_CHARS;
   }
 
   private beginCompaction(): void {
@@ -180,16 +207,37 @@ export class BrainTurnContext {
     if (!compactor) return;
     // Capture the exact turn OBJECTS being retired. Indices are not safe: new
     // turns arrive while this runs, and the hard ceiling may evict underneath.
-    const batch = this.history.slice(0, Math.min(COMPACT_BATCH_TURNS, this.history.length - 1));
+    const candidates = this.history.slice(0, Math.min(COMPACT_BATCH_TURNS, this.history.length - 1));
+    const batch: HistoryTurn[] = [];
+    let budget = MAX_COMPACT_BATCH_CHARS;
+    for (const turn of candidates) {
+      const cost = turn.user.length + turn.assistant.length;
+      // Always take the first turn: per-turn text is already capped well under
+      // the budget, and a batch of zero would make no progress at all.
+      if (batch.length > 0 && cost > budget) break;
+      batch.push(turn);
+      budget -= cost;
+    }
     if (batch.length === 0) return;
     const previousSummary = this.summary;
     const generation = this.generation;
 
     const run = async (): Promise<void> => {
       const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), COMPACTION_TIMEOUT_MS);
+      let expire!: (reason: Error) => void;
+      const deadline = new Promise<never>((_resolve, reject) => { expire = reject; });
+      const timer = setTimeout(() => {
+        controller.abort();
+        // Aborting only asks. A compactor that ignores its signal would other-
+        // wise hold the single-flight latch — and the relaxed ceiling — forever,
+        // so stop waiting on it here rather than trusting it to cooperate.
+        expire(new Error(`compaction exceeded ${this.compactionTimeoutMs}ms`));
+      }, this.compactionTimeoutMs);
       try {
-        const result = await compactor({ turns: batch, previousSummary }, controller.signal);
+        const result = await Promise.race([
+          compactor({ turns: batch, previousSummary }, controller.signal),
+          deadline,
+        ]);
         const summary = result.trim();
         if (!summary) throw new Error("compactor returned nothing");
         if (generation !== this.generation) return; // cleared while we were running
@@ -208,6 +256,11 @@ export class BrainTurnContext {
     // never clear and only the FIRST compaction would ever run.
     const tracked: Promise<void> = run().finally(() => {
       if (this.compacting === tracked) this.compacting = null;
+      // Only now, with the latch cleared, does limit() report the normal
+      // ceiling again. Trim here so a failed compaction lands back at the
+      // documented bound immediately instead of sitting at 2x until the next
+      // turn happens to arrive.
+      this.enforceLimits();
     });
     this.compacting = tracked;
     // Observed by settled(); never left as an unhandled rejection.

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -35,6 +35,20 @@ function tail(value: string, max: number): string {
   return value.length <= max ? value : `[earlier content truncated]\n${value.slice(-max)}`;
 }
 
+const SUMMARY_TRUNCATION_MARKER = "\n[summary truncated]";
+
+/**
+ * Bound a summary to MAX_SUMMARY_CHARS *inclusive* of its marker, so the cap is
+ * the number documented rather than that plus however long the marker is.
+ *
+ * Unlike a transcript, a summary keeps its head: it opens with what the
+ * conversation was about, and the tail is the most recent detail.
+ */
+function boundSummary(value: string): string {
+  if (value.length <= MAX_SUMMARY_CHARS) return value;
+  return value.slice(0, MAX_SUMMARY_CHARS - SUMMARY_TRUNCATION_MARKER.length) + SUMMARY_TRUNCATION_MARKER;
+}
+
 interface HistoryTurn { user: string; assistant: string }
 
 /**
@@ -277,7 +291,7 @@ export class BrainTurnContext {
   private applyCompaction(batch: readonly HistoryTurn[], summary: string): void {
     const retired = new Set<HistoryTurn>(batch);
     this.history = this.history.filter((turn) => !retired.has(turn));
-    this.summary = tail(summary, MAX_SUMMARY_CHARS);
+    this.summary = boundSummary(summary);
   }
 
   buildTextPrompt(message: string, includeHistory: boolean, systemContext?: string): string {

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -275,8 +275,14 @@ export class BrainTurnContext {
         this.applyCompaction(batch, summary);
         outcome = "applied";
       } catch (error: unknown) {
-        // Falling back to eviction is the correct failure mode: the transcript
-        // stays bounded, we just lose the older turns as we always did.
+        // A failure that belongs to a conversation which no longer exists says
+        // nothing about the current one — and the history that replaced it has
+        // never been attempted. Checking the generation only on the success path
+        // left a stale REJECTION suppressing the follow-up, so fresh turns were
+        // evicted unsummarized after a restart.
+        if (generation !== this.generation) outcome = "superseded";
+        // Otherwise, falling back to eviction is the correct failure mode: the
+        // transcript stays bounded, we just lose the older turns as we always did.
         log("info", `History compaction failed, falling back to eviction: ${error instanceof Error ? error.message : String(error)}`);
       } finally {
         clearTimeout(timer);

--- a/src/brain/turn-context.ts
+++ b/src/brain/turn-context.ts
@@ -242,7 +242,11 @@ export class BrainTurnContext {
     if (batch.length === 0) return;
     const previousSummary = this.summary;
     const generation = this.generation;
-    let compacted = false;
+    // Three outcomes, not two. A run discarded because clear() bumped the
+    // generation SUCCEEDED — it is only its result that no longer applies — so
+    // it must still hand off to a follow-up pass. Treating it as a failure left
+    // the fresh history with no compaction and let the trim below evict it.
+    let outcome: "applied" | "superseded" | "failed" = "failed";
 
     const run = async (): Promise<void> => {
       const controller = new AbortController();
@@ -264,9 +268,12 @@ export class BrainTurnContext {
         ]);
         const summary = result.trim();
         if (!summary) throw new Error("compactor returned nothing");
-        if (generation !== this.generation) return; // cleared while we were running
+        if (generation !== this.generation) {
+          outcome = "superseded"; // cleared while we were running
+          return;
+        }
         this.applyCompaction(batch, summary);
-        compacted = true;
+        outcome = "applied";
       } catch (error: unknown) {
         // Falling back to eviction is the correct failure mode: the transcript
         // stays bounded, we just lose the older turns as we always did.
@@ -287,11 +294,12 @@ export class BrainTurnContext {
       // ever summarizing them — precisely the loss compaction exists to
       // prevent. Summarize them in a follow-up pass instead.
       //
-      // Only after a SUCCESSFUL run: chaining after a failure would retry the
-      // same batch against the same broken summarizer forever. Termination is
-      // structural — every batch leaves at least one turn behind, so the chain
-      // stops as soon as there is nothing left to retire.
-      if (compacted && this.overCap()) this.beginCompaction();
+      // Only after a run that actually reached the summarizer: chaining after a
+      // failure would retry the same batch against the same broken summarizer
+      // forever. Termination is structural — every batch leaves at least one
+      // turn behind, so the chain stops as soon as there is nothing left to
+      // retire.
+      if (outcome !== "failed" && this.overCap()) this.beginCompaction();
       // Only now, with the latch cleared, does limit() report the normal
       // ceiling again. Trim here so a failed compaction lands back at the
       // documented bound immediately instead of sitting at 2x until the next

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -981,6 +981,29 @@ export async function collectChecks(
     }
   }
 
+  // -- background history compaction ----------------------------------------
+  const compaction = config.brain?.history_compaction;
+  if (compaction?.enabled) {
+    const url = compaction.summarizer_url ?? config.web_voice?.tldr?.summarizer_url;
+    if (!url) {
+      checks.push({
+        name: "history compaction",
+        level: "warn",
+        detail: "enabled but no summarizer_url is set — old turns are dropped instead of summarized",
+        hint: "set brain.history_compaction.summarizer_url (or web_voice.tldr.summarizer_url)",
+      });
+    } else {
+      checks.push((await probe(`${url.replace(/\/$/, "")}/models`))
+        ? { name: "history compaction", level: "ok", detail: url }
+        : {
+            name: "history compaction",
+            level: "warn",
+            detail: `${url} not responding — long conversations fall back to dropping their oldest turns`,
+            hint: "start the summarizer endpoint or set brain.history_compaction.enabled: false",
+          });
+    }
+  }
+
   // -- input-side tone (speech emotion) -------------------------------------
   const tone = config.tone;
   if (tone.enabled) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -45,6 +45,7 @@ import {
   supportedBackendsForRole,
 } from "../backends/supported-backends";
 import { createBrain } from "../brain";
+import { redactSnapshotSecrets } from "../operational-state";
 import { detectTerminal } from "../terminal/detect";
 import {
   WEB_VOICE_TOKEN_GENERATION_HINT,
@@ -975,9 +976,10 @@ export async function collectChecks(
     }
     const sum = wv.tldr?.summarizer_url;
     if (sum) {
+      const shownSum = redactSnapshotSecrets(sum);
       checks.push((await probe(`${sum.replace(/\/$/, "")}/models`))
-        ? { name: "tldr summarizer", level: "ok", detail: sum }
-        : { name: "tldr summarizer", level: "warn", detail: `${sum} not responding — TLDR codas fall back to a generic line`, hint: "start the summarizer endpoint or remove web_voice.tldr" });
+        ? { name: "tldr summarizer", level: "ok", detail: shownSum }
+        : { name: "tldr summarizer", level: "warn", detail: `${shownSum} not responding — TLDR codas fall back to a generic line`, hint: "start the summarizer endpoint or remove web_voice.tldr" });
     }
   }
 
@@ -993,12 +995,14 @@ export async function collectChecks(
         hint: "set brain.history_compaction.summarizer_url (or web_voice.tldr.summarizer_url)",
       });
     } else {
+      // The URL may carry userinfo or a query token; never echo it raw.
+      const shown = redactSnapshotSecrets(url);
       checks.push((await probe(`${url.replace(/\/$/, "")}/models`))
-        ? { name: "history compaction", level: "ok", detail: url }
+        ? { name: "history compaction", level: "ok", detail: shown }
         : {
             name: "history compaction",
             level: "warn",
-            detail: `${url} not responding — long conversations fall back to dropping their oldest turns`,
+            detail: `${shown} not responding — long conversations fall back to dropping their oldest turns`,
             hint: "start the summarizer endpoint or set brain.history_compaction.enabled: false",
           });
     }

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -196,18 +196,41 @@ function checkStringRecord(value: unknown, path: string, issues: string[]): void
   }
 }
 
+/**
+ * Validate a provider BASE url.
+ *
+ * Every caller appends a path to this value (`/chat/completions`, `/models`) by
+ * string concatenation, so a query or fragment does not survive: an accepted
+ * `https://api.example/v1?token=abc` becomes
+ * `https://api.example/v1?token=abc/chat/completions`, whose real path is `/v1`
+ * and whose token is `abc/chat/completions`. The intended endpoint is never
+ * requested, and the failure looks like a broken provider rather than a
+ * mis-set URL. Refuse it at config time, where the message can say what to fix.
+ *
+ * The offending value is deliberately never echoed — it is exactly the kind of
+ * URL that carries a credential.
+ */
 function checkHttpUrl(value: unknown, path: string, issues: string[]): void {
   if (typeof value !== "string" || value.trim().length === 0) {
     issues.push(`${path} must be a non-empty HTTP(S) URL`);
     return;
   }
+  let url: URL;
   try {
-    const url = new URL(value);
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      issues.push(`${path} must be a non-empty HTTP(S) URL`);
-    }
+    url = new URL(value);
   } catch {
     issues.push(`${path} must be a non-empty HTTP(S) URL`);
+    return;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    issues.push(`${path} must be a non-empty HTTP(S) URL`);
+    return;
+  }
+  if (url.search) {
+    issues.push(`${path} must not carry a query string — Cicero appends a path to it; put credentials in the API key setting instead`);
+  }
+  if (url.hash) {
+    issues.push(`${path} must not carry a fragment — Cicero appends a path to it`);
   }
 }
 

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -226,10 +226,14 @@ function checkHttpUrl(value: unknown, path: string, issues: string[]): void {
     issues.push(`${path} must be a non-empty HTTP(S) URL`);
     return;
   }
-  if (url.search) {
+  // Test the raw value, not `url.search`/`url.hash`: those are empty strings for
+  // a bare `?` or `#`, so `http://h/v1?` slipped through and still concatenated
+  // into `http://h/v1?/chat/completions`, whose real path is `/v1`. The
+  // delimiter is the problem, with or without anything after it.
+  if (value.includes("?")) {
     issues.push(`${path} must not carry a query string — Cicero appends a path to it; put credentials in the API key setting instead`);
   }
-  if (url.hash) {
+  if (value.includes("#")) {
     issues.push(`${path} must not carry a fragment — Cicero appends a path to it`);
   }
 }

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -331,6 +331,7 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     checkKnownKeys(config.brain, "brain", [
       "backend", "mode", "target_tab", "auto_approve_tools", "confirm_tools", "confirm_retry",
       "max_queue_bytes", "max_response_bytes", "max_pending_turns", "escalate", "lanes",
+      "history_compaction",
       "binary", "binary_args", "ollama_port", "ollama_model",
       "base_url", "model", "api_key", "api_key_env", "max_tokens", "timeout_ms", "turn_timeout_ms",
       "headers", "session_header", "narrate_progress", "unset_env", "agent_first", "thinking_filler",
@@ -355,6 +356,14 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     }
     for (const key of ["auto_approve_tools", "confirm_retry", "narrate_progress", "agent_first", "thinking_filler"]) {
       checkOptionalBoolean(config.brain, key, "brain", issues);
+    }
+    if (config.brain.history_compaction !== undefined
+      && checkRecord(config.brain.history_compaction, "brain.history_compaction", issues)) {
+      const compaction = config.brain.history_compaction;
+      checkKnownKeys(compaction, "brain.history_compaction", ["enabled", "summarizer_url", "summarizer_model"], issues);
+      checkOptionalBoolean(compaction, "enabled", "brain.history_compaction", issues);
+      checkOptionalHttpUrl(compaction, "summarizer_url", "brain.history_compaction", issues);
+      checkOptionalString(compaction, "summarizer_model", "brain.history_compaction", issues);
     }
     if (config.brain.ollama_port !== undefined) {
       checkInteger(config.brain.ollama_port, "brain.ollama_port", issues, { min: 1, max: 65_535 });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -743,7 +743,18 @@ export class CiceroDaemon {
         summarizer_url: compaction.summarizer_url ?? this.config.web_voice?.tldr?.summarizer_url,
         summarizer_model: compaction.summarizer_model ?? this.config.web_voice?.tldr?.summarizer_model,
       });
-      if (compactor) this.releaseCompactor = setDefaultHistoryCompactor(compactor);
+      if (compactor) {
+        // Shutdown must be able to cancel a compaction that is already in the
+        // air, not just stop new ones from starting. This controller is the
+        // daemon's handle on every request the registered compactor makes.
+        const abort = new AbortController();
+        const unregister = setDefaultHistoryCompactor((input, signal) =>
+          compactor(input, AbortSignal.any([signal, abort.signal])));
+        this.releaseCompactor = () => {
+          unregister();
+          abort.abort();
+        };
+      }
       else log("warn", "brain.history_compaction is enabled but no summarizer_url is configured — history will evict its oldest turns instead");
     }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,6 +7,8 @@ import { log, logStep, logError } from "./logger";
 import { createListener, createConversationalListener } from "./listener";
 import { createRouter } from "./router";
 import { createBrain, summarizerClassifier } from "./brain";
+import { createHistoryCompactor, createSummarizerComplete } from "./brain/history-compactor";
+import { setDefaultHistoryCompactor } from "./brain/turn-context";
 import {
   waitForBrainReadiness,
   type BrainReadinessOptions,
@@ -710,6 +712,9 @@ export class CiceroDaemon {
     }
   }
 
+  /** Releases the daemon-wide history compactor; null when compaction is off. */
+  private releaseCompactor: (() => void) | null = null;
+
   private async startComponents(): Promise<void> {
     const totalSteps = 5;
 
@@ -728,6 +733,20 @@ export class CiceroDaemon {
       builtInProviders: this.options.providerFactory === undefined
         || this.options.providerFactory === createProviders,
     });
+    // Background history compaction (opt-in). Every brain adapter builds its own
+    // private BrainTurnContext, so the compactor is registered process-wide here
+    // rather than threaded through eight constructors and every brain wrapper.
+    // Without it the transcript evicts its oldest turns exactly as it always has.
+    const compaction = this.config.brain.history_compaction;
+    if (compaction?.enabled) {
+      const compactor = createHistoryCompactor({
+        summarizer_url: compaction.summarizer_url ?? this.config.web_voice?.tldr?.summarizer_url,
+        summarizer_model: compaction.summarizer_model ?? this.config.web_voice?.tldr?.summarizer_model,
+      });
+      if (compactor) this.releaseCompactor = setDefaultHistoryCompactor(compactor);
+      else log("warn", "brain.history_compaction is enabled but no summarizer_url is configured — history will evict its oldest turns instead");
+    }
+
     const audioPlayer = createAudioPlayer();
     const audioRecorder = createAudioRecorder();
 
@@ -1073,38 +1092,9 @@ export class CiceroDaemon {
         pending: () => lastSpokenReply,
       };
       const tldrCfg = wv.tldr;
-      const summarizerUrl = tldrCfg?.summarizer_url;
       // One small-model completion helper, shared by the TLDR gate and the
       // call-minutes writer — same local summarizer endpoint for both.
-      const summarizerComplete = summarizerUrl
-        ? async (prompt: string, maxTokens: number): Promise<string> => {
-            try {
-              const res = await fetch(`${summarizerUrl.replace(/\/$/, "")}/chat/completions`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  model: tldrCfg?.summarizer_model ?? "",
-                  max_tokens: maxTokens,
-                  reasoning_effort: "none",
-                  messages: [{ role: "user", content: prompt }],
-                }),
-                signal: providerSignal(PROVIDER_TIMEOUT_MS.summarizer),
-              });
-              if (!res.ok) {
-                await discardResponseBody(res);
-                throw new Error(`summarizer ${res.status}`);
-              }
-              const data = await readBoundedJson<{
-                choices?: Array<{ message?: { content?: string } }>;
-              }>(res);
-              const line = data.choices?.[0]?.message?.content?.trim();
-              if (!line) throw new Error("summarizer returned nothing");
-              return line;
-            } catch (err: unknown) {
-              throw err;
-            }
-          }
-        : undefined;
+      const summarizerComplete = createSummarizerComplete(tldrCfg);
       const tldr = (tldrCfg?.enabled ?? true)
         ? {
             cap: tldrCfg?.spoken_sentences ?? 4,
@@ -2602,6 +2592,11 @@ export class CiceroDaemon {
     try {
       // Quiesce every scheduler/timer synchronously, then drain the briefing's
       // exact owned run before dependencies are released.
+      // Unregister before anything else so a brain that keeps running past this
+      // point (a drain, a rollback) cannot start a fresh compaction against an
+      // endpoint we are done with. In-flight ones are drained below.
+      this.releaseCompactor?.();
+      this.releaseCompactor = null;
       const briefingStop = this.briefingScheduler?.stop();
       this.promptScheduler?.stop();
       this.promptScheduler = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,6 +259,15 @@ export interface BrainConfig {
   max_queue_bytes?: number; // acp: maximum unread streamed UTF-8 text retained in memory (default 256 KiB)
   max_response_bytes?: number; // acp: maximum UTF-8 text accumulated by send(); streaming stays incremental (default 2 MiB)
   max_pending_turns?: number; // acp: maximum active + queued turns admitted to one session (default 32)
+  // Background history compaction: when the replayed transcript crosses its cap,
+  // summarize the older half through a small local model instead of dropping it.
+  // Off by default. Without a summarizer_url here it falls back to the one under
+  // web_voice.tldr; with neither, compaction stays off and eviction applies.
+  history_compaction?: {
+    enabled?: boolean;
+    summarizer_url?: string;   // e.g. http://127.0.0.1:8080/v1
+    summarizer_model?: string;
+  };
   // Think lane (acp backend): a second, heavier ACP agent that handles turns
   // containing a trigger phrase ("think hard about…"). Separate conversation —
   // suits one-shot deep questions.

--- a/tests/backends/http-transfer.test.ts
+++ b/tests/backends/http-transfer.test.ts
@@ -125,6 +125,29 @@ test("bounded JSON reads accept encoded JSON exactly at the cap", async () => {
     .toEqual({ ok: true });
 });
 
+// Codex: a bare JSON.parse here put the body into the error. The runtime quotes
+// the offending token, so an HTML error page, a proxy notice, or a leaked
+// credential arriving as a 200 travelled straight into a message that callers
+// log to the console and publish to the dashboard. Fixed at this one function
+// because every provider path parses through it, not just the cited caller.
+test("a malformed body is reported without any of its content", async () => {
+  const secret = "ghp_SYNTHETIC0000000000000000000000000000";
+  const failure = await readBoundedJson(new Response(secret), 1_024, "provider JSON response")
+    .then(() => null, (error: unknown) => error as Error);
+
+  expect(failure).toBeInstanceOf(Error);
+  expect(failure!.message).toBe("provider JSON response was not valid JSON");
+  expect(failure!.message).not.toContain(secret);
+});
+
+test("the label distinguishes which provider read failed", async () => {
+  const failure = await readBoundedJson(new Response("<html>gateway timeout</html>"), 1_024, "summarizer response")
+    .then(() => null, (error: unknown) => error as Error);
+
+  expect(failure!.message).toBe("summarizer response was not valid JSON");
+  expect(failure!.message).not.toContain("html");
+});
+
 test("error detail captures only a bounded prefix and cancels the peer", async () => {
   let cancelled = false;
   const response = new Response(new ReadableStream<Uint8Array>({

--- a/tests/brain/history-compactor.test.ts
+++ b/tests/brain/history-compactor.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHistoryCompactor, createSummarizerComplete } from "../../src/brain/history-compactor";
+import { BrainTurnContext, setDefaultHistoryCompactor } from "../../src/brain/turn-context";
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+/** Capture the outbound request and answer with a fixed completion. */
+function stubSummarizer(reply: string | { status: number }): { requests: { url: string; body: any }[] } {
+  const requests: { url: string; body: any }[] = [];
+  globalThis.fetch = (async (input: any, init?: any) => {
+    requests.push({ url: String(input), body: JSON.parse(String(init?.body ?? "{}")) });
+    if (typeof reply !== "string") {
+      return new Response("upstream detail", { status: reply.status });
+    }
+    return new Response(JSON.stringify({ choices: [{ message: { content: reply } }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { requests };
+}
+
+describe("summarizer client", () => {
+  test("no URL means no client — the feature is simply off", () => {
+    expect(createSummarizerComplete(undefined)).toBeUndefined();
+    expect(createSummarizerComplete({})).toBeUndefined();
+    expect(createHistoryCompactor({})).toBeUndefined();
+  });
+
+  test("posts to the chat-completions path with the configured model", async () => {
+    const { requests } = stubSummarizer("a line");
+    const complete = createSummarizerComplete({ summarizer_url: "http://x:1/v1/", summarizer_model: "small" })!;
+    expect(await complete("hello", 40)).toBe("a line");
+    expect(requests[0]!.url).toBe("http://x:1/v1/chat/completions");
+    expect(requests[0]!.body.model).toBe("small");
+    expect(requests[0]!.body.max_tokens).toBe(40);
+  });
+
+  // The URL can carry credentials; only the status is safe to put in an error.
+  test("an error surfaces the status, never the URL or the response body", async () => {
+    stubSummarizer({ status: 401 });
+    const complete = createSummarizerComplete({ summarizer_url: "http://user:hunter2@x:1/v1" })!;
+    await expect(complete("hello", 40)).rejects.toThrow(/^summarizer 401$/);
+  });
+
+  test("an empty completion is an error, not an empty summary", async () => {
+    stubSummarizer("   ");
+    const complete = createSummarizerComplete({ summarizer_url: "http://x:1/v1" })!;
+    await expect(complete("hello", 40)).rejects.toThrow(/returned nothing/);
+  });
+});
+
+describe("history compactor", () => {
+  test("sends the retired turns and folds in the previous summary", async () => {
+    const { requests } = stubSummarizer("folded summary");
+    const compactor = createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!;
+    const out = await compactor(
+      { turns: [{ user: "where is the config", assistant: "in config.yaml" }], previousSummary: "earlier: they set up TTS" },
+      new AbortController().signal,
+    );
+    expect(out).toBe("folded summary");
+    const prompt: string = requests[0]!.body.messages[0].content;
+    expect(prompt).toContain("where is the config");
+    expect(prompt).toContain("in config.yaml");
+    expect(prompt).toContain("earlier: they set up TTS");
+    // It must fold, not stack — the instruction has to say so.
+    expect(prompt).toContain("do not simply append");
+  });
+
+  test("with no previous summary the fold instruction is omitted", async () => {
+    const { requests } = stubSummarizer("s");
+    const compactor = createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!;
+    await compactor({ turns: [{ user: "u", assistant: "a" }], previousSummary: null }, new AbortController().signal);
+    expect(requests[0]!.body.messages[0].content).not.toContain("do not simply append");
+  });
+
+  test("the prompt is bounded even when the turns are enormous", async () => {
+    const { requests } = stubSummarizer("s");
+    const compactor = createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!;
+    await compactor(
+      { turns: [{ user: "x".repeat(100_000), assistant: "y".repeat(100_000) }], previousSummary: null },
+      new AbortController().signal,
+    );
+    const prompt: string = requests[0]!.body.messages[0].content;
+    expect(prompt.length).toBeLessThan(25_000);
+    expect(prompt).toContain("[excerpt truncated]");
+  });
+
+  test("the caller's abort signal cancels the request", async () => {
+    globalThis.fetch = ((_input: any, init?: any) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      })) as typeof fetch;
+    const compactor = createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!;
+    const controller = new AbortController();
+    const pending = compactor({ turns: [{ user: "u", assistant: "a" }], previousSummary: null }, controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toThrow();
+  });
+});
+
+describe("process-wide registration", () => {
+  test("a context with no compactor of its own uses the registered default", async () => {
+    stubSummarizer("the registered default ran");
+    const release = setDefaultHistoryCompactor(createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!);
+    try {
+      const ctx = new BrainTurnContext();
+      for (let i = 0; i < 13; i += 1) ctx.remember(`q${i}`, `a${i}`);
+      await ctx.settled();
+      expect(ctx.buildTextPrompt("now", true)).toContain("the registered default ran");
+    } finally {
+      release();
+    }
+  });
+
+  test("releasing restores plain eviction for contexts created afterwards", async () => {
+    stubSummarizer("should not appear");
+    setDefaultHistoryCompactor(createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!)();
+    const ctx = new BrainTurnContext();
+    for (let i = 0; i < 20; i += 1) ctx.remember(`q${i}`, `a${i}`);
+    await ctx.settled();
+    const text = ctx.buildTextPrompt("now", true);
+    expect(text).not.toContain("should not appear");
+    expect(text).not.toContain("q0");
+  });
+
+  // An explicit off must not silently fall back to the process-wide default.
+  test("setCompactor(null) turns compaction off for that context", async () => {
+    stubSummarizer("default summary");
+    const release = setDefaultHistoryCompactor(createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!);
+    try {
+      const ctx = new BrainTurnContext();
+      ctx.setCompactor(null);
+      for (let i = 0; i < 20; i += 1) ctx.remember(`q${i}`, `a${i}`);
+      await ctx.settled();
+      const text = ctx.buildTextPrompt("now", true);
+      expect(text).not.toContain("default summary");
+      expect(text).not.toContain("q0");
+    } finally {
+      release();
+    }
+  });
+
+  // An instance compactor is the explicit choice and must win.
+  test("an explicit per-context compactor overrides the default", async () => {
+    stubSummarizer("default summary");
+    const release = setDefaultHistoryCompactor(createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!);
+    try {
+      const ctx = new BrainTurnContext();
+      ctx.setCompactor(async () => "instance summary");
+      for (let i = 0; i < 13; i += 1) ctx.remember(`q${i}`, `a${i}`);
+      await ctx.settled();
+      const text = ctx.buildTextPrompt("now", true);
+      expect(text).toContain("instance summary");
+      expect(text).not.toContain("default summary");
+    } finally {
+      release();
+    }
+  });
+});

--- a/tests/brain/history-compactor.test.ts
+++ b/tests/brain/history-compactor.test.ts
@@ -49,6 +49,25 @@ describe("summarizer client", () => {
     await expect(complete("hello", 40)).rejects.toThrow(/^summarizer 401$/);
   });
 
+  // Codex: readBoundedJson used a bare JSON.parse, and the runtime quotes the
+  // offending token in its message. A 200 that is not JSON at all put the body
+  // verbatim into an Error the caller logs to the console AND publishes to the
+  // dashboard. Provider bodies are an explicit trust boundary.
+  test("a malformed 200 body never reaches the error message", async () => {
+    const secret = "ghp_SYNTHETIC0000000000000000000000000000";
+    globalThis.fetch = (async () => new Response(secret, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+    const complete = createSummarizerComplete({ summarizer_url: "http://x:1/v1" })!;
+
+    const failure = await complete("hello", 40).then(() => null, (error: unknown) => error as Error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure!.message).not.toContain(secret);
+    expect(failure!.message).not.toContain("ghp_");
+    expect(failure!.message).toMatch(/was not valid JSON/);
+  });
+
   test("an empty completion is an error, not an empty summary", async () => {
     stubSummarizer("   ");
     const complete = createSummarizerComplete({ summarizer_url: "http://x:1/v1" })!;

--- a/tests/brain/history-compactor.test.ts
+++ b/tests/brain/history-compactor.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHistoryCompactor, createSummarizerComplete } from "../../src/brain/history-compactor";
-import { BrainTurnContext, setDefaultHistoryCompactor } from "../../src/brain/turn-context";
+import {
+  BrainTurnContext,
+  MAX_COMPACT_BATCH_CHARS,
+  MAX_SUMMARY_CHARS,
+  setDefaultHistoryCompactor,
+} from "../../src/brain/turn-context";
 
 const realFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = realFetch; });
@@ -82,8 +87,10 @@ describe("history compactor", () => {
       { turns: [{ user: "x".repeat(100_000), assistant: "y".repeat(100_000) }], previousSummary: null },
       new AbortController().signal,
     );
+    // The guard is derived from the caller's own bounds; a well-formed batch
+    // never reaches it, but an unbounded caller must still be cut off.
     const prompt: string = requests[0]!.body.messages[0].content;
-    expect(prompt.length).toBeLessThan(25_000);
+    expect(prompt.length).toBeLessThan(MAX_COMPACT_BATCH_CHARS + MAX_SUMMARY_CHARS + 4_100);
     expect(prompt).toContain("[excerpt truncated]");
   });
 

--- a/tests/brain/history-compactor.test.ts
+++ b/tests/brain/history-compactor.test.ts
@@ -125,6 +125,29 @@ describe("process-wide registration", () => {
     expect(text).not.toContain("q0");
   });
 
+  // A daemon restart re-registers before the old instance finishes stopping.
+  // If release restored "whatever was there before", it would wipe the new one.
+  test("a late release does not clobber a newer registration", async () => {
+    stubSummarizer("old");
+    const releaseOld = setDefaultHistoryCompactor(createHistoryCompactor({ summarizer_url: "http://x:1/v1" })!);
+    const releaseNew = setDefaultHistoryCompactor(async () => "new registration");
+    releaseOld(); // out of order, after the newer one took over
+    try {
+      const ctx = new BrainTurnContext();
+      for (let i = 0; i < 13; i += 1) ctx.remember(`q${i}`, `a${i}`);
+      await ctx.settled();
+      expect(ctx.buildTextPrompt("now", true)).toContain("new registration");
+    } finally {
+      releaseNew();
+    }
+  });
+
+  test("releasing twice is harmless", () => {
+    const release = setDefaultHistoryCompactor(async () => "s");
+    release();
+    expect(() => release()).not.toThrow();
+  });
+
   // An explicit off must not silently fall back to the process-wide default.
   test("setCompactor(null) turns compaction off for that context", async () => {
     stubSummarizer("default summary");

--- a/tests/brain/turn-context-compaction.test.ts
+++ b/tests/brain/turn-context-compaction.test.ts
@@ -263,18 +263,29 @@ describe("history compaction", () => {
     expect(turns).toBeLessThanOrEqual(12);
   });
 
-  // The documented 2x ceiling has to count everything that gets replayed.
+  // The documented ceiling has to count everything that gets replayed.
   test("the running summary counts toward the character ceiling", async () => {
     const ctx = new BrainTurnContext();
     ctx.setCompactor(async () => "S".repeat(MAX_SUMMARY_CHARS));
     for (let i = 0; i < 13; i += 1) ctx.remember(`u${i}`.padEnd(1_500, "x"), `a${i}`.padEnd(1_500, "y"));
     await ctx.settled();
-    // Push well past the cap with the summary now in place.
-    for (let i = 0; i < 20; i += 1) {
-      ctx.remember(`later${i}`.padEnd(1_500, "x"), `reply${i}`.padEnd(1_500, "y"));
-      await ctx.settled();
-    }
-    const state = ctx as unknown as { retainedChars: () => number };
-    expect(state.retainedChars()).toBeLessThanOrEqual(32_000);
+
+    // With the summary in place, turn compaction off so plain eviction is what
+    // enforces the ceiling — otherwise compaction keeps trimming first and the
+    // char accounting is never what binds.
+    ctx.setCompactor(null);
+    for (let i = 0; i < 30; i += 1) ctx.remember(`later${i}`.padEnd(1_500, "x"), `reply${i}`.padEnd(1_500, "y"));
+
+    // Measured independently of retainedChars(), or this would just assert that
+    // the helper agrees with itself and pass with the accounting removed.
+    const state = ctx as unknown as {
+      history: { user: string; assistant: string }[];
+      summary: string | null;
+    };
+    expect(state.summary).not.toBeNull();
+    const replayed = state.history.reduce((n, t) => n + t.user.length + t.assistant.length, 0)
+      + (state.summary?.length ?? 0);
+    expect(replayed).toBeLessThanOrEqual(32_000);
   });
+
 });

--- a/tests/brain/turn-context-compaction.test.ts
+++ b/tests/brain/turn-context-compaction.test.ts
@@ -334,3 +334,41 @@ test("a failing compactor is not retried in a loop by the follow-up pass", async
   expect(calls).toBe(afterFirst);
   expect(calls).toBeLessThan(5);
 });
+
+// Round 3 (Codex): a brain restart calls clear() while a compaction is in
+// flight. That run is discarded on generation mismatch — which is a SUCCESS
+// whose result no longer applies, not a failure — but it was counted as a
+// failure, so no follow-up pass ran and the trim evicted fresh turns that had
+// never been summarized.
+test("a compaction discarded by clear() still hands off to a follow-up pass", async () => {
+  const sent: string[] = [];
+  let releaseStale!: () => void;
+  const stale = new Promise<void>((resolve) => { releaseStale = resolve; });
+  let runs = 0;
+
+  const ctx = new BrainTurnContext();
+  ctx.setCompactor(async ({ turns }) => {
+    runs += 1;
+    for (const turn of turns) sent.push(turn.user);
+    if (runs === 1) await stale;
+    return `summary ${runs}`;
+  });
+
+  // A conversation that trips compaction, then a restart mid-flight.
+  for (let i = 0; i < 13; i += 1) ctx.remember(`old${i}`, `a${i}`);
+  ctx.clear();
+
+  // Fresh turns pile up past the cap while the stale request is still open.
+  for (let i = 0; i < 13; i += 1) ctx.remember(`fresh${i}`, `b${i}`);
+  releaseStale();
+  await ctx.settled();
+
+  // fresh0 must be accounted for: summarized, or still in the transcript.
+  const text = prompt(ctx);
+  const retained = text.includes("fresh0");
+  const summarized = sent.includes("fresh0");
+  expect({ retained, summarized, accountedFor: retained || summarized })
+    .toEqual({ retained, summarized, accountedFor: true });
+  // And the stale summary never reattached to the new conversation.
+  expect(text).not.toContain("summary 1");
+});

--- a/tests/brain/turn-context-compaction.test.ts
+++ b/tests/brain/turn-context-compaction.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+import { BrainTurnContext, MAX_SUMMARY_CHARS, type HistoryCompactor } from "../../src/brain/turn-context";
+
+/** Fill the context past its 12-turn cap. */
+function fill(ctx: BrainTurnContext, count: number, prefix = "q"): void {
+  for (let i = 0; i < count; i += 1) ctx.remember(`${prefix}${i}`, `a${i}`);
+}
+
+const prompt = (ctx: BrainTurnContext): string => ctx.buildTextPrompt("now", true);
+
+describe("history compaction", () => {
+  // The whole point: without a compactor, turn 13 silently deletes turn 1.
+  test("without a compactor the oldest turns are still evicted, exactly as before", () => {
+    const ctx = new BrainTurnContext();
+    fill(ctx, 20);
+    const text = prompt(ctx);
+    expect(text).not.toContain("q0");
+    expect(text).toContain("q19");
+    expect(text).not.toContain("Summary of earlier conversation");
+  });
+
+  test("a compactor replaces the older turns with a summary instead of dropping them", async () => {
+    const seen: string[][] = [];
+    const compactor: HistoryCompactor = async ({ turns }) => {
+      seen.push(turns.map((t) => t.user));
+      return "The user asked about the early topics.";
+    };
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(compactor);
+    fill(ctx, 13);
+    await ctx.settled();
+
+    const text = prompt(ctx);
+    expect(text).toContain("Summary of earlier conversation:");
+    expect(text).toContain("The user asked about the early topics.");
+    // The summarized turns are gone from the verbatim transcript...
+    expect(text).not.toContain("User: q0\n");
+    // ...and the recent ones are still there in full.
+    expect(text).toContain("q12");
+    // It summarized the older half, not everything.
+    expect(seen[0]).toEqual(["q0", "q1", "q2", "q3", "q4", "q5"]);
+  });
+
+  test("the summary is carried into chat-message form too", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => "earlier: they discussed deployment");
+    fill(ctx, 13);
+    await ctx.settled();
+
+    const messages = ctx.buildChatMessages("now", "SYSTEM");
+    const summaries = messages.filter((m) => m.role === "system" && m.content.includes("Summary of earlier"));
+    expect(summaries.length).toBe(1);
+    expect(summaries[0]!.content).toContain("they discussed deployment");
+    // The system prompt still leads.
+    expect(messages[0]).toEqual({ role: "system", content: "SYSTEM" });
+  });
+
+  // Single-flight: a second trigger while one is running must not start another.
+  test("only one compaction runs at a time", async () => {
+    let started = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => {
+      started += 1;
+      await gate;
+      return "summary";
+    });
+
+    fill(ctx, 13);
+    expect(started).toBe(1);
+    fill(ctx, 6, "later"); // keeps crossing the cap while the first is in flight
+    expect(started).toBe(1);
+
+    release();
+    await ctx.settled();
+    expect(started).toBe(1);
+  });
+
+  // The full turns must keep serving prompts until the summary actually lands —
+  // otherwise compaction is just eviction with extra steps.
+  test("history is served in full while the compaction is still running", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => { await gate; return "summary"; });
+
+    fill(ctx, 13);
+    const during = prompt(ctx);
+    expect(during).toContain("q0");   // not yet dropped
+    expect(during).not.toContain("Summary of earlier conversation");
+
+    release();
+    await ctx.settled();
+    const after = prompt(ctx);
+    expect(after).not.toContain("User: q0\n");
+    expect(after).toContain("Summary of earlier conversation");
+  });
+
+  // The transcript must stay bounded even if the compactor never returns.
+  test("a compactor that never finishes cannot grow the transcript without bound", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(() => new Promise<string>(() => { /* never settles */ }));
+    fill(ctx, 200);
+
+    const text = prompt(ctx);
+    const turns = (text.match(/User: /g) ?? []).length;
+    // Relaxed to 2x the normal 12-turn cap while compacting, and no further.
+    expect(turns).toBeLessThanOrEqual(24);
+    expect(text).not.toContain("User: q0\n");
+  });
+
+  test("a failing compactor degrades to plain eviction", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => { throw new Error("summarizer down"); });
+    fill(ctx, 13);
+    await ctx.settled();
+
+    const text = prompt(ctx);
+    expect(text).not.toContain("Summary of earlier conversation");
+    expect(text).toContain("q12");
+    // And it recovers: a later compaction can still succeed.
+    ctx.setCompactor(async () => "recovered summary");
+    fill(ctx, 13, "second");
+    await ctx.settled();
+    expect(prompt(ctx)).toContain("recovered summary");
+  });
+
+  test("an empty summary is treated as a failure, not stored", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => "   ");
+    fill(ctx, 13);
+    await ctx.settled();
+    expect(prompt(ctx)).not.toContain("Summary of earlier conversation");
+  });
+
+  // Successive compactions fold into one running summary rather than stacking.
+  test("a later compaction receives the previous summary and replaces it", async () => {
+    const previous: (string | null)[] = [];
+    const ctx = new BrainTurnContext();
+    let round = 0;
+    ctx.setCompactor(async ({ previousSummary }) => {
+      previous.push(previousSummary);
+      round += 1;
+      return `summary round ${round}`;
+    });
+
+    fill(ctx, 13, "first");
+    await ctx.settled();
+    fill(ctx, 13, "second");
+    await ctx.settled();
+
+    expect(previous[0]).toBeNull();
+    expect(previous[1]).toBe("summary round 1");
+    const text = prompt(ctx);
+    expect(text).toContain("summary round 2");
+    expect(text).not.toContain("summary round 1"); // replaced, not stacked
+  });
+
+  test("an oversized summary is bounded before it is retained", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => "x".repeat(MAX_SUMMARY_CHARS + 5_000));
+    fill(ctx, 13);
+    await ctx.settled();
+    const text = prompt(ctx);
+    expect(text).toContain("earlier content truncated");
+    expect(text.length).toBeLessThan(MAX_SUMMARY_CHARS + 20_000);
+  });
+
+  // clear() must not let a compaction started before it resurrect old content.
+  test("clear() discards a compaction that was already in flight", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => { await gate; return "stale summary"; });
+
+    fill(ctx, 13);
+    ctx.clear();
+    release();
+    await ctx.settled();
+
+    ctx.remember("fresh", "reply");
+    const text = prompt(ctx);
+    expect(text).not.toContain("stale summary");
+    expect(text).toContain("fresh");
+  });
+
+  test("the compactor is given the turns verbatim", async () => {
+    let received: readonly { user: string; assistant: string }[] = [];
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async ({ turns }) => { received = turns; return "s"; });
+    fill(ctx, 13);
+    await ctx.settled();
+    expect(received[0]).toEqual({ user: "q0", assistant: "a0" });
+  });
+
+  test("setting the compactor back to null restores plain eviction", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => "should not appear");
+    ctx.setCompactor(null);
+    fill(ctx, 20);
+    await ctx.settled();
+    expect(prompt(ctx)).not.toContain("Summary of earlier conversation");
+  });
+});

--- a/tests/brain/turn-context-compaction.test.ts
+++ b/tests/brain/turn-context-compaction.test.ts
@@ -372,3 +372,51 @@ test("a compaction discarded by clear() still hands off to a follow-up pass", as
   // And the stale summary never reattached to the new conversation.
   expect(text).not.toContain("summary 1");
 });
+
+// Round 4 (Codex): the same restart hazard through the FAILURE path. The
+// generation was only checked after a successful summary, so a stale rejection
+// (a delayed HTTP 500 arriving after clear()) counted as a real failure and
+// suppressed the follow-up — evicting fresh post-restart turns unsummarized.
+test("a stale compaction that FAILS still hands off to a follow-up pass", async () => {
+  const sent: string[] = [];
+  let rejectStale!: (error: Error) => void;
+  const stale = new Promise<never>((_resolve, reject) => { rejectStale = reject; });
+  let runs = 0;
+
+  const ctx = new BrainTurnContext();
+  ctx.setCompactor(async ({ turns }) => {
+    runs += 1;
+    for (const turn of turns) sent.push(turn.user);
+    if (runs === 1) await stale; // never resolves; rejects below
+    return `summary ${runs}`;
+  });
+
+  for (let i = 0; i < 13; i += 1) ctx.remember(`old${i}`, `a${i}`);
+  ctx.clear();
+  for (let i = 0; i < 13; i += 1) ctx.remember(`fresh${i}`, `b${i}`);
+
+  // The stale request finally answers — with an error, after the restart.
+  rejectStale(new Error("summarizer 500"));
+  await ctx.settled();
+
+  const text = prompt(ctx);
+  const retained = text.includes("fresh0");
+  const summarized = sent.includes("fresh0");
+  expect({ retained, summarized, accountedFor: retained || summarized })
+    .toEqual({ retained, summarized, accountedFor: true });
+});
+
+// ...but a failure on the CURRENT generation must still stop the chain, or a
+// broken summarizer is retried against the same batch forever.
+test("a live failure still degrades to eviction without retrying in a loop", async () => {
+  let calls = 0;
+  const ctx = new BrainTurnContext();
+  ctx.setCompactor(async () => { calls += 1; throw new Error("summarizer down"); });
+  for (let i = 0; i < 13; i += 1) ctx.remember(`u${i}`.padEnd(4_000, "x"), `a${i}`.padEnd(8_000, "y"));
+  await ctx.settled();
+
+  const afterFirst = calls;
+  await ctx.settled();
+  expect(calls).toBe(afterFirst);
+  expect(calls).toBeLessThan(5);
+});

--- a/tests/brain/turn-context-compaction.test.ts
+++ b/tests/brain/turn-context-compaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { BrainTurnContext, MAX_SUMMARY_CHARS, type HistoryCompactor } from "../../src/brain/turn-context";
+import { BrainTurnContext, MAX_COMPACT_BATCH_CHARS, MAX_SUMMARY_CHARS, type HistoryCompactor } from "../../src/brain/turn-context";
 
 /** Fill the context past its 12-turn cap. */
 function fill(ctx: BrainTurnContext, count: number, prefix = "q"): void {
@@ -201,5 +201,80 @@ describe("history compaction", () => {
     fill(ctx, 20);
     await ctx.settled();
     expect(prompt(ctx)).not.toContain("Summary of earlier conversation");
+  });
+
+  // Regressions for defects found in review.
+
+  // Retiring a turn whose text never reached the summarizer deletes exactly the
+  // content compaction exists to preserve.
+  test("a batch is sized so every turn it retires actually fit in the request", async () => {
+    let sent: readonly { user: string; assistant: string }[] = [];
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async ({ turns }) => { sent = turns; return "summary"; });
+    // Each turn is capped at 4k user + 8k assistant, so these are near-maximal.
+    for (let i = 0; i < 13; i += 1) ctx.remember(`u${i}`.padEnd(4_000, "x"), `a${i}`.padEnd(8_000, "y"));
+    await ctx.settled();
+
+    const sentChars = sent.reduce((n, t) => n + t.user.length + t.assistant.length, 0);
+    expect(sent.length).toBeGreaterThan(0);
+    expect(sentChars).toBeLessThanOrEqual(MAX_COMPACT_BATCH_CHARS);
+    // Nothing that was dropped from the transcript is missing from the batch:
+    // every turn still present, plus every turn sent, accounts for all of them.
+    const text = ctx.buildTextPrompt("now", true);
+    for (const turn of sent) expect(text).not.toContain(turn.assistant);
+  });
+
+  // A failure must land back at the normal ceiling, not sit at the relaxed one.
+  test("a failed compaction trims back to the normal cap without waiting for another turn", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => { throw new Error("summarizer down"); });
+    for (let i = 0; i < 24; i += 1) {
+      ctx.remember(`q${i}`, `a${i}`);
+      await ctx.settled();
+    }
+    const turns = (ctx.buildTextPrompt("now", true).match(/User: /g) ?? []).length;
+    expect(turns).toBeLessThanOrEqual(12);
+  });
+
+  // Aborting only asks. A compactor that ignores its signal must not hold the
+  // single-flight latch, and the relaxed ceiling, forever.
+  test("a compactor that ignores its abort signal still releases the latch at the deadline", async () => {
+    let calls = 0;
+    let sawAbort = false;
+    const ctx = new BrainTurnContext({ compactionTimeoutMs: 20 });
+    ctx.setCompactor((_input, signal) => {
+      calls += 1;
+      signal.addEventListener("abort", () => { sawAbort = true; });
+      return new Promise<string>(() => { /* never settles, ignores abort */ });
+    });
+
+    for (let i = 0; i < 13; i += 1) ctx.remember(`q${i}`, `a${i}`);
+    expect(calls).toBe(1);
+    await ctx.settled();          // returns once the deadline fires, not never
+    expect(sawAbort).toBe(true);
+
+    // The latch is free, so a later crossing can compact again...
+    ctx.setCompactor(async () => "recovered");
+    for (let i = 0; i < 13; i += 1) ctx.remember(`later${i}`, `reply${i}`);
+    await ctx.settled();
+    expect(ctx.buildTextPrompt("now", true)).toContain("recovered");
+    // ...and the relaxed ceiling was given back.
+    const turns = (ctx.buildTextPrompt("now", true).match(/User: /g) ?? []).length;
+    expect(turns).toBeLessThanOrEqual(12);
+  });
+
+  // The documented 2x ceiling has to count everything that gets replayed.
+  test("the running summary counts toward the character ceiling", async () => {
+    const ctx = new BrainTurnContext();
+    ctx.setCompactor(async () => "S".repeat(MAX_SUMMARY_CHARS));
+    for (let i = 0; i < 13; i += 1) ctx.remember(`u${i}`.padEnd(1_500, "x"), `a${i}`.padEnd(1_500, "y"));
+    await ctx.settled();
+    // Push well past the cap with the summary now in place.
+    for (let i = 0; i < 20; i += 1) {
+      ctx.remember(`later${i}`.padEnd(1_500, "x"), `reply${i}`.padEnd(1_500, "y"));
+      await ctx.settled();
+    }
+    const state = ctx as unknown as { retainedChars: () => number };
+    expect(state.retainedChars()).toBeLessThanOrEqual(32_000);
   });
 });

--- a/tests/brain/turn-context-compaction.test.ts
+++ b/tests/brain/turn-context-compaction.test.ts
@@ -135,38 +135,18 @@ describe("history compaction", () => {
   });
 
   // Successive compactions fold into one running summary rather than stacking.
-  test("a later compaction receives the previous summary and replaces it", async () => {
-    const previous: (string | null)[] = [];
-    const ctx = new BrainTurnContext();
-    let round = 0;
-    ctx.setCompactor(async ({ previousSummary }) => {
-      previous.push(previousSummary);
-      round += 1;
-      return `summary round ${round}`;
-    });
-
-    fill(ctx, 13, "first");
-    await ctx.settled();
-    fill(ctx, 13, "second");
-    await ctx.settled();
-
-    expect(previous[0]).toBeNull();
-    expect(previous[1]).toBe("summary round 1");
-    const text = prompt(ctx);
-    expect(text).toContain("summary round 2");
-    expect(text).not.toContain("summary round 1"); // replaced, not stacked
-  });
-
   test("an oversized summary is bounded before it is retained", async () => {
     const ctx = new BrainTurnContext();
-    ctx.setCompactor(async () => "x".repeat(MAX_SUMMARY_CHARS + 5_000));
+    ctx.setCompactor(async () => "HEAD-OF-SUMMARY " + "x".repeat(MAX_SUMMARY_CHARS + 5_000));
     fill(ctx, 13);
     await ctx.settled();
-    const text = prompt(ctx);
-    expect(text).toContain("earlier content truncated");
-    expect(text.length).toBeLessThan(MAX_SUMMARY_CHARS + 20_000);
+    const state = ctx as unknown as { summary: string | null };
+    // The cap is inclusive of the marker, not the cap plus the marker.
+    expect(state.summary!.length).toBeLessThanOrEqual(MAX_SUMMARY_CHARS);
+    expect(state.summary).toContain("[summary truncated]");
+    // A summary keeps its head; the opening is what says what this was about.
+    expect(state.summary!.startsWith("HEAD-OF-SUMMARY ")).toBe(true);
   });
-
   // clear() must not let a compaction started before it resurrect old content.
   test("clear() discards a compaction that was already in flight", async () => {
     let release!: () => void;

--- a/tests/brain/turn-context-compaction.test.ts
+++ b/tests/brain/turn-context-compaction.test.ts
@@ -58,13 +58,21 @@ describe("history compaction", () => {
   // Single-flight: a second trigger while one is running must not start another.
   test("only one compaction runs at a time", async () => {
     let started = 0;
+    let inFlight = 0;
+    let maxInFlight = 0;
     let release!: () => void;
     const gate = new Promise<void>((r) => { release = r; });
     const ctx = new BrainTurnContext();
     ctx.setCompactor(async () => {
       started += 1;
-      await gate;
-      return "summary";
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await gate;
+        return "summary";
+      } finally {
+        inFlight -= 1;
+      }
     });
 
     fill(ctx, 13);
@@ -74,7 +82,10 @@ describe("history compaction", () => {
 
     release();
     await ctx.settled();
-    expect(started).toBe(1);
+    // Single-flight means never two AT ONCE. A follow-up pass afterwards is
+    // wanted, not a violation: turns that arrived during the run were not in
+    // its batch, and evicting them instead would delete unsummarized history.
+    expect(maxInFlight).toBe(1);
   });
 
   // The full turns must keep serving prompts until the summary actually lands —
@@ -268,4 +279,58 @@ describe("history compaction", () => {
     expect(replayed).toBeLessThanOrEqual(32_000);
   });
 
+});
+
+// Round 2 (Codex): turns that arrive DURING a compaction are not in its batch,
+// so a successful run could return under the relaxed ceiling and then be trimmed
+// straight to the normal one — deleting turns that were never summarized. That
+// is the exact loss compaction exists to prevent, arriving through compaction's
+// own success path.
+test("a turn that arrived mid-compaction is summarized, never silently dropped", async () => {
+  const sent: string[] = [];
+  let releaseFirst!: () => void;
+  const firstRun = new Promise<void>((resolve) => { releaseFirst = resolve; });
+  let runs = 0;
+
+  const ctx = new BrainTurnContext();
+  ctx.setCompactor(async ({ turns }) => {
+    runs += 1;
+    for (const turn of turns) sent.push(turn.assistant);
+    if (runs === 1) await firstRun;
+    return `summary ${runs}`;
+  });
+
+  // Six small turns trip the compactor; the batch is those six.
+  for (let i = 0; i < 6; i += 1) ctx.remember(`t${i}`, `t${i}-reply`);
+  // Three near-maximal turns land while that request is still open. Together
+  // they exceed the normal ceiling but fit the relaxed one.
+  const large = ["L0", "L1", "L2"];
+  for (const tag of large) ctx.remember(tag.padEnd(4_000, "x"), `${tag}-reply`.padEnd(8_000, "y"));
+
+  releaseFirst();
+  await ctx.settled();
+
+  // Every large turn is either still in the transcript or was handed to a
+  // summarizer. None may be missing from both.
+  const text = ctx.buildTextPrompt("now", true);
+  for (const tag of large) {
+    const retained = text.includes(`${tag}-reply`.padEnd(8_000, "y"));
+    const summarized = sent.some((assistant) => assistant.startsWith(`${tag}-reply`));
+    expect({ tag, accountedFor: retained || summarized }).toEqual({ tag, accountedFor: true });
+  }
+});
+
+// The chain must not spin: a failing summarizer would otherwise be retried
+// against the same batch forever.
+test("a failing compactor is not retried in a loop by the follow-up pass", async () => {
+  let calls = 0;
+  const ctx = new BrainTurnContext();
+  ctx.setCompactor(async () => { calls += 1; throw new Error("summarizer down"); });
+  for (let i = 0; i < 13; i += 1) ctx.remember(`u${i}`.padEnd(4_000, "x"), `a${i}`.padEnd(8_000, "y"));
+  await ctx.settled();
+
+  const afterFirst = calls;
+  await ctx.settled();
+  expect(calls).toBe(afterFirst);
+  expect(calls).toBeLessThan(5);
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -623,6 +623,55 @@ describe("Config — fail-fast validation", () => {
     );
   });
 
+  // Codex: every consumer appends a path to a base URL by concatenation, so
+  // `https://api.example/v1?token=abc` became
+  // `https://api.example/v1?token=abc/chat/completions` — real path `/v1`, token
+  // `abc/chat/completions`. The intended endpoint was never requested, and it
+  // read like a broken provider rather than a mis-set URL.
+  test("rejects a base URL carrying a query string or fragment", () => {
+    expect(loadYaml([
+      "brain:",
+      "  backend: openai-compatible",
+      "  base_url: https://api.example/v1?token=abc",
+      "",
+    ].join("\n"))).toThrow(/brain\.base_url must not carry a query string/);
+
+    expect(loadYaml([
+      "brain:",
+      "  backend: openai-compatible",
+      "  base_url: https://api.example/v1#frag",
+      "",
+    ].join("\n"))).toThrow(/brain\.base_url must not carry a fragment/);
+  });
+
+  // The same validator guards every base URL, so the fix holds for all of them
+  // rather than only the summarizer the finding happened to cite.
+  test("the query rejection covers every configured base URL", () => {
+    expect(loadYaml([
+      "brain:",
+      "  history_compaction:",
+      "    summarizer_url: http://x:1/v1?token=abc",
+      "web_voice:",
+      "  tldr:",
+      "    summarizer_url: http://x:1/v1?key=abc",
+      "",
+    ].join("\n"))).toThrow(
+      /brain\.history_compaction\.summarizer_url must not carry a query string[\s\S]*web_voice\.tldr\.summarizer_url must not carry a query string/,
+    );
+  });
+
+  // The offending value is exactly the kind of URL that carries a credential.
+  test("the rejection never echoes the URL it refused", () => {
+    const failure = loadYaml([
+      "brain:",
+      "  backend: openai-compatible",
+      "  base_url: https://api.example/v1?token=SYNTHETIC_SECRET_VALUE",
+      "",
+    ].join("\n"));
+    expect(failure).toThrow(/must not carry a query string/);
+    expect(failure).not.toThrow(/SYNTHETIC_SECRET_VALUE/);
+  });
+
   test("validates audio detector thresholds and timing relationships", () => {
     expect(loadYaml([
       "turn: { threshold: -0.1, grace_attempts: 1.5, grace_max_duration: 0 }",

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -15,6 +15,7 @@ import { OvernightStore } from "../src/notify/overnight-store";
 import type { WebReplySink } from "../src/web-voice/turn";
 import type { HistoryTurn } from "../src/web-voice/history";
 import { readPairingState } from "../src/web-voice/pairing-state";
+import { hasDefaultHistoryCompactor } from "../src/brain/turn-context";
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -254,6 +255,101 @@ describe("CiceroDaemon lifecycle", () => {
     } catch (error) {
       await daemon.stop().catch(() => {});
       throw new Error(`successful lifecycle timer test failed: ${(error as Error).message}`, { cause: error });
+    }
+  });
+
+  // The compactor is registered process-wide, so a daemon that fails to start
+  // or is stopped must take it back down with it — otherwise a retired daemon's
+  // summarizer endpoint keeps serving every brain in the process.
+  test("history compaction is registered on start and unregistered on rollback", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cicero-daemon-compaction-test-"));
+    const pidFile = join(home, "cicero.pid");
+    const config = loadConfig({}, { home });
+    config.raw.headless = true;
+    config.raw.web_voice = { ...config.raw.web_voice, enabled: true };
+    config.raw.dashboard = { enabled: false };
+    config.raw.tts_enabled = false;
+    config.raw.brain = {
+      ...config.raw.brain,
+      backend: "qwen",
+      mode: "subprocess",
+      binary: process.execPath,
+      binary_args: ["-e", "console.log('ok')"],
+      thinking_filler: false,
+      history_compaction: { enabled: true, summarizer_url: "http://127.0.0.1:1/v1" },
+    };
+    let releaseProvider!: () => void;
+    const providerGate = new Promise<void>((resolve) => { releaseProvider = resolve; });
+    let signalProviderStarted!: () => void;
+    const providerStarted = new Promise<void>((resolve) => { signalProviderStarted = resolve; });
+    const daemon = new CiceroDaemon(config, {
+      pidFile,
+      providerFactory: () => ({
+        stt: {
+          name: "test-stt",
+          transcribe: () => Promise.resolve(null),
+          health: () => Promise.resolve(true),
+          start: () => Promise.resolve(),
+          stop: () => Promise.resolve(),
+        },
+        tts: {
+          name: "test-tts",
+          generateAudio: () => Promise.resolve(new ArrayBuffer(0)),
+          health: () => Promise.resolve(true),
+          start: () => Promise.resolve(),
+          stop: () => Promise.resolve(),
+        },
+        llm: {
+          name: "test-llm",
+          chatCompletion: () => Promise.resolve("ok"),
+          health: () => Promise.resolve(true),
+          start: async () => { signalProviderStarted(); await providerGate; },
+          stop: () => Promise.resolve(),
+        },
+      }),
+    });
+
+    expect(hasDefaultHistoryCompactor()).toBe(false);
+    try {
+      const startResult = daemon.start().then(() => null, (error: unknown) => error);
+      await providerStarted;
+      // Registered before the daemon is even fully up.
+      expect(hasDefaultHistoryCompactor()).toBe(true);
+
+      const stopping = daemon.stop();
+      const observedStop = stopping.then(() => undefined, () => undefined);
+      releaseProvider();
+      await startResult;
+      await observedStop;
+      expect(hasDefaultHistoryCompactor()).toBe(false);
+    } catch (error) {
+      releaseProvider();
+      await daemon.stop().catch(() => {});
+      throw new Error(`compaction registration test failed: ${(error as Error).message}`, { cause: error });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  // Enabled with nowhere to send the summary must not look like it is working.
+  test("history compaction with no summarizer URL stays unregistered", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cicero-daemon-compaction-nourl-test-"));
+    const config = loadConfig({}, { home });
+    config.raw.headless = true;
+    config.raw.web_voice = { ...config.raw.web_voice, enabled: true };
+    config.raw.dashboard = { enabled: false };
+    config.raw.tts_enabled = false;
+    config.raw.brain = { ...config.raw.brain, history_compaction: { enabled: true } };
+    const daemon = new CiceroDaemon(config, {
+      pidFile: join(home, "cicero.pid"),
+      providerFactory: () => { throw new Error("stop here"); },
+    });
+    try {
+      await expect(daemon.start()).rejects.toThrow(/stop here/);
+      expect(hasDefaultHistoryCompactor()).toBe(false);
+      await daemon.stop();
+    } finally {
+      rmSync(home, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## What

Cicero replays a bounded transcript to the brain: 12 turns or 32,000 characters. Past that, the oldest turns were **deleted**. A long conversation quietly forgot how it started, with no signal to anyone.

This affects every adapter that replays Cicero-managed history — including `claude-code`, which uses it by default. Stateful sessions (ACP, tab-inject, resumed Codex lanes) keep history in the agent itself and are untouched.

Given a summarizer endpoint, the older half is now summarized **in the background** while the conversation continues against the full, un-compacted history. When the summary lands, those turns are replaced by it. Successive compactions fold into one running summary rather than stacking.

Off by default:

```yaml
brain:
  history_compaction:
    enabled: true
    summarizer_url: http://127.0.0.1:8080/v1   # omit to reuse web_voice.tldr's
    summarizer_model: your-small-model
```

Implements Spec 2 from `docs/superpowers/specs/2026-07-28-upstream-findings.md` (PR #60), taken from `huggingface/speech-to-speech`'s `chat.py::trim_if_needed`.

## Why it is registered process-wide

Each of the eight brain adapters builds its own `private`/`protected` `BrainTurnContext`. There is no instance to configure from outside.

The alternative — threading a compactor through eight constructors and every brain wrapper — is the forwarding trap this codebase has already been bitten by twice: a wrapper that forwards a fixed set silently drops the new thing, and the feature passes its tests while doing nothing in production. The compactor is a daemon-wide resource anyway (one summarizer endpoint for every lane), so it is registered once at startup and released on every stop path, including startup rollback.

Contexts keep a tri-state override: unset uses the process default, an explicit compactor wins, and an explicit `null` means off and does **not** fall through.

## Bounds

Background work in this daemon has to be incapable of making a turn worse:

- Single-flight. A second trigger while one is in flight is a no-op.
- A turn is only retired if its text actually fit in the request. A batch that would overflow is made smaller rather than sent truncated.
- 15s on the request, 30s on the compaction as a whole — enforced by settling the wait, not by asking a compactor to honor an abort.
- Summary capped at 4,000 chars and counted toward the transcript's own character ceiling.
- History may overrun to 2× while a compaction runs and no further, then is trimmed back as soon as it settles.
- Any failure falls back to today's eviction, logs why, and stays retryable — no restart needed.
- `restart()` invalidates a compaction already in flight; daemon shutdown cancels one still in the air.

## Also

Lifts the summarizer client out of the web-voice startup block into `src/brain/history-compactor.ts`, so the TLDR gate, the call-minutes writer, and compaction share one implementation instead of one being trapped in a scope. Behavior unchanged — the removed `try/catch` only rethrew.

Redacts the summarizer URL in `doctor` output; it can carry userinfo or a query token. The adjacent tldr check had the same leak and is fixed with it.

## Review

Two Codex passes (`gpt-5.6-sol`, high).

**Round 1** found six issues on the first commit. Four were real and are fixed in `a364972`. The worst: a batch was retired in full even though the prompt builder truncated at a character cap, so oversized turns were deleted **without ever being summarized** — precisely the data loss this feature exists to prevent. The others: a failed compaction sat at the relaxed 2× ceiling until the next turn arrived; the 30s deadline only aborted a signal, so a compactor that ignored cancellation held the latch forever; and the documented character ceiling did not count the retained summary. One finding was stale (`ff91a28` had already added shutdown cancellation) and one was pre-existing repo behavior, fixed anyway.

**Round 2** verified each fix and confirmed all six correct, with one new finding: `tail()` prepends a 28-character marker, so a "4,000 character" summary was really 4,028. Fixed in `218339d` — which also changed summaries to keep their **head** rather than their tail, since a summary opens with what the conversation was about and truncating from the front discarded the part worth keeping.

Every regression was checked by reverting the fix it covers and confirming it fails. One did not, and was rewritten (`48894bf`): it called `retainedChars()` to assert `retainedChars()` was right, and its scenario let compaction do the trimming so the character ceiling was never what bound. A redundant `catch` and its test were dropped for the same reason — `Promise.race` subscribes to both promises, so a late rejection is already handled, and the test passed with and without the code it claimed to cover.

## Verification

- `bun run typecheck` clean
- `bun test` — 2076 pass, 2 fail; **both fail identically on clean `origin/main`** (an ANSI-colored stderr assertion in `terminal-send-errors`, and a "Phone pairing" row in `cli/status`). Neither is touched by this branch.
- `git diff --check` clean
- 32 new tests: compaction state machine, the summarizer client, registry lifecycle, and daemon start/rollback registration.
- No live model needed for any of them.

Docs: `docs/brains.md`, `config.yaml.example`, plus `doctor` coverage for enabled-but-unreachable and enabled-but-unconfigured.
