### PR TITLE
feat(backends): add an optional classification-only model role

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -139,10 +139,15 @@ llm:
 # reply model is far too expensive to run on every utterance. Same shape as an
 # `llm:` section. There is no default and no fallback: leave this out and the
 # features that need it stay off and log why.
+# It needs its OWN port: a local server that is already healthy on a port is
+# reused as-is, so pointing this at the reply model's port (or web_voice's, or
+# any other listener above) silently runs classification on whatever is already
+# there — or fails to bind. Cicero refuses that configuration rather than
+# pretending the model loaded.
 # classifier:
 #   backend: llama-cpp
 #   host: 127.0.0.1
-#   port: 8090
+#   port: 8093
 #   model: your-small-model
 
 brain:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -134,6 +134,17 @@ llm:
 #   brain: { backend: codex }                              # Codex CLI
 #   brain: { backend: ollama, ollama_model: qwen3.5:4b }   # fully local
 #   brain: { backend: openai-compatible, base_url: http://127.0.0.1:8080/v1, model: your-model, timeout_ms: 120000 }
+# Optional classification-only model, held apart from the reply model above.
+# Per-utterance decisions (see docs/classifier.md) need a small warm model; the
+# reply model is far too expensive to run on every utterance. Same shape as an
+# `llm:` section. There is no default and no fallback: leave this out and the
+# features that need it stay off and log why.
+# classifier:
+#   backend: llama-cpp
+#   host: 127.0.0.1
+#   port: 8090
+#   model: your-small-model
+
 brain:
   backend: acp
   binary: hermes                # install/auth this ACP agent, or replace it; see docs/brains.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ are provenance, not guidance.
 | [Daemon mode & local mic](daemon-mode.md) | Lifecycle, activation, echo cancellation, computer use on the local machine |
 | [Voice activation](voice-activation.md) | Hands-free start, claps, VAD tuning, earcons |
 | [Turn detection](turn-detection.md) | Semantic end-of-turn (Smart-Turn): what it fixes and how to enable it |
+| [The classifier backend](classifier.md) | An optional small model held apart from the reply model for per-utterance decisions |
 | [Voice cloning](voice-cloning.md) | Giving Cicero (or a lane) any voice from one reference clip |
 | [Notifications](notifications.md) | Cicero speaking up on its own: Telegram, briefings, schedules, quiet hours |
 | [Telegram calls](https://github.com/5uck1ess/cicero/blob/main/sidecars/telegram-call/README.md) | The phone-call sidecar: talk to your agent from anywhere |

--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -1,0 +1,63 @@
+# The classifier backend
+
+Cicero has one model that writes replies. Some decisions are not replies: was
+that utterance addressed to me, what kind of request is this, should this route
+somewhere else. Those run **per utterance**, and running a reply-tier model on
+every utterance is not affordable — on a single-GPU box it is not even
+schedulable alongside STT and TTS.
+
+The `classifier` role is a second, smaller model held apart for exactly that
+work. It is optional, off by default, and nothing today requires it.
+
+## Configuration
+
+Same shape as an `llm:` section:
+
+```yaml
+classifier:
+  backend: llama-cpp          # any backend the llm role supports
+  host: 127.0.0.1
+  port: 8090
+  model: your-small-model
+```
+
+A ~2B-class instruct model is the intended size. It must be **warm** — a model
+that loads on demand defeats the purpose, because the latency lands in the path
+of every utterance.
+
+Remote and local-managed both work. `host` pointing at another machine makes it
+a remote endpoint Cicero only talks to; a local backend that Cicero can launch
+is started and stopped with the daemon like any other managed provider.
+
+## What absence means
+
+Leaving the section out means the role is **unconfigured**, and every feature
+that depends on it stays off and logs the reason.
+
+It does **not** silently fall back to the reply model. That fallback is the
+failure this role exists to prevent: it would look like a working feature while
+quietly costing a full reply per utterance, and on a VRAM-tight box it would
+contend with the STT/TTS seat. There is no implicit default either — unlike
+`llm`, an absent `classifier` section resolves to nothing at all.
+
+A configured but **unsupported** backend is an error at startup, not a fallback,
+and the message names `classifier.backend` rather than `llm.backend` so it is
+clear which of the two sections is wrong.
+
+## Failure behavior
+
+The classifier is never a required primary. If it is configured and cannot
+start, the daemon logs a warning and carries on — a per-utterance helper being
+down must not stop a daemon that can still hold a conversation. Features that
+need it decline rather than guess.
+
+`cicero doctor` reports a configured-but-unreachable classifier as a warning; an
+unconfigured one is silent, since absence is a valid choice rather than a
+problem. `cicero status` shows a `Classifier` row only when the role is
+configured.
+
+## VRAM
+
+A resident classifier competes with the STT and TTS seats on a single-GPU box.
+Measure the resident cost on your hardware before enabling anything that depends
+on it — this is the reason the role ships optional rather than on.

--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -40,9 +40,10 @@ quietly costing a full reply per utterance, and on a VRAM-tight box it would
 contend with the STT/TTS seat. There is no implicit default either — unlike
 `llm`, an absent `classifier` section resolves to nothing at all.
 
-A configured but **unsupported** backend is an error at startup, not a fallback,
-and the message names `classifier.backend` rather than `llm.backend` so it is
-clear which of the two sections is wrong.
+A configured but **unsupported** backend is an error at startup, not a fallback.
+The message names the classifier (`Unknown classifier backend '<name>'`) rather
+than the reply model, so it is clear which of the two sections is wrong, and
+`cicero doctor` points at `classifier.backend` for the same reason.
 
 ## Failure behavior
 
@@ -51,10 +52,11 @@ start, the daemon logs a warning and carries on — a per-utterance helper being
 down must not stop a daemon that can still hold a conversation. Features that
 need it decline rather than guess.
 
-`cicero doctor` reports a configured-but-unreachable classifier as a warning; an
-unconfigured one is silent, since absence is a valid choice rather than a
-problem. `cicero status` shows a `Classifier` row only when the role is
-configured.
+`cicero doctor` reports a configured-but-unreachable classifier as a failing
+check, exactly as it does for an unreachable reply model — the role was asked
+for and is not there. An unconfigured one is silent, since absence is a valid
+choice rather than a problem. `cicero status` shows a `Classifier` row only when
+the role is configured.
 
 ## VRAM
 

--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -17,13 +17,19 @@ Same shape as an `llm:` section:
 classifier:
   backend: llama-cpp          # any backend the llm role supports
   host: 127.0.0.1
-  port: 8090
+  port: 8093                  # not 8090 — that is web voice's default
   model: your-small-model
 ```
 
 A ~2B-class instruct model is the intended size. It must be **warm** — a model
 that loads on demand defeats the purpose, because the latency lands in the path
-of every utterance.
+of every utterance. Cicero sends one throwaway completion to the classifier at
+startup so the model is resident before the first real one arrives; a health
+check alone would not do it, since none of the backends load a model on a health
+probe (ollama's `/api/tags` lists what is available, it does not load anything).
+The warmup is best-effort and runs in the background — startup does not wait on
+it, and a classifier that fails to answer is not fatal because every caller
+already falls back.
 
 Remote and local-managed both work. `host` pointing at another machine makes it
 a remote endpoint Cicero only talks to; a local backend that Cicero can launch

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,11 @@ llm:
   timeout_ms: 120000
 ```
 
+An optional `classifier:` section takes the same shape as `llm:` and holds a
+small model apart from the reply model for per-utterance decisions. It is off by
+default; absence means the features that need it stay off, never that they
+borrow the reply model. See [the classifier backend](classifier.md).
+
 Computer-use file tools default to the daemon's working directory, and public
 LLMs are refused unless data egress is explicitly enabled:
 
@@ -88,7 +93,8 @@ the configured backend as `llama-cpp`: Cicero launches `llama-server` with its
 Hugging Face GGUF model ID (or an explicit `.gguf` path), and does not route
 through Ollama. Install llama.cpp's `llama-server` on `PATH`; repository models
 download on first launch. TTS alternatives (cloning engines, fallback chains)
-are in [voice cloning](voice-cloning.md); brain backends in [brains](brains.md).
+are in [voice cloning](voice-cloning.md); brain backends in [brains](brains.md);
+the optional classification model in [classifier](classifier.md).
 
 ## Quick intents — your own zero-latency phrases
 

--- a/src/backends/llm/llama-cpp.ts
+++ b/src/backends/llm/llama-cpp.ts
@@ -1,4 +1,4 @@
-import { LLM_DEFAULT_MODEL, normalizedLlmModel } from "./provider";
+import { LLM_DEFAULT_MODEL, normalizedLlmModel, LLM_DEFAULT_PORTS } from "./provider";
 import type { LLMProvider, LLMProviderConfig, ChatMessage, LLMCompletionOpts } from "./provider";
 import { startManagedServer, stopManagedServer, type ManagedProcess } from "../managed-server";
 import { httpBase, isLocalHost } from "../net";
@@ -24,7 +24,7 @@ export class LlamaCppProvider implements LLMProvider {
 
   constructor(config: LLMProviderConfig) {
     this.host = config.host;
-    this.port = config.port ?? 8080; // llama-server default port
+    this.port = config.port ?? LLM_DEFAULT_PORTS["llama-cpp"]!;
     // llama-server serves whatever GGUF it loaded; the request model field is
     // informational. A concrete value is used as the -m path when auto-launching.
     // Doctor applies the same normalization before checking local launch

--- a/src/backends/llm/mlx-lm.ts
+++ b/src/backends/llm/mlx-lm.ts
@@ -1,3 +1,4 @@
+import { LLM_DEFAULT_PORTS } from "./provider";
 import type { LLMProvider, LLMProviderConfig, ChatMessage, LLMCompletionOpts } from "./provider";
 import { startManagedServer, stopManagedServer, type ManagedProcess } from "../managed-server";
 import { httpBase, isLocalHost } from "../net";
@@ -26,7 +27,7 @@ export class MlxLmProvider implements LLMProvider {
 
   constructor(config: LLMProviderConfig) {
     this.host = config.host;
-    this.port = config.port ?? 8081;
+    this.port = config.port ?? LLM_DEFAULT_PORTS["mlx-lm"]!;
     this.model = config.model ?? "mlx-community/Qwen3.5-0.8B-MLX-4bit";
     this.extra = config.extra;
     this.timeoutMs = requestTimeout(config.timeout_ms, PROVIDER_TIMEOUT_MS.llm);

--- a/src/backends/llm/ollama.ts
+++ b/src/backends/llm/ollama.ts
@@ -94,6 +94,11 @@ export class OllamaProvider implements LLMProvider {
       name: "ollama",
       port: this.port,
       command: ["ollama", "serve"],
+      // `ollama serve` has no port flag: it binds OLLAMA_HOST, defaulting to
+      // 127.0.0.1:11434. Without this, a second Ollama role configured on its
+      // own port spawns a server on the FIRST role's port, which is already
+      // taken — the child exits and that role is silently unavailable.
+      env: { OLLAMA_HOST: `${this.host}:${this.port}` },
       healthUrl: `${httpBase(this.host, this.port)}/api/tags`,
       timeoutMs: 30000,
     });

--- a/src/backends/llm/ollama.ts
+++ b/src/backends/llm/ollama.ts
@@ -1,4 +1,4 @@
-import { LLM_DEFAULT_MODEL, normalizedLlmModel } from "./provider";
+import { LLM_DEFAULT_MODEL, normalizedLlmModel, LLM_DEFAULT_PORTS } from "./provider";
 import type { LLMProvider, LLMProviderConfig, ChatMessage, LLMCompletionOpts } from "./provider";
 import { startManagedServer, stopManagedServer, type ManagedProcess } from "../managed-server";
 import { httpBase, isLocalHost } from "../net";
@@ -21,7 +21,7 @@ export class OllamaProvider implements LLMProvider {
 
   constructor(config: LLMProviderConfig) {
     this.host = config.host;
-    this.port = config.port ?? 11434;
+    this.port = config.port ?? LLM_DEFAULT_PORTS.ollama!;
     // Doctor applies the same normalization before checking /api/tags. Keep
     // launch/request identity exact so diagnostics cannot verify another model.
     this.model = normalizedLlmModel(config.model, LLM_DEFAULT_MODEL.ollama);

--- a/src/backends/llm/ollama.ts
+++ b/src/backends/llm/ollama.ts
@@ -1,7 +1,7 @@
 import { LLM_DEFAULT_MODEL, normalizedLlmModel, LLM_DEFAULT_PORTS } from "./provider";
 import type { LLMProvider, LLMProviderConfig, ChatMessage, LLMCompletionOpts } from "./provider";
 import { startManagedServer, stopManagedServer, type ManagedProcess } from "../managed-server";
-import { httpBase, isLocalHost } from "../net";
+import { httpBase, isLocalHost, hostPort } from "../net";
 import {
   PROVIDER_TIMEOUT_MS,
   providerSignal,
@@ -98,7 +98,12 @@ export class OllamaProvider implements LLMProvider {
       // 127.0.0.1:11434. Without this, a second Ollama role configured on its
       // own port spawns a server on the FIRST role's port, which is already
       // taken — the child exits and that role is silently unavailable.
-      env: { OLLAMA_HOST: `${this.host}:${this.port}` },
+      //
+      // Built from the same expression as healthUrl below. An omitted host is
+      // the common case (every tier preset leaves it out), and interpolating it
+      // raw produced the literal `undefined:11434` — a hostname Ollama tries to
+      // bind rather than its localhost default.
+      env: { OLLAMA_HOST: hostPort(this.host, this.port) },
       healthUrl: `${httpBase(this.host, this.port)}/api/tags`,
       timeoutMs: 30000,
     });

--- a/src/backends/llm/provider.ts
+++ b/src/backends/llm/provider.ts
@@ -8,6 +8,22 @@ export const LLM_DEFAULT_MODEL = {
   "llama-cpp": "local",
 } as const;
 
+/**
+ * Port a local LLM backend binds when config names none. Validation resolves
+ * endpoints through the same map the providers do, so a collision cannot hide
+ * behind an omitted port. OpenAI-compatible backends are deliberately absent:
+ * they address a base URL, not a local seat.
+ */
+export const LLM_DEFAULT_PORTS: Readonly<Record<string, number>> = Object.freeze({
+  "mlx-lm": 8081,
+  ollama: 11434,
+  "llama-cpp": 8080, // llama-server default
+});
+
+export function llmDefaultPort(backend: string | undefined): number | undefined {
+  return backend ? LLM_DEFAULT_PORTS[backend] : undefined;
+}
+
 /** The one shared normalization: trimmed config value, or the backend default. */
 export function normalizedLlmModel(model: string | undefined, fallback: string): string {
   return model?.trim() || fallback;

--- a/src/backends/llm/provider.ts
+++ b/src/backends/llm/provider.ts
@@ -9,6 +9,18 @@ export const LLM_DEFAULT_MODEL = {
 } as const;
 
 /**
+ * Backends whose server SELECTS a model per request rather than serving the one
+ * it loaded. It matters when two roles share a server: on llama-cpp the model
+ * field is informational, so leaving a second role's model unset genuinely
+ * shares whatever is loaded — while on Ollama an unset model is not "whatever is
+ * loaded", it is this backend's own default above, i.e. a DIFFERENT model the
+ * shared server may not have pulled at all.
+ */
+export function backendRoutesByModel(backend: string | undefined): boolean {
+  return backend === "ollama";
+}
+
+/**
  * Port a local LLM backend binds when config names none. Validation resolves
  * endpoints through the same map the providers do, so a collision cannot hide
  * behind an omitted port. OpenAI-compatible backends are deliberately absent:

--- a/src/backends/managed-server.ts
+++ b/src/backends/managed-server.ts
@@ -48,6 +48,12 @@ interface StartOpts {
    * gives up after 3 consecutive failed revivals (loud error each time).
    */
   supervise?: boolean;
+  /**
+   * Extra environment for the child. Some servers take no port flag and are
+   * steered only by their environment (`ollama serve` binds OLLAMA_HOST), so
+   * without this the configured port is silently ignored.
+   */
+  env?: Record<string, string>;
 }
 
 const REVIVE_BACKOFF_MS = [1000, 5000, 15000];
@@ -152,7 +158,7 @@ async function runSupervisor(
       const next = spawnOwnedProcess(opts.command, {
         stdout: "ignore",
         stderr: "pipe",
-        env: { ...process.env },
+        env: { ...process.env, ...opts.env },
         windowsHide: true,
       });
       // Publish ownership in the same synchronous turn as spawn. stop() can
@@ -446,7 +452,7 @@ export async function startManagedServer(opts: StartOpts): Promise<ManagedProces
   }
 
   const proc = spawnOwnedProcess(command, {
-    stdout: "ignore", stderr: "pipe", env: { ...process.env },
+    stdout: "ignore", stderr: "pipe", env: { ...process.env, ...opts.env },
   });
   const stderrTail = collectStderrTail(proc);
 

--- a/src/backends/net.ts
+++ b/src/backends/net.ts
@@ -79,6 +79,15 @@ export function isKeylessHost(host: string | undefined): boolean {
 }
 
 /** Build an http base URL (`http://host:port`), defaulting host to localhost. */
+/**
+ * `host:port` for a server configured with an authority rather than a URL
+ * (`OLLAMA_HOST`). Derived from httpBase so a launch and the probe that follows
+ * it cannot disagree about which endpoint the child was told to bind.
+ */
+export function hostPort(host: string | undefined, port: number): string {
+  return httpBase(host, port).slice("http://".length);
+}
+
 export function httpBase(host: string | undefined, port: number): string {
   const normalized = unbracketHost(host ?? "localhost");
   const literal = addressWithoutZone(normalized);

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -2,7 +2,7 @@ import type { RuntimeConfig } from "../config";
 import { sttEndpointKey, type STTProvider, type STTProviderConfig } from "./stt/provider";
 import { wrapSTTWithTap } from "./stt/tap";
 import type { TTSProvider, TTSProviderConfig } from "./tts/provider";
-import type { LLMProvider } from "./llm/provider";
+import type { LLMProvider, LLMProviderConfig } from "./llm/provider";
 import { MlxWhisperProvider } from "./stt/mlx-whisper";
 import { FasterWhisperProvider } from "./stt/faster-whisper";
 import { AudioCppSTTProvider } from "./stt/audiocpp";
@@ -31,16 +31,25 @@ export interface BackendProviders {
   stt: STTProvider;
   tts: TTSProvider;
   llm: LLMProvider;
+  /**
+   * Optional classification-only model, absent unless `classifier` is
+   * configured. Callers must treat absence as "the feature is off" — never as
+   * a reason to borrow {@link BackendProviders.llm}, which is sized for writing
+   * replies and far too expensive to run per utterance.
+   */
+  classifier?: LLMProvider;
 }
 
 /** A mode may need only part of the stack (for example sidecars need no STT). */
 export type BackendProviderSet = Partial<BackendProviders>;
 
 export function createProviders(config: RuntimeConfig): BackendProviders {
+  const classifier = createClassifierProvider(config);
   return {
     stt: createSTTProvider(config),
     tts: createTTSProvider(config),
     llm: createLLMProvider(config),
+    ...(classifier ? { classifier } : {}),
   };
 }
 
@@ -150,7 +159,24 @@ function buildVoiceTTSProvider(contract: VoiceProviderContract, config: TTSProvi
 }
 
 export function createLLMProvider(config: RuntimeConfig): LLMProvider {
-  const llmConfig = config.llmBackend;
+  return buildLLMProvider(config.llmBackend, "llm");
+}
+
+/**
+ * The classification-only model, or null when `classifier` is unconfigured.
+ *
+ * A configured-but-unsupported backend is an error, exactly as it is for `llm`.
+ * Silently falling back to the reply model would make an unaffordable
+ * per-utterance cost look like a working feature.
+ */
+export function createClassifierProvider(config: RuntimeConfig): LLMProvider | null {
+  const classifierConfig = config.classifierBackend;
+  if (!classifierConfig) return null;
+  return buildLLMProvider(classifierConfig, "classifier");
+}
+
+/** Shared LLM construction. `role` names the config key an error should blame. */
+function buildLLMProvider(llmConfig: LLMProviderConfig, role: "llm" | "classifier"): LLMProvider {
   // Cloud / paid / remote OpenAI-compatible brains (OpenAI, OpenRouter, Groq,
   // DeepSeek, Qwen/DashScope, Moonshot/Kimi, Zhipu/GLM, MiniMax, …).
   if (OPENAI_COMPATIBLE_BACKENDS.includes(llmConfig.backend ?? "")) {
@@ -164,8 +190,8 @@ export function createLLMProvider(config: RuntimeConfig): LLMProvider {
     case "llama-cpp":
       return new LlamaCppProvider(llmConfig);
     case "claude-api":
-      throw new Error(`LLM backend 'claude-api' is not implemented — for a cloud brain use 'openai' (or any OpenAI-compatible preset: deepseek, dashscope, moonshot, zhipu, openrouter, groq); for local use 'mlx-lm'/'ollama'/'llama-cpp'`);
+      throw new Error(`${role} backend 'claude-api' is not implemented — for a cloud brain use 'openai' (or any OpenAI-compatible preset: deepseek, dashscope, moonshot, zhipu, openrouter, groq); for local use 'mlx-lm'/'ollama'/'llama-cpp'`);
     default:
-      throw new Error(`Unknown LLM backend '${llmConfig.backend}'`);
+      throw new Error(`Unknown ${role} backend '${llmConfig.backend}'`);
   }
 }

--- a/src/backends/supported-backends.ts
+++ b/src/backends/supported-backends.ts
@@ -30,12 +30,12 @@ export function supportedBackendsForRole(
 ): readonly string[] | undefined {
   if (role === "stt" || role === "stt_fallback") return SUPPORTED_STT_BACKENDS;
   if (role === "tts" || role === "tts_fallback") return SUPPORTED_TTS_BACKENDS;
-  if (role === "llm") return SUPPORTED_LLM_BACKENDS;
+  if (role === "llm" || role === "classifier") return SUPPORTED_LLM_BACKENDS;
   return undefined;
 }
 
 export function backendConfigKey(role: string): string | undefined {
-  if (role === "stt" || role === "stt_fallback" || role === "tts" || role === "tts_fallback" || role === "llm") {
+  if (role === "stt" || role === "stt_fallback" || role === "tts" || role === "tts_fallback" || role === "llm" || role === "classifier") {
     return `${role}.backend`;
   }
   return undefined;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -501,15 +501,16 @@ async function checkLlm(
   checks: Check[],
   options: DoctorCheckOptions,
   implicitDefault: boolean,
+  role: "llm" | "classifier" = "llm",
 ): Promise<void> {
   const backend = cfg.backend ?? "unknown";
-  const validValues = supportedBackendsForRole("llm") ?? [];
+  const validValues = supportedBackendsForRole(role) ?? [];
   if (backend === "mlx-lm" || !validValues.includes(backend)) {
-    await checkEngine("llm", cfg, checks, options, implicitDefault);
+    await checkEngine(role, cfg, checks, options, implicitDefault);
     return;
   }
 
-  const label = `llm (${backend})`;
+  const label = `${role} (${backend})`;
   const record = (check: Omit<Check, "name">): void => {
     if (check.level === "ok") {
       checks.push({ name: label, ...check });
@@ -518,8 +519,8 @@ async function checkLlm(
     checks.push({
       name: label,
       ...check,
-      detail: `${implicitDefault ? "implicit " : ""}llm.backend='${backend}': ${check.detail}`,
-      hint: `${check.hint ? `${check.hint}; ` : ""}${supportedBackendHint("llm.backend", validValues)}`,
+      detail: `${implicitDefault ? "implicit " : ""}${role}.backend='${backend}': ${check.detail}`,
+      hint: `${check.hint ? `${check.hint}; ` : ""}${supportedBackendHint(`${role}.backend`, validValues)}`,
     });
   };
   const timeoutMs = options.cloudProbeTimeoutMs ?? DOCTOR_HTTP_TIMEOUT_MS;
@@ -772,6 +773,13 @@ export async function collectChecks(
   await checkEngine("tts", config.ttsBackend, checks, options, config.raw.tts === undefined);
   await checkEngine("tts_fallback", config.ttsFallbackBackend ?? undefined, checks, options);
   await checkLlm(config.llmBackend, checks, options, config.raw.llm === undefined);
+  // The classifier is optional, so absence is silent. Configured-but-unreachable
+  // is not: features that depend on it will decline turns, and the operator
+  // should learn that here rather than from a feature that quietly does nothing.
+  const classifierBackend = config.classifierBackend;
+  if (classifierBackend) {
+    await checkLlm(classifierBackend, checks, options, false, "classifier");
+  }
 
   // -- semantic end-of-turn sidecar ---------------------------------------
   const turn = config.turn;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -295,7 +295,9 @@ async function checkEngine(
   }
   const sttRole = role.startsWith("stt");
   const ttsRole = role.startsWith("tts");
-  const llmRole = role === "llm";
+  // The classifier is an LLM in every respect that matters here: same ports,
+  // same defaults, same probes. Only its config key differs.
+  const llmRole = role === "llm" || role === "classifier";
   const voiceContract = role.startsWith("tts")
     ? voiceProviderContractForBackend(cfg.backend)
     : null;
@@ -538,7 +540,7 @@ async function checkLlm(
         record({
           level: "fail",
           detail: `remote Ollama endpoint ${endpoint} is not responding with a valid model list`,
-          hint: `start Ollama on ${cfg.host} or fix llm.host/llm.port`,
+          hint: `start Ollama on ${cfg.host} or fix ${role}.host/${role}.port`,
         });
       } else if (!hasOllamaModel(models, model)) {
         record({
@@ -594,7 +596,7 @@ async function checkLlm(
         : {
             level: "fail",
             detail: `remote llama-server ${endpoint} is not responding`,
-            hint: `start llama-server on ${cfg.host} or fix llm.host/llm.port`,
+            hint: `start llama-server on ${cfg.host} or fix ${role}.host/${role}.port`,
           });
       return;
     }
@@ -604,12 +606,12 @@ async function checkLlm(
     const missing: string[] = [];
     if (!binary) missing.push("'llama-server' is not on PATH");
     if (model === LLM_DEFAULT_MODEL["llama-cpp"]) {
-      missing.push("llm.model must name a GGUF file or Hugging Face GGUF repo");
+      missing.push(`${role}.model must name a GGUF file or Hugging Face GGUF repo`);
     } else if (model.toLowerCase().endsWith(".gguf")) {
       const problem = localGgufProblem(model);
       if (problem) missing.push(problem);
     } else if (!isHuggingFaceGgufRepo(model)) {
-      missing.push(`llm.model is not a valid Hugging Face GGUF repo (expected owner/repo[:quant]): ${model}`);
+      missing.push(`${role}.model is not a valid Hugging Face GGUF repo (expected owner/repo[:quant]): ${model}`);
     }
     if (missing.length > 0) {
       record({
@@ -617,7 +619,7 @@ async function checkLlm(
         detail: up
           ? `local llama-server is healthy, but Cicero cannot relaunch it (${missing.join("; ")})`
           : `local llama.cpp launch prerequisites are incomplete (${missing.join("; ")})`,
-        hint: "install llama.cpp's llama-server on PATH and set llm.model to a readable .gguf path or owner/repo[:quant]",
+        hint: `install llama.cpp's llama-server on PATH and set ${role}.model to a readable .gguf path or owner/repo[:quant]`,
       });
     } else {
       record(up
@@ -636,7 +638,7 @@ async function checkLlm(
       record({
         level: "fail",
         detail: "the configured OpenAI-compatible base URL is invalid",
-        hint: "set llm.baseUrl to an http:// or https:// API base ending in /v1",
+        hint: `set ${role}.baseUrl to an http:// or https:// API base ending in /v1`,
       });
       return;
     }
@@ -644,7 +646,7 @@ async function checkLlm(
       record({
         level: "fail",
         detail: `unsupported OpenAI-compatible URL scheme '${parsed.protocol}'`,
-        hint: "set llm.baseUrl to an http:// or https:// API base ending in /v1",
+        hint: `set ${role}.baseUrl to an http:// or https:// API base ending in /v1`,
       });
       return;
     }
@@ -661,7 +663,7 @@ async function checkLlm(
       record({
         level: "fail",
         detail: `OpenAI-compatible endpoint ${displayBase} contains a query string or fragment, which cannot be used as an API base`,
-        hint: "remove the query/fragment and set llm.baseUrl to the API base ending in /v1",
+        hint: `remove the query/fragment and set ${role}.baseUrl to the API base ending in /v1`,
       });
       return;
     }
@@ -691,7 +693,7 @@ async function checkLlm(
       : {
           level: "fail",
           detail: `${backend} endpoint ${displayEndpoint} is not responding`,
-          hint: "check llm.baseUrl, network access, and the configured API credential",
+          hint: `check ${role}.baseUrl, network access, and the configured API credential`,
         });
     return;
   }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -655,7 +655,7 @@ async function checkLlm(
       record({
         level: "fail",
         detail: `OpenAI-compatible endpoint ${displayBase} embeds URL credentials, which the provider does not support`,
-        hint: "remove URL userinfo and configure llm.apiKey or llm.apiKeyEnv instead",
+        hint: `remove URL userinfo and configure ${role}.apiKey or ${role}.apiKeyEnv instead`,
       });
       return;
     }
@@ -676,7 +676,7 @@ async function checkLlm(
       record({
         level: "fail",
         detail: `${target.apiKeyEnv} is not set, so ${displayBase} cannot authenticate`,
-        hint: `export ${target.apiKeyEnv}=<your-key> or set llm.apiKeyEnv to the correct environment variable`,
+        hint: `export ${target.apiKeyEnv}=<your-key> or set ${role}.apiKeyEnv to the correct environment variable`,
       });
       return;
     }

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -732,6 +732,11 @@ export async function collectStatus(
     ? probePlan("TTS fallback", ttsPlan(config.ttsFallbackBackend, env), probe, timeoutMs, ttsSkip)
     : null;
   const llm = probePlan("LLM", llmPlan(config.llmBackend, env), probe, timeoutMs);
+  // Only shown when configured — the classifier is optional, and a row saying
+  // "unconfigured" on every operator's status would be noise.
+  const classifier = config.classifierBackend
+    ? probePlan("Classifier", llmPlan(config.classifierBackend, env), probe, timeoutMs)
+    : null;
   const brain = checkBrain(config, env, probe, which, isExecutable, timeoutMs);
 
   const usesTab = config.brain.mode === "tab-inject" && config.brain.backend === "claude-code";
@@ -745,13 +750,14 @@ export async function collectStatus(
     ? null
     : checkHotkey(hotkeyPath, config.hotkey, isExecutable, timeoutMs, platform);
 
-  const [daemonLineResult, sttLine, sttFallbackLine, ttsLine, ttsFallbackLine, llmLine, brainLine, terminalLines, hotkeyLine] = await Promise.all([
+  const [daemonLineResult, sttLine, sttFallbackLine, ttsLine, ttsFallbackLine, llmLine, classifierLine, brainLine, terminalLines, hotkeyLine] = await Promise.all([
     daemon,
     stt,
     sttFallback,
     tts,
     ttsFallback,
     llm,
+    classifier,
     brain,
     terminal,
     hotkey,
@@ -769,6 +775,7 @@ export async function collectStatus(
     ttsLine,
     ...(ttsFallbackLine ? [ttsFallbackLine] : []),
     llmLine,
+    ...(classifierLine ? [classifierLine] : []),
     brainLine,
     ...(terminalLines ?? []),
     ...(hotkeyLine ? [hotkeyLine] : []),

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -249,7 +249,7 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     "wake_word_enabled", "hotkey", "wispr_hotkey", "terminal", "voice", "voice_ref_audio",
     "voice_ref_text", "barge_in_enabled", "full_duplex", "aec", "silence_duration",
     "silence_threshold", "phonetic_aliases", "brain", "servers", "actions", "deployment", "stt",
-    "stt_fallback", "tts", "tts_fallback", "llm", "compute", "sidecar", "dashboard", "web_voice",
+    "stt_fallback", "tts", "tts_fallback", "llm", "classifier", "compute", "sidecar", "dashboard", "web_voice",
     "notify", "headless", "turn", "tone", "clap", "vad", "earcons",
   ], issues);
 
@@ -442,12 +442,12 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     }
   }
 
-  for (const name of ["stt", "stt_fallback", "tts", "tts_fallback", "llm"] as const) {
+  for (const name of ["stt", "stt_fallback", "tts", "tts_fallback", "llm", "classifier"] as const) {
     const provider = config[name];
     if (provider === undefined) continue;
     if (!checkRecord(provider, name, issues)) continue;
     const commonProviderKeys = ["backend", "host", "port", "model", "timeout_ms"] as const;
-    const roleProviderKeys = name === "llm"
+    const roleProviderKeys = name === "llm" || name === "classifier"
       ? ["apiKey", "apiKeyEnv", "baseUrl", "extraHeaders", "extra"] as const
       : name === "stt" || name === "stt_fallback"
         ? ["compute_type"] as const
@@ -460,7 +460,7 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     }
     if (provider.baseUrl !== undefined) checkHttpUrl(provider.baseUrl, `${name}.baseUrl`, issues);
     if (provider.extraHeaders !== undefined) checkStringRecord(provider.extraHeaders, `${name}.extraHeaders`, issues);
-    if (name === "llm" && provider.extra !== undefined) checkRecord(provider.extra, `${name}.extra`, issues);
+    if ((name === "llm" || name === "classifier") && provider.extra !== undefined) checkRecord(provider.extra, `${name}.extra`, issues);
     if (provider.responseTimeoutMs !== undefined) {
       checkInteger(provider.responseTimeoutMs, `${name}.responseTimeoutMs`, issues, {
         min: 1,

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -498,6 +498,59 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     }
   }
 
+  // A local model server that is ALREADY healthy on a port is reused as-is —
+  // startManagedServer() adopts it rather than starting a second one — and a
+  // chat request's `model` field is informational to llama-server. So pointing
+  // the classifier at a port something else already serves does not load the
+  // classifier's model; it silently classifies on whatever is listening there,
+  // and reports healthy. An explicitly configured collision is an error, not a
+  // silent fallback.
+  if (config.classifier !== undefined && isRecord(config.classifier)) {
+    const classifier = config.classifier;
+    const llm = isRecord(config.llm) ? config.llm : null;
+    const localPort = (value: unknown): number | undefined =>
+      Number.isInteger(value) ? value as number : undefined;
+    const host = (value: unknown): string =>
+      typeof value === "string" && value.trim() ? value.trim().toLowerCase() : "127.0.0.1";
+    const classifierHost = host(classifier.host);
+    const classifierPort = localPort(classifier.port);
+    // Same backend, same host, same port (explicit or both defaulted) is ONE
+    // server. Sharing it is legitimate — as long as both roles want the model
+    // that server actually loaded.
+    const sharesLlmServer = llm !== null
+      && classifier.backend === llm.backend
+      && classifierHost === host(llm.host)
+      && classifierPort === localPort(llm.port);
+    if (sharesLlmServer && classifier.model !== llm!.model) {
+      issues.push(
+        "classifier resolves to the same endpoint as llm but names a different model "
+        + `(${String(classifier.model)} vs ${String(llm!.model)}); the already-running reply server is reused, so the `
+        + "classifier model would never load. Give classifier its own port, or drop classifier.model to share the reply model.",
+      );
+    }
+    const isLoopback = classifierHost === "127.0.0.1" || classifierHost === "localhost"
+      || classifierHost === "::1" || classifierHost === "0.0.0.0";
+    if (classifierPort !== undefined && isLoopback) {
+      const others: Array<[string, unknown]> = [
+        ["web_voice", isRecord(config.web_voice) ? config.web_voice.port : undefined],
+        ["tone", isRecord(config.tone) ? config.tone.port : undefined],
+        ["stt", isRecord(config.stt) ? config.stt.port : undefined],
+        ["stt_fallback", isRecord(config.stt_fallback) ? config.stt_fallback.port : undefined],
+        ["tts", isRecord(config.tts) ? config.tts.port : undefined],
+        ["tts_fallback", isRecord(config.tts_fallback) ? config.tts_fallback.port : undefined],
+        ...(sharesLlmServer ? [] : [["llm", llm ? llm.port : undefined] as [string, unknown]]),
+      ];
+      for (const [name, port] of others) {
+        if (localPort(port) === classifierPort) {
+          issues.push(
+            `classifier.port ${classifierPort} is already used by ${name}.port; `
+            + "give the classification model a port of its own",
+          );
+        }
+      }
+    }
+  }
+
   if (checkRecord(config.actions, "actions", issues)) {
     const categories = new Set(["terminal", "cli", "brain", "local", "local-llm"]);
     const ttsModes = new Set(["full", "summary", "silent"]);

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -7,9 +7,15 @@ import {
 } from "./action-command-limits";
 import { MAX_ACP_PENDING_TURN_LIMIT, MAX_ACP_TEXT_LIMIT_BYTES } from "./brain/acp-limits";
 import {
+  sttDefaultPort,
   sttEndpointKey,
   type STTProviderConfig,
 } from "./backends/stt/provider";
+import { ttsDefaultPort } from "./backends/tts/provider";
+import { llmDefaultPort } from "./backends/llm/provider";
+
+/** A resolved network seat: what the role will actually bind or reach. */
+interface Endpoint { host: string; port: number | undefined }
 import {
   WEB_VOICE_TOKEN_GENERATION_HINT,
   webVoiceTokenProblem,
@@ -507,43 +513,113 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
   // silent fallback.
   if (config.classifier !== undefined && isRecord(config.classifier)) {
     const classifier = config.classifier;
-    const llm = isRecord(config.llm) ? config.llm : null;
-    const localPort = (value: unknown): number | undefined =>
+    const portOf = (value: unknown): number | undefined =>
       Number.isInteger(value) ? value as number : undefined;
-    const host = (value: unknown): string =>
+    const hostOf = (value: unknown): string =>
       typeof value === "string" && value.trim() ? value.trim().toLowerCase() : "127.0.0.1";
-    const classifierHost = host(classifier.host);
-    const classifierPort = localPort(classifier.port);
-    // Same backend, same host, same port (explicit or both defaulted) is ONE
-    // server. Sharing it is legitimate — as long as both roles want the model
-    // that server actually loaded.
-    const sharesLlmServer = llm !== null
-      && classifier.backend === llm.backend
-      && classifierHost === host(llm.host)
-      && classifierPort === localPort(llm.port);
-    if (sharesLlmServer && classifier.model !== llm!.model) {
+    const isLocal = (host: string): boolean =>
+      host === "127.0.0.1" || host === "localhost" || host === "::1" || host === "0.0.0.0";
+    const servers = isRecord(config.servers) ? config.servers : {};
+    const serverPort = (role: string, fallback: number): number => {
+      const entry = servers[role];
+      return (isRecord(entry) ? portOf(entry.port) : undefined) ?? fallback;
+    };
+    const section = (key: string): Record<string, unknown> | null =>
+      isRecord(config[key]) ? config[key] as Record<string, unknown> : null;
+    /** A listener only occupies a port when it is actually enabled. */
+    const enabledPort = (key: string, fallback: number): Endpoint | null => {
+      const value = section(key);
+      if (value?.enabled !== true) return null;
+      return { host: hostOf(value.host), port: portOf(value.port) ?? fallback };
+    };
+    // Round 5 (Codex): comparing the literal config values only sees the
+    // collisions an operator spelled out. Every one of these roles binds a
+    // DEFAULT when its port — or its whole section — is omitted, and that
+    // default is what the runtime actually occupies.
+    const voicePort = (key: string, backendPort: (backend: string | undefined) => number | undefined,
+      absent: number): Endpoint => {
+      const value = section(key);
+      if (!value) return { host: "127.0.0.1", port: absent };
+      return {
+        host: hostOf(value.host),
+        port: portOf(value.port) ?? backendPort(typeof value.backend === "string" ? value.backend : undefined),
+      };
+    };
+    const optionalVoicePort = (key: string,
+      backendPort: (backend: string | undefined) => number | undefined): Endpoint | null => {
+      const value = section(key);
+      if (!value) return null;
+      return {
+        host: hostOf(value.host),
+        port: portOf(value.port) ?? backendPort(typeof value.backend === "string" ? value.backend : undefined),
+      };
+    };
+
+    const classifierBackend = typeof classifier.backend === "string" ? classifier.backend : undefined;
+    const classifierEndpoint: Endpoint = {
+      host: hostOf(classifier.host),
+      port: portOf(classifier.port) ?? llmDefaultPort(classifierBackend),
+    };
+
+    // An absent `llm:` does not mean "no reply model": RuntimeConfig.llmBackend
+    // synthesizes mlx-lm on servers.router.port, and THAT is the process a
+    // classifier on the same seat would silently adopt.
+    const llmSection = section("llm");
+    const llmBackend = llmSection && typeof llmSection.backend === "string" ? llmSection.backend : undefined;
+    const llm = llmSection
+      ? {
+        backend: llmBackend,
+        model: llmSection.model,
+        host: hostOf(llmSection.host),
+        port: portOf(llmSection.port) ?? llmDefaultPort(llmBackend),
+      }
+      : {
+        backend: "mlx-lm" as string | undefined,
+        model: (isRecord(servers.router) ? servers.router.model : undefined),
+        host: "127.0.0.1",
+        port: serverPort("router", 8081),
+      };
+
+    // One host:port is one server process, whether it is on this box or a
+    // remote one — llama-server loads a single model, so a second role naming
+    // a different one there is asking for something it will never get.
+    const sharesLlmServer = classifierEndpoint.port !== undefined
+      && classifierEndpoint.port === llm.port
+      && classifierEndpoint.host === llm.host;
+    // An UNSET classifier.model is the documented way to share the reply model
+    // on purpose — it must stay accepted, or the hint below sends operators to
+    // a config this same check refuses.
+    const modelConflict = classifier.model !== undefined && classifier.model !== llm.model;
+    const backendConflict = classifierBackend !== undefined && llm.backend !== undefined
+      && classifierBackend !== llm.backend;
+    if (sharesLlmServer && (modelConflict || backendConflict)) {
+      const named = modelConflict
+        ? `names a different model (${String(classifier.model)} vs ${String(llm.model)})`
+        : `names a different backend (${String(classifierBackend)} vs ${String(llm.backend)})`;
       issues.push(
-        "classifier resolves to the same endpoint as llm but names a different model "
-        + `(${String(classifier.model)} vs ${String(llm!.model)}); the already-running reply server is reused, so the `
-        + "classifier model would never load. Give classifier its own port, or drop classifier.model to share the reply model.",
+        `classifier resolves to the same endpoint as llm (${classifierEndpoint.host}:${classifierEndpoint.port}) but ${named}; `
+        + "the already-running reply server is reused, so the classifier model would never load. "
+        + "Give classifier its own port, or drop classifier.model to share the reply model.",
       );
     }
-    const isLoopback = classifierHost === "127.0.0.1" || classifierHost === "localhost"
-      || classifierHost === "::1" || classifierHost === "0.0.0.0";
-    if (classifierPort !== undefined && isLoopback) {
-      const others: Array<[string, unknown]> = [
-        ["web_voice", isRecord(config.web_voice) ? config.web_voice.port : undefined],
-        ["tone", isRecord(config.tone) ? config.tone.port : undefined],
-        ["stt", isRecord(config.stt) ? config.stt.port : undefined],
-        ["stt_fallback", isRecord(config.stt_fallback) ? config.stt_fallback.port : undefined],
-        ["tts", isRecord(config.tts) ? config.tts.port : undefined],
-        ["tts_fallback", isRecord(config.tts_fallback) ? config.tts_fallback.port : undefined],
-        ...(sharesLlmServer ? [] : [["llm", llm ? llm.port : undefined] as [string, unknown]]),
+
+    // A port collision is about two local processes wanting one seat. A remote
+    // peer binds nothing here, so its port is not in the way.
+    if (classifierEndpoint.port !== undefined && isLocal(classifierEndpoint.host)) {
+      const others: Array<[string, Endpoint | null]> = [
+        ["web_voice", enabledPort("web_voice", 8090)],
+        ["tone", enabledPort("tone", 8091)],
+        ["turn", enabledPort("turn", 8087)],
+        ["stt", voicePort("stt", sttDefaultPort, serverPort("stt", 8083))],
+        ["stt_fallback", optionalVoicePort("stt_fallback", sttDefaultPort)],
+        ["tts", voicePort("tts", ttsDefaultPort, serverPort("tts", 8082))],
+        ["tts_fallback", optionalVoicePort("tts_fallback", ttsDefaultPort)],
+        ...(sharesLlmServer ? [] : [["llm", { host: llm.host, port: llm.port }] as [string, Endpoint]]),
       ];
-      for (const [name, port] of others) {
-        if (localPort(port) === classifierPort) {
+      for (const [name, endpoint] of others) {
+        if (endpoint && isLocal(endpoint.host) && endpoint.port === classifierEndpoint.port) {
           issues.push(
-            `classifier.port ${classifierPort} is already used by ${name}.port; `
+            `classifier.port ${classifierEndpoint.port} is already used by ${name}; `
             + "give the classification model a port of its own",
           );
         }

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -12,7 +12,7 @@ import {
   type STTProviderConfig,
 } from "./backends/stt/provider";
 import { ttsDefaultPort } from "./backends/tts/provider";
-import { llmDefaultPort } from "./backends/llm/provider";
+import { backendRoutesByModel, llmDefaultPort, LLM_DEFAULT_MODEL } from "./backends/llm/provider";
 import { OPENAI_COMPATIBLE_BACKENDS } from "./backends/llm/openai";
 
 /** A resolved network seat: what the role will actually bind or reach. */
@@ -643,17 +643,37 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     // An UNSET classifier.model is the documented way to share the reply model
     // on purpose — it must stay accepted, or the hint below sends operators to
     // a config this same check refuses.
+    // Round 9 (Codex): "drop classifier.model to share the reply model" is only
+    // true where the model field is informational. On a backend that routes by
+    // model, an UNSET model is not "whatever is loaded" — it is that backend's
+    // own default, so the remediation this check recommends produced exactly the
+    // mismatch the check exists to prevent, and startup would not notice: the
+    // shared server is adopted on a health probe that never mentions a model.
+    const unsetShareIsAmbiguous = classifier.model === undefined
+      && backendRoutesByModel(classifierBackend ?? llm.backend);
     const modelConflict = classifier.model !== undefined && classifier.model !== llm.model;
     const backendConflict = classifierBackend !== undefined && llm.backend !== undefined
       && classifierBackend !== llm.backend;
-    if (sharesLlmServer && (modelConflict || backendConflict)) {
+    if (sharesLlmServer && unsetShareIsAmbiguous) {
+      issues.push(
+        `classifier resolves to the same endpoint as llm (${classifierEndpoint.host}:${classifierEndpoint.port}) `
+        + `and names no model, but the '${String(classifierBackend ?? llm.backend)}' backend selects a model per `
+        + `request — so an unset one resolves to its default (${LLM_DEFAULT_MODEL.ollama}), not to the reply model. `
+        + `Set classifier.model to ${String(llm.model)} to share it, or give classifier its own port.`,
+      );
+    } else if (sharesLlmServer && (modelConflict || backendConflict)) {
       const named = modelConflict
         ? `names a different model (${String(classifier.model)} vs ${String(llm.model)})`
         : `names a different backend (${String(classifierBackend)} vs ${String(llm.backend)})`;
+      // The remediation differs by backend on purpose: dropping the model only
+      // shares it where the field is informational.
+      const share = backendRoutesByModel(classifierBackend ?? llm.backend)
+        ? `set classifier.model to ${String(llm.model)} to share the reply model`
+        : "drop classifier.model to share the reply model";
       issues.push(
         `classifier resolves to the same endpoint as llm (${classifierEndpoint.host}:${classifierEndpoint.port}) but ${named}; `
         + "the already-running reply server is reused, so the classifier model would never load. "
-        + "Give classifier its own port, or drop classifier.model to share the reply model.",
+        + `Give classifier its own port, or ${share}.`,
       );
     }
 

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -561,8 +561,26 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
       };
     };
 
+    // Round 7 (Codex): an OpenAI-compatible backend addresses a URL, not a
+    // host/port pair — and has no default port, so a classifier configured only
+    // with baseUrl resolved to `port: undefined` and skipped every comparison
+    // below. It is the same seat either way: `baseUrl: http://127.0.0.1:8080/v1`
+    // pointed at the reply server adopts the reply model exactly as `port: 8080`
+    // would.
+    const fromBaseUrl = (value: unknown): Endpoint | null => {
+      if (typeof value !== "string" || !value.trim()) return null;
+      try {
+        const url = new URL(value.trim());
+        const port = url.port ? Number(url.port) : (url.protocol === "https:" ? 443 : 80);
+        // URL keeps IPv6 literals bracketed; the host comparisons here do not.
+        return { host: url.hostname.toLowerCase().replace(/^\[|\]$/g, ""), port };
+      } catch {
+        return null; // malformed URLs are reported by the dedicated baseUrl check
+      }
+    };
+
     const classifierBackend = typeof classifier.backend === "string" ? classifier.backend : undefined;
-    const classifierEndpoint: Endpoint = {
+    const classifierEndpoint: Endpoint = fromBaseUrl(classifier.baseUrl) ?? {
       host: hostOf(classifier.host),
       port: portOf(classifier.port) ?? llmDefaultPort(classifierBackend),
     };
@@ -572,12 +590,13 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     // classifier on the same seat would silently adopt.
     const llmSection = section("llm");
     const llmBackend = llmSection && typeof llmSection.backend === "string" ? llmSection.backend : undefined;
+    const llmUrlEndpoint = llmSection ? fromBaseUrl(llmSection.baseUrl) : null;
     const llm = llmSection
       ? {
         backend: llmBackend,
         model: llmSection.model,
-        host: hostOf(llmSection.host),
-        port: portOf(llmSection.port) ?? llmDefaultPort(llmBackend),
+        host: llmUrlEndpoint?.host ?? hostOf(llmSection.host),
+        port: llmUrlEndpoint?.port ?? portOf(llmSection.port) ?? llmDefaultPort(llmBackend),
       }
       : {
         backend: "mlx-lm" as string | undefined,

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -13,6 +13,7 @@ import {
 } from "./backends/stt/provider";
 import { ttsDefaultPort } from "./backends/tts/provider";
 import { llmDefaultPort } from "./backends/llm/provider";
+import { OPENAI_COMPATIBLE_BACKENDS } from "./backends/llm/openai";
 
 /** A resolved network seat: what the role will actually bind or reach. */
 interface Endpoint { host: string; port: number | undefined }
@@ -579,8 +580,26 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
       }
     };
 
+    // Round 8 (Codex): only the OpenAI-compatible family reads baseUrl. The
+    // local single-model backends select their endpoint from host/port and
+    // ignore it entirely, so resolving THEIR baseUrl made validation reason
+    // about an endpoint the runtime never contacts — the opposite mismatch to
+    // the one it was added to catch.
+    const readsBaseUrl = (backend: string | undefined): boolean =>
+      backend !== undefined && OPENAI_COMPATIBLE_BACKENDS.includes(backend);
+    /** A server that loads ONE model, so a second role naming another never gets it. */
+    const singleModelServer = (backend: string | undefined): boolean =>
+      backend !== undefined && llmDefaultPort(backend) !== undefined;
+
     const classifierBackend = typeof classifier.backend === "string" ? classifier.backend : undefined;
-    const classifierEndpoint: Endpoint = fromBaseUrl(classifier.baseUrl) ?? {
+    if (classifier.baseUrl !== undefined && classifierBackend !== undefined && !readsBaseUrl(classifierBackend)) {
+      issues.push(
+        `classifier.baseUrl is set but the '${classifierBackend}' backend ignores it and connects to `
+        + "classifier.host/classifier.port instead; use classifier.host and classifier.port, or "
+        + "backend: openai-compatible if that URL is what you meant.",
+      );
+    }
+    const classifierEndpoint: Endpoint = (readsBaseUrl(classifierBackend) ? fromBaseUrl(classifier.baseUrl) : null) ?? {
       host: hostOf(classifier.host),
       port: portOf(classifier.port) ?? llmDefaultPort(classifierBackend),
     };
@@ -590,7 +609,7 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     // classifier on the same seat would silently adopt.
     const llmSection = section("llm");
     const llmBackend = llmSection && typeof llmSection.backend === "string" ? llmSection.backend : undefined;
-    const llmUrlEndpoint = llmSection ? fromBaseUrl(llmSection.baseUrl) : null;
+    const llmUrlEndpoint = llmSection && readsBaseUrl(llmBackend) ? fromBaseUrl(llmSection.baseUrl) : null;
     const llm = llmSection
       ? {
         backend: llmBackend,
@@ -608,9 +627,19 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     // One host:port is one server process, whether it is on this box or a
     // remote one — llama-server loads a single model, so a second role naming
     // a different one there is asking for something it will never get.
-    const sharesLlmServer = classifierEndpoint.port !== undefined
+    // Round 8 (Codex): a shared endpoint only forces ONE model when it is one
+    // model server. A cloud API multiplexes — two roles at api.openai.com with
+    // different models is the ordinary way to run a cheap classifier beside an
+    // expensive reply model, and refusing it was plain wrong. Loopback still
+    // counts whatever the backend says: that is a server this daemon starts or
+    // adopts, and adoption is what silently hands over the wrong model.
+    const sharedEndpoint = classifierEndpoint.port !== undefined
       && classifierEndpoint.port === llm.port
       && classifierEndpoint.host === llm.host;
+    const sharesLlmServer = sharedEndpoint
+      && (isLocal(classifierEndpoint.host)
+        || singleModelServer(classifierBackend)
+        || singleModelServer(llm.backend));
     // An UNSET classifier.model is the documented way to share the reply model
     // on purpose — it must stay accepted, or the hint below sends operators to
     // a config this same check refuses.

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -526,11 +526,17 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     };
     const section = (key: string): Record<string, unknown> | null =>
       isRecord(config[key]) ? config[key] as Record<string, unknown> : null;
-    /** A listener only occupies a port when it is actually enabled. */
+    /** An opt-in listener only occupies a port when it is switched on. */
     const enabledPort = (key: string, fallback: number): Endpoint | null => {
       const value = section(key);
       if (value?.enabled !== true) return null;
       return { host: hostOf(value.host), port: portOf(value.port) ?? fallback };
+    };
+    /** A default-ON listener holds its port unless explicitly switched off. */
+    const defaultOnPort = (key: string, fallback: number): Endpoint | null => {
+      const value = section(key);
+      if (value?.enabled === false) return null;
+      return { host: hostOf(value?.host), port: portOf(value?.port) ?? fallback };
     };
     // Round 5 (Codex): comparing the literal config values only sees the
     // collisions an operator spelled out. Every one of these roles binds a
@@ -607,6 +613,9 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     // peer binds nothing here, so its port is not in the way.
     if (classifierEndpoint.port !== undefined && isLocal(classifierEndpoint.host)) {
       const others: Array<[string, Endpoint | null]> = [
+        // The dashboard is default-ON and starts before any provider, so it is
+        // holding 8086 in every config that does not switch it off.
+        ["dashboard", defaultOnPort("dashboard", 8086)],
         ["web_voice", enabledPort("web_voice", 8090)],
         ["tone", enabledPort("tone", 8091)],
         ["turn", enabledPort("turn", 8087)],

--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -588,8 +588,13 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
     const readsBaseUrl = (backend: string | undefined): boolean =>
       backend !== undefined && OPENAI_COMPATIBLE_BACKENDS.includes(backend);
     /** A server that loads ONE model, so a second role naming another never gets it. */
+    // A server this daemon launches that holds exactly ONE model: llama-server
+    // and mlx_lm.server load a model at startup and treat a request's `model`
+    // field as informational. Ollama also has a default port and is also
+    // launched here, but it selects per request, so it is deliberately not one
+    // of these -- sharing it between roles is a working setup, not a clash.
     const singleModelServer = (backend: string | undefined): boolean =>
-      backend !== undefined && llmDefaultPort(backend) !== undefined;
+      backend !== undefined && llmDefaultPort(backend) !== undefined && !backendRoutesByModel(backend);
 
     const classifierBackend = typeof classifier.backend === "string" ? classifier.backend : undefined;
     if (classifier.baseUrl !== undefined && classifierBackend !== undefined && !readsBaseUrl(classifierBackend)) {
@@ -624,62 +629,76 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
         port: serverPort("router", 8081),
       };
 
-    // One host:port is one server process, whether it is on this box or a
-    // remote one — llama-server loads a single model, so a second role naming
-    // a different one there is asking for something it will never get.
-    // Round 8 (Codex): a shared endpoint only forces ONE model when it is one
-    // model server. A cloud API multiplexes — two roles at api.openai.com with
-    // different models is the ordinary way to run a cheap classifier beside an
-    // expensive reply model, and refusing it was plain wrong. Loopback still
-    // counts whatever the backend says: that is a server this daemon starts or
-    // adopts, and adoption is what silently hands over the wrong model.
+    // Two roles on one host:port are one server process. Whether that is a
+    // problem depends entirely on what that process can serve:
+    //
+    //   - a SINGLE-MODEL server (llama-server, mlx_lm.server) loads one model at
+    //     launch, and `model` in a request is informational. A second role
+    //     naming a different one silently classifies on whatever is loaded --
+    //     and reports healthy, because adoption probes health, never the model.
+    //   - a MODEL-ROUTING server (ollama, vLLM, llama-swap, a cloud API) selects
+    //     per request. Two roles with different models there is the ordinary way
+    //     to run a cheap classifier beside an expensive reply model.
+    //
+    // Round 10 (Codex): loopback was previously treated as single-model on its
+    // own, which rejected a local vLLM or llama-swap multiplexing two models --
+    // a configuration this repo explicitly supports. What matters is the
+    // backend, not whether the socket happens to be on this box.
     const sharedEndpoint = classifierEndpoint.port !== undefined
       && classifierEndpoint.port === llm.port
       && classifierEndpoint.host === llm.host;
-    const sharesLlmServer = sharedEndpoint
-      && (isLocal(classifierEndpoint.host)
-        || singleModelServer(classifierBackend)
-        || singleModelServer(llm.backend));
-    // An UNSET classifier.model is the documented way to share the reply model
-    // on purpose — it must stay accepted, or the hint below sends operators to
-    // a config this same check refuses.
-    // Round 9 (Codex): "drop classifier.model to share the reply model" is only
-    // true where the model field is informational. On a backend that routes by
-    // model, an UNSET model is not "whatever is loaded" — it is that backend's
-    // own default, so the remediation this check recommends produced exactly the
-    // mismatch the check exists to prevent, and startup would not notice: the
-    // shared server is adopted on a health probe that never mentions a model.
-    const unsetShareIsAmbiguous = classifier.model === undefined
-      && backendRoutesByModel(classifierBackend ?? llm.backend);
+    const effectiveBackend = classifierBackend ?? llm.backend;
+    const singleModelShare = sharedEndpoint
+      && singleModelServer(effectiveBackend)
+      && singleModelServer(llm.backend ?? classifierBackend);
+    // Round 10 (Codex): an unset model was treated as ambiguous on every
+    // routing backend, which rejected the plainest configuration there is --
+    // two ollama roles, neither naming a model, both resolving to the same
+    // default. There is nothing to refuse on a routing backend at all: an unset
+    // classifier model there resolves to that backend's own small default and
+    // the server loads it alongside the reply model, which is a working setup,
+    // not a misconfiguration. So the conflict below is asked only of a
+    // single-model share, where an EXPLICIT second model is the trap and an
+    // unset one is the documented way to share what is already loaded.
     const modelConflict = classifier.model !== undefined && classifier.model !== llm.model;
     const backendConflict = classifierBackend !== undefined && llm.backend !== undefined
       && classifierBackend !== llm.backend;
-    if (sharesLlmServer && unsetShareIsAmbiguous) {
+    if (singleModelShare && modelConflict) {
       issues.push(
         `classifier resolves to the same endpoint as llm (${classifierEndpoint.host}:${classifierEndpoint.port}) `
-        + `and names no model, but the '${String(classifierBackend ?? llm.backend)}' backend selects a model per `
-        + `request — so an unset one resolves to its default (${LLM_DEFAULT_MODEL.ollama}), not to the reply model. `
-        + `Set classifier.model to ${String(llm.model)} to share it, or give classifier its own port.`,
+        + `but names a different model (${String(classifier.model)} vs ${String(llm.model)}); the already-running reply server is `
+        + `reused and it serves one model, so the classifier model would never load. `
+        + "Give classifier its own port, or drop classifier.model to share the reply model.",
       );
-    } else if (sharesLlmServer && (modelConflict || backendConflict)) {
-      const named = modelConflict
-        ? `names a different model (${String(classifier.model)} vs ${String(llm.model)})`
-        : `names a different backend (${String(classifierBackend)} vs ${String(llm.backend)})`;
-      // The remediation differs by backend on purpose: dropping the model only
-      // shares it where the field is informational.
-      const share = backendRoutesByModel(classifierBackend ?? llm.backend)
-        ? `set classifier.model to ${String(llm.model)} to share the reply model`
-        : "drop classifier.model to share the reply model";
+    } else if (sharedEndpoint && backendConflict
+      && (singleModelServer(classifierBackend) || singleModelServer(llm.backend))) {
+      // Only raised when one side is a server this daemon LAUNCHES: that is the
+      // case where a specific process must own the port and the other role
+      // adopts it on a health probe, then speaks the wrong protocol to it. Two
+      // routing backends sharing a port is left alone -- ollama, for one, serves
+      // its own API and an OpenAI-compatible one from the same socket.
       issues.push(
-        `classifier resolves to the same endpoint as llm (${classifierEndpoint.host}:${classifierEndpoint.port}) but ${named}; `
-        + "the already-running reply server is reused, so the classifier model would never load. "
-        + `Give classifier its own port, or ${share}.`,
+        `classifier resolves to the same endpoint as llm (${classifierEndpoint.host}:${classifierEndpoint.port}) `
+        + `but names a different backend (${String(classifierBackend)} vs ${String(llm.backend)}); one of them starts `
+        + "a server on that port and the other adopts it. Give classifier its own port.",
       );
     }
 
     // A port collision is about two local processes wanting one seat. A remote
     // peer binds nothing here, so its port is not in the way.
+    //
+    // Round 10 (Codex): a wildcard bind takes the port on EVERY interface, so
+    // 0.0.0.0:8090 contends with an interface-specific listener on 8090 even
+    // though neither host string matches the other and one of them is not a
+    // loopback address at all.
+    const bindsEveryInterface = (host: string): boolean =>
+      host === "0.0.0.0" || host === "::" || host === "*";
+    const overlaps = (a: string, b: string): boolean =>
+      a === b || bindsEveryInterface(a) || bindsEveryInterface(b) || (isLocal(a) && isLocal(b));
     if (classifierEndpoint.port !== undefined && isLocal(classifierEndpoint.host)) {
+      // `boundHere` separates the listeners this daemon always binds -- whatever
+      // host they are given is one of THIS box's interfaces -- from provider
+      // endpoints, which may be a remote peer that binds nothing locally.
       const others: Array<[string, Endpoint | null]> = [
         // The dashboard is default-ON and starts before any provider, so it is
         // holding 8086 in every config that does not switch it off.
@@ -691,10 +710,15 @@ export function validateRuntimeConfig(config: unknown, source = "merged configur
         ["stt_fallback", optionalVoicePort("stt_fallback", sttDefaultPort)],
         ["tts", voicePort("tts", ttsDefaultPort, serverPort("tts", 8082))],
         ["tts_fallback", optionalVoicePort("tts_fallback", ttsDefaultPort)],
-        ...(sharesLlmServer ? [] : [["llm", { host: llm.host, port: llm.port }] as [string, Endpoint]]),
+        // A deliberate, permitted share is not also a collision: the whole point
+        // is that one server answers both roles.
+        ...(sharedEndpoint ? [] : [["llm", { host: llm.host, port: llm.port }] as [string, Endpoint]]),
       ];
+      const boundHere = new Set(["dashboard", "web_voice", "tone", "turn"]);
       for (const [name, endpoint] of others) {
-        if (endpoint && isLocal(endpoint.host) && endpoint.port === classifierEndpoint.port) {
+        if (!endpoint || endpoint.port !== classifierEndpoint.port) continue;
+        if ((boundHere.has(name) || isLocal(endpoint.host))
+          && overlaps(classifierEndpoint.host, endpoint.host)) {
           issues.push(
             `classifier.port ${classifierEndpoint.port} is already used by ${name}; `
             + "give the classification model a port of its own",

--- a/src/config.ts
+++ b/src/config.ts
@@ -479,6 +479,15 @@ export class RuntimeConfig {
       model: this.config.servers.router.model,
     };
   }
+
+  /**
+   * Optional classification-only model. Unlike llmBackend there is no implicit
+   * default: an absent section means the role is unconfigured, which callers
+   * must treat as "off", never as "borrow the reply model".
+   */
+  get classifierBackend(): LLMProviderConfig | null {
+    return (this.config.classifier as LLMProviderConfig | undefined) ?? null;
+  }
 }
 
 /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -976,6 +976,20 @@ export class CiceroDaemon {
           .chatCompletion([{ role: "user" as const, content: "hi" }], { max_tokens: 1, signal })
           .then(() => { if (!signal.aborted) log("ok", "LLM model warmed"); }));
       }
+      // The classifier role promises a model that is already warm, but startup
+      // only ever probed its health — and a health probe does not load a model.
+      // On ollama it is GET /api/tags, which lists what is AVAILABLE; the model
+      // loads on the first generate/chat request. On an adopted llama-server the
+      // probe says nothing about which model is resident either. So warm it the
+      // same way as the reply model: with a real completion, in the background,
+      // best-effort. A classifier that cannot answer this is not fatal — every
+      // caller of it already falls back.
+      const classifier = this.providers.classifier;
+      if (classifier && !this.startupPolicies.classifier?.skipReason) {
+        this.runBackground("classifier warmup", (signal) => classifier
+          .chatCompletion([{ role: "user" as const, content: "hi" }], { max_tokens: 1, signal })
+          .then(() => { if (!signal.aborted) log("ok", "Classifier model warmed"); }));
+      }
     }
 
     // Step 3b: Web voice server (browser audio client). For a headless box with no

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -497,6 +497,7 @@ export class CiceroDaemon {
     };
     addUrlCredentials(this.config.brain?.base_url);
     addUrlCredentials(this.config.llmBackend?.baseUrl);
+    addUrlCredentials(this.config.classifierBackend?.baseUrl);
 
     // Lane agents receive their configured env maps verbatim (brain.lanes.*.env
     // and each fallback's env) — an ANTHROPIC_API_KEY placed there reaches the
@@ -515,6 +516,14 @@ export class CiceroDaemon {
       addEnv(resolveOpenAiTarget(llm).apiKeyEnv);
     }
     addHeaderValues(llm?.extraHeaders);
+    // The classifier takes the same credential fields as the reply model, so it
+    // needs the same inventory — a key here is no less a key.
+    const classifier = this.config.classifierBackend;
+    add(classifier?.apiKey);
+    if (classifier && OPENAI_COMPATIBLE_BACKENDS.includes(classifier.backend ?? "")) {
+      addEnv(resolveOpenAiTarget(classifier).apiKeyEnv);
+    }
+    addHeaderValues(classifier?.extraHeaders);
     add(this.config.ttsBackend?.apiKey);
     add(this.config.ttsFallbackBackend?.apiKey);
     // ElevenLabs resolves its key from ELEVENLABS_API_KEY when no inline key is

--- a/src/servers/index.ts
+++ b/src/servers/index.ts
@@ -105,8 +105,10 @@ export class ServerManager {
   }
 
   async stop(providers: BackendProviderSet): Promise<void> {
-    for (const provider of [providers.stt, providers.tts, providers.llm]) {
-      if (provider?.stop) {
+    // Derived from providerEntries, not a second hand-written role list: a role
+    // added to one and forgotten in the other gets started and never stopped.
+    for (const [, provider] of providerEntries(providers)) {
+      if (provider.stop) {
         try {
           await provider.stop();
         } catch (error: unknown) {

--- a/src/servers/index.ts
+++ b/src/servers/index.ts
@@ -166,6 +166,7 @@ function providerEntries(
   if (providers.llm) entries.push(["llm", providers.llm]);
   if (providers.tts) entries.push(["tts", providers.tts]);
   if (providers.stt) entries.push(["stt", providers.stt]);
+  if (providers.classifier) entries.push(["classifier", providers.classifier]);
   return entries;
 }
 

--- a/src/servers/startup-policy.ts
+++ b/src/servers/startup-policy.ts
@@ -3,11 +3,12 @@ import { isLocalHost } from "../backends/net";
 import {
   SUPPORTED_STT_BACKENDS,
   SUPPORTED_TTS_BACKENDS,
+  SUPPORTED_LLM_BACKENDS,
   supportedBackendHint,
 } from "../backends/supported-backends";
 import { MLX_MIN_MACOS_MAJOR, supportsCurrentMlx } from "../platform/python";
 
-export type BackendRole = "stt" | "tts" | "llm";
+export type BackendRole = "stt" | "tts" | "llm" | "classifier";
 
 export interface BackendStartupPolicy {
   /** Explicit STT and enabled TTS primaries must be usable before startup commits. */
@@ -40,6 +41,7 @@ export function createBackendStartupPolicies(
   const stt = config.sttBackend;
   const tts = config.ttsBackend;
   const llm = config.llmBackend;
+  const classifier = config.classifierBackend;
 
   return {
     stt: createPolicy({
@@ -77,6 +79,25 @@ export function createBackendStartupPolicies(
       builtInProviders,
       options,
     }),
+    // Only present when configured. Not required: the classifier is optional,
+    // and a daemon that can still answer must not refuse to start because a
+    // per-utterance helper is down.
+    ...(classifier
+      ? {
+          classifier: createPolicy({
+            role: "classifier" as const,
+            configKey: "classifier.backend",
+            backend: classifier.backend,
+            host: classifier.host,
+            explicit: true,
+            required: false,
+            hasConfiguredFallback: false,
+            validValues: builtInProviders ? SUPPORTED_LLM_BACKENDS : undefined,
+            builtInProviders,
+            options,
+          }),
+        }
+      : {}),
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export interface CiceroConfig {
   tts?: TTSBackendConfig;
   tts_fallback?: TTSBackendConfig; // hot-standby engine used when the primary fails a generation
   llm?: LLMBackendConfig;
+  // Optional small model held apart from the reply model, for per-utterance
+  // classification (see docs/classifier.md). Same shape as `llm`. There is no
+  // default and no fallback to `llm`: features that need it stay off and say so.
+  classifier?: LLMBackendConfig;
   compute?: {
     /** Permit computer-use goals, file observations, and command output to reach a public/cloud LLM. */
     allow_cloud?: boolean;

--- a/tests/backends/classifier.test.ts
+++ b/tests/backends/classifier.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClassifierProvider, createProviders } from "../../src/backends/registry";
+import { createBackendStartupPolicies } from "../../src/servers/startup-policy";
+import { loadConfig as loadConfigRaw } from "../../src/config";
+import { validateRuntimeConfig } from "../../src/config-validation";
+import { DEFAULT_CONFIG, RuntimeConfig } from "../../src/config";
+import { collectChecks } from "../../src/cli/doctor";
+import type { LLMBackendConfig } from "../../src/types";
+
+const NO_CONFIG_HOME = join(tmpdir(), "cicero-test-no-config");
+
+/** A config with the classifier section set (or absent when omitted). */
+function configWith(classifier?: LLMBackendConfig) {
+  const config = loadConfigRaw({}, { home: NO_CONFIG_HOME });
+  if (classifier) config.raw.classifier = classifier;
+  return config;
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+describe("classifier backend role", () => {
+  // Absence must mean "the feature is off", never "borrow the reply model" --
+  // a reply-tier model per utterance is exactly the cost this role avoids.
+  test("is absent unless configured, and never falls back to the reply model", () => {
+    const config = configWith();
+    expect(createClassifierProvider(config)).toBeNull();
+
+    const providers = createProviders(config);
+    expect(providers.classifier).toBeUndefined();
+    expect(providers.llm).toBeDefined();
+    // Nothing aliased the reply model into the role.
+    expect(providers.classifier as unknown).not.toBe(providers.llm);
+  });
+
+  test("is constructed when configured, separately from the reply model", () => {
+    const config = configWith({ backend: "llama-cpp", host: "127.0.0.1", port: 8090, model: "small" });
+    const providers = createProviders(config);
+    expect(providers.classifier).toBeDefined();
+    expect(providers.classifier).not.toBe(providers.llm);
+  });
+
+  // AGENTS.md: an explicitly configured unsupported backend is an error.
+  test("an unsupported backend is an error, not a silent fallback", () => {
+    const config = configWith({ backend: "definitely-not-a-backend" });
+    expect(() => createClassifierProvider(config)).toThrow(/Unknown classifier backend/);
+    // And it blames the classifier key, not llm -- the operator has to know
+    // which of the two sections is wrong.
+    expect(() => createClassifierProvider(config)).not.toThrow(/llm backend/);
+  });
+
+  test("claude-api is rejected for the classifier with a classifier-specific message", () => {
+    const config = configWith({ backend: "claude-api" });
+    expect(() => createClassifierProvider(config)).toThrow(/classifier backend 'claude-api' is not implemented/);
+  });
+
+  // Remote-host and local-managed are different code paths and must be
+  // exercised separately (AGENTS.md).
+  test("remote-host mode builds against the configured host", async () => {
+    let seen = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen = String(input);
+      return new Response(JSON.stringify({ choices: [{ message: { content: "yes" } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const config = configWith({ backend: "llama-cpp", host: "classifier-box.local", port: 9099, model: "tiny" });
+    const provider = createClassifierProvider(config)!;
+    await provider.chatCompletion([{ role: "user", content: "hi" }]);
+    expect(seen).toContain("classifier-box.local");
+    expect(seen).toContain("9099");
+  });
+
+  test("local-managed mode targets localhost and owns a lifecycle", () => {
+    const config = configWith({ backend: "mlx-lm", port: 8123, model: "tiny" });
+    const provider = createClassifierProvider(config)!;
+    expect(provider.name).toBeTruthy();
+    // A managed provider is what the ServerManager starts and stops.
+    expect(typeof provider.health).toBe("function");
+  });
+});
+
+describe("classifier startup policy", () => {
+  test("there is no policy at all when the role is unconfigured", () => {
+    const policies = createBackendStartupPolicies(configWith());
+    expect(policies.classifier).toBeUndefined();
+  });
+
+  // A per-utterance helper being down must not stop a daemon that can still
+  // hold a conversation.
+  test("a configured classifier is never a required primary", () => {
+    const policies = createBackendStartupPolicies(
+      configWith({ backend: "llama-cpp", host: "127.0.0.1", port: 8090 }),
+    );
+    expect(policies.classifier).toBeDefined();
+    expect(policies.classifier?.required).toBe(false);
+    expect(policies.classifier?.configKey).toBe("classifier.backend");
+  });
+});
+
+describe("classifier config validation", () => {
+  /** Collect the issues validateRuntimeConfig reports for a classifier section. */
+  function issuesFor(classifier: unknown): string[] {
+    const config = structuredClone(DEFAULT_CONFIG) as Record<string, unknown>;
+    config.classifier = classifier;
+    try {
+      validateRuntimeConfig(config, "test config");
+      return [];
+    } catch (error) {
+      return String((error as Error).message).split("\n");
+    }
+  }
+
+  test("a well-formed classifier section is accepted", () => {
+    expect(issuesFor({ backend: "llama-cpp", host: "127.0.0.1", port: 8090, model: "tiny" })).toEqual([]);
+  });
+
+  // Cicero's validation is fail-fast on unknown keys; the new section must be
+  // held to the same standard rather than silently accepting typos.
+  test("an unknown key inside classifier is rejected", () => {
+    const issues = issuesFor({ backend: "llama-cpp", modle: "typo" });
+    expect(issues.some((i) => i.includes("classifier") && i.includes("modle"))).toBe(true);
+  });
+
+  test("a non-http baseUrl is rejected", () => {
+    expect(issuesFor({ backend: "openai", baseUrl: "ftp://nope" }).some((i) => i.includes("classifier.baseUrl"))).toBe(true);
+  });
+
+  test("an out-of-range port is rejected", () => {
+    expect(issuesFor({ backend: "llama-cpp", port: 99_999 }).some((i) => i.includes("classifier.port"))).toBe(true);
+  });
+});
+
+describe("classifier doctor coverage", () => {
+  function doctorConfig(classifier?: LLMBackendConfig): RuntimeConfig {
+    return new RuntimeConfig({
+      ...structuredClone(DEFAULT_CONFIG),
+      headless: true,
+      classifier,
+    });
+  }
+
+  // Absence is a valid choice, not a problem to report.
+  test("says nothing when the role is unconfigured", async () => {
+    const checks = await collectChecks(doctorConfig(), { which: (b: string) => `/mock/${b}` });
+    expect(checks.some((check) => check.name.startsWith("classifier"))).toBe(false);
+  });
+
+  // Configured-but-unreachable is a problem: features that depend on it will
+  // decline turns, and the operator should learn it here rather than from a
+  // feature that quietly does nothing.
+  test("warns when configured but unreachable, naming classifier.backend", async () => {
+    globalThis.fetch = (() => Promise.reject(new Error("connection refused"))) as unknown as typeof fetch;
+    const checks = await collectChecks(
+      doctorConfig({ backend: "llama-cpp", host: "127.0.0.1", port: 8090, model: "tiny" }),
+      { which: (b: string) => `/mock/${b}` },
+    );
+    const check = checks.find((c) => c.name.startsWith("classifier"));
+    expect(check).toBeDefined();
+    expect(check!.level).not.toBe("ok");
+    // The message must blame the right section; llm and classifier are
+    // configured separately and either could be the broken one.
+    const text = `${check!.detail ?? ""} ${check!.hint ?? ""}`;
+    expect(text).toContain("classifier.backend");
+    expect(text).not.toContain("llm.backend");
+  });
+});

--- a/tests/backends/classifier.test.ts
+++ b/tests/backends/classifier.test.ts
@@ -46,9 +46,9 @@ describe("classifier backend role", () => {
   // AGENTS.md: an explicitly configured unsupported backend is an error.
   test("an unsupported backend is an error, not a silent fallback", () => {
     const config = configWith({ backend: "definitely-not-a-backend" });
-    expect(() => createClassifierProvider(config)).toThrow(/Unknown classifier backend/);
-    // And it blames the classifier key, not llm -- the operator has to know
-    // which of the two sections is wrong.
+    expect(() => createClassifierProvider(config)).toThrow(/Unknown classifier backend 'definitely-not-a-backend'/);
+    // And it blames the classifier, not llm -- the operator has to know which of
+    // the two sections is wrong.
     expect(() => createClassifierProvider(config)).not.toThrow(/llm backend/);
   });
 
@@ -58,8 +58,9 @@ describe("classifier backend role", () => {
   });
 
   // Remote-host and local-managed are different code paths and must be
-  // exercised separately (AGENTS.md).
-  test("remote-host mode builds against the configured host", async () => {
+  // exercised separately (AGENTS.md). The distinction that matters is whether
+  // Cicero manages a local process, not merely which URL it builds.
+  test("remote-host mode talks to the configured host and manages no local process", async () => {
     let seen = "";
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       seen = String(input);
@@ -74,14 +75,40 @@ describe("classifier backend role", () => {
     await provider.chatCompletion([{ role: "user", content: "hi" }]);
     expect(seen).toContain("classifier-box.local");
     expect(seen).toContain("9099");
+
+    // A remote endpoint is not ours to launch: start() must be a no-op that
+    // spawns nothing, rather than trying to run a server on someone else's box.
+    const spawned: string[] = [];
+    const realSpawn = Bun.spawn;
+    (Bun as unknown as { spawn: unknown }).spawn = ((cmd: string[]) => {
+      spawned.push(cmd.join(" "));
+      return realSpawn(["true"]);
+    }) as unknown as typeof Bun.spawn;
+    try {
+      await provider.start?.();
+      expect(spawned).toEqual([]);
+    } finally {
+      (Bun as unknown as { spawn: unknown }).spawn = realSpawn;
+    }
   });
 
-  test("local-managed mode targets localhost and owns a lifecycle", () => {
-    const config = configWith({ backend: "mlx-lm", port: 8123, model: "tiny" });
+  test("local-managed mode targets localhost rather than a remote host", async () => {
+    let seen = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      seen = String(input);
+      return new Response(JSON.stringify({ choices: [{ message: { content: "yes" } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const config = configWith({ backend: "llama-cpp", port: 8123, model: "tiny" });
     const provider = createClassifierProvider(config)!;
-    expect(provider.name).toBeTruthy();
-    // A managed provider is what the ServerManager starts and stops.
-    expect(typeof provider.health).toBe("function");
+    await provider.chatCompletion([{ role: "user", content: "hi" }]);
+    // No host configured, so it is Cicero's own managed endpoint.
+    expect(seen).toMatch(/127\.0\.0\.1|localhost/);
+    expect(seen).toContain("8123");
+    expect(typeof provider.stop).toBe("function");
   });
 });
 
@@ -154,7 +181,7 @@ describe("classifier doctor coverage", () => {
   // Configured-but-unreachable is a problem: features that depend on it will
   // decline turns, and the operator should learn it here rather than from a
   // feature that quietly does nothing.
-  test("warns when configured but unreachable, naming classifier.backend", async () => {
+  test("fails when configured but unreachable, and blames only classifier.*", async () => {
     globalThis.fetch = (() => Promise.reject(new Error("connection refused"))) as unknown as typeof fetch;
     const checks = await collectChecks(
       doctorConfig({ backend: "llama-cpp", host: "127.0.0.1", port: 8090, model: "tiny" }),
@@ -162,12 +189,13 @@ describe("classifier doctor coverage", () => {
     );
     const check = checks.find((c) => c.name.startsWith("classifier"));
     expect(check).toBeDefined();
-    expect(check!.level).not.toBe("ok");
+    expect(check!.level).toBe("fail");
     // The message must blame the right section; llm and classifier are
-    // configured separately and either could be the broken one.
+    // configured separately and either could be the broken one. Excluding only
+    // llm.backend would let llm.host/llm.port/llm.model guidance slip through.
     const text = `${check!.detail ?? ""} ${check!.hint ?? ""}`;
-    expect(text).toContain("classifier.backend");
-    expect(text).not.toContain("llm.backend");
+    expect(text).toContain("classifier.");
+    expect(text).not.toMatch(/\bllm\./);
   });
 });
 

--- a/tests/backends/classifier.test.ts
+++ b/tests/backends/classifier.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClassifierProvider, createProviders } from "../../src/backends/registry";
 import { createBackendStartupPolicies } from "../../src/servers/startup-policy";
+import { ServerManager } from "../../src/servers";
 import { loadConfig as loadConfigRaw } from "../../src/config";
 import { validateRuntimeConfig } from "../../src/config-validation";
 import { DEFAULT_CONFIG, RuntimeConfig } from "../../src/config";
@@ -167,5 +168,59 @@ describe("classifier doctor coverage", () => {
     const text = `${check!.detail ?? ""} ${check!.hint ?? ""}`;
     expect(text).toContain("classifier.backend");
     expect(text).not.toContain("llm.backend");
+  });
+});
+
+describe("classifier lifecycle", () => {
+  /** A provider that records whether it was started and stopped. */
+  function recorder(name: string, log: string[]) {
+    return {
+      name,
+      chatCompletion: () => Promise.resolve("ok"),
+      health: () => Promise.resolve(true),
+      start: () => { log.push(`start:${name}`); return Promise.resolve(); },
+      stop: () => { log.push(`stop:${name}`); return Promise.resolve(); },
+    };
+  }
+
+  // A role wired into start but not stop leaves a model resident after the
+  // daemon says it stopped -- on a VRAM-tight box that is the whole seat.
+  test("a configured classifier is both started and stopped", async () => {
+    const events: string[] = [];
+    const providers = {
+      stt: { name: "stt", transcribe: () => Promise.resolve(null), ...recorder("stt", events) },
+      tts: { name: "tts", generateAudio: () => Promise.resolve(new ArrayBuffer(0)), ...recorder("tts", events) },
+      llm: recorder("llm", events),
+      classifier: recorder("classifier", events),
+    } as never;
+
+    const manager = new ServerManager();
+    await manager.start(providers, {});
+    expect(events).toContain("start:classifier");
+
+    await manager.stop(providers);
+    expect(events).toContain("stop:classifier");
+    // And every other role still stops, so this did not narrow the set.
+    for (const role of ["stt", "tts", "llm"]) expect(events).toContain(`stop:${role}`);
+  });
+
+  test("a classifier that fails to start does not stop the daemon", async () => {
+    const providers = {
+      stt: { name: "stt", transcribe: () => Promise.resolve(null), health: () => Promise.resolve(true) },
+      tts: { name: "tts", generateAudio: () => Promise.resolve(new ArrayBuffer(0)), health: () => Promise.resolve(true) },
+      llm: { name: "llm", chatCompletion: () => Promise.resolve("ok"), health: () => Promise.resolve(true) },
+      classifier: {
+        name: "classifier",
+        chatCompletion: () => Promise.resolve("ok"),
+        health: () => Promise.resolve(false),
+        start: () => Promise.reject(new Error("classifier model failed to load")),
+      },
+    } as never;
+
+    const policies = createBackendStartupPolicies(
+      configWith({ backend: "llama-cpp", host: "127.0.0.1", port: 8090 }),
+    );
+    // Never required, so a failure is a warning rather than a startup abort.
+    await expect(new ServerManager().start(providers, policies)).resolves.toBeUndefined();
   });
 });

--- a/tests/backends/classifier.test.ts
+++ b/tests/backends/classifier.test.ts
@@ -197,6 +197,31 @@ describe("classifier doctor coverage", () => {
     expect(text).toContain("classifier.");
     expect(text).not.toMatch(/\bllm\./);
   });
+
+  // Round 4 (Codex): the OpenAI-compatible branches are the ones that carry
+  // credential remediation, and both hardcoded `llm.` — so a broken classifier
+  // endpoint sent the operator to edit the unrelated reply role. Neither branch
+  // is reachable through a llama-cpp check, which is why the test above missed
+  // it.
+  test("credential remediation names the classifier role, not llm", async () => {
+    const embedded = await collectChecks(
+      doctorConfig({ backend: "openai", baseUrl: "https://user:pass@classifier.example/v1", model: "tiny" }),
+      { which: (b: string) => `/mock/${b}` },
+    );
+    const credentials = embedded.find((c) => c.name.startsWith("classifier"));
+    expect(credentials!.hint).toContain("classifier.apiKey");
+    expect(`${credentials!.detail ?? ""} ${credentials!.hint ?? ""}`).not.toMatch(/\bllm\./);
+    // And the secret itself never reaches the report.
+    expect(`${credentials!.detail ?? ""} ${credentials!.hint ?? ""}`).not.toContain("pass");
+
+    const missingKey = await collectChecks(
+      doctorConfig({ backend: "openai", baseUrl: "https://classifier.example/v1", model: "tiny" }),
+      { which: (b: string) => `/mock/${b}`, env: {} },
+    );
+    const missing = missingKey.find((c) => c.name.startsWith("classifier"));
+    expect(missing!.hint).toContain("classifier.apiKeyEnv");
+    expect(`${missing!.detail ?? ""} ${missing!.hint ?? ""}`).not.toMatch(/\bllm\./);
+  });
 });
 
 describe("classifier lifecycle", () => {

--- a/tests/backends/llm/ollama.test.ts
+++ b/tests/backends/llm/ollama.test.ts
@@ -64,3 +64,33 @@ test.skipIf(process.platform === "win32")("a managed ollama is told its port thr
     rmSync(dir, { recursive: true, force: true });
   }
 }, 20_000);
+
+// Round 7 (Codex): every tier preset configures Ollama WITHOUT a host, and
+// interpolating it raw produced the literal `OLLAMA_HOST=undefined:11434` —
+// a hostname Ollama tries to bind rather than its localhost default. The
+// previous regression only covered an explicitly configured host, so it passed.
+test.skipIf(process.platform === "win32")("an omitted host resolves to localhost, never the string 'undefined'", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "cicero-ollama-nohost-test-"));
+  const recorded = join(dir, "env.txt");
+  const fake = join(dir, "ollama");
+  writeFileSync(fake, `#!/bin/sh\nprintf '%s' "$OLLAMA_HOST" > ${JSON.stringify(recorded)}\nexit 0\n`);
+  chmodSync(fake, 0o755);
+
+  const reservation = Bun.serve({ port: 0, fetch: () => new Response("reserved") });
+  const port = reservation.port;
+  await Promise.resolve(reservation.stop(true));
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${dir}:${originalPath ?? ""}`;
+  try {
+    // No `host` — exactly what deployment: local-cpu expands to.
+    await new OllamaProvider({ backend: "ollama", port, model: "m" }).start();
+    const recordedHost = readFileSync(recorded, "utf8");
+    expect(recordedHost).not.toContain("undefined");
+    // And it names the same endpoint the health probe will use.
+    expect(recordedHost).toBe(`localhost:${port}`);
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}, 20_000);

--- a/tests/backends/llm/ollama.test.ts
+++ b/tests/backends/llm/ollama.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { OllamaProvider } from "../../../src/backends/llm/ollama";
 
 let lastBody: Record<string, unknown> = {};
@@ -28,3 +31,36 @@ test("Ollama request model uses the same whitespace normalization as doctor", as
   expect(await provider.chatCompletion([{ role: "user", content: "hello" }])).toBe("ready");
   expect(lastBody.model).toBe("qwen3.5:0.8b");
 });
+
+// Round 6 (Codex): `ollama serve` takes no port argument — it binds OLLAMA_HOST,
+// default 127.0.0.1:11434. A second Ollama role (a classifier on its own port)
+// therefore spawned a server aimed at the FIRST role's port, which was already
+// bound; the child exited and that role was silently unavailable for the run.
+// The fake binary here records the environment it was launched with.
+test.skipIf(process.platform === "win32")("a managed ollama is told its port through OLLAMA_HOST", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "cicero-ollama-env-test-"));
+  const recorded = join(dir, "env.txt");
+  const fake = join(dir, "ollama");
+  writeFileSync(fake, `#!/bin/sh\nprintf '%s' "$OLLAMA_HOST" > ${JSON.stringify(recorded)}\nexit 0\n`);
+  chmodSync(fake, 0o755);
+
+  // Reserve a port, then free it: a real free port that is NOT ollama's default.
+  const reservation = Bun.serve({ port: 0, fetch: () => new Response("reserved") });
+  const port = reservation.port;
+  await Promise.resolve(reservation.stop(true));
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${dir}:${originalPath ?? ""}`;
+  try {
+    const provider = new OllamaProvider({ backend: "ollama", host: "127.0.0.1", port, model: "m" });
+    // The fake exits immediately, so start() gives up on readiness — the point
+    // is what it put in the child's environment before that.
+    await provider.start();
+    expect(existsSync(recorded)).toBe(true);
+    expect(readFileSync(recorded, "utf8")).toBe(`127.0.0.1:${port}`);
+    expect(port).not.toBe(11434);
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}, 20_000);

--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -74,6 +74,47 @@ describe("configured CLI status", () => {
     expect(lines.some((line) => line.name === "Phone pairing")).toBe(false);
   });
 
+  // The role is optional, so a row on every operator's status would be noise.
+  test("omits the classifier row when the role is unconfigured", async () => {
+    const config = runtimeConfig((raw) => {
+      raw.headless = true;
+      raw.brain = { backend: "acp", mode: "subprocess", binary: "hermes" };
+    });
+    const lines = await collectStatus(config, {
+      inspectDaemon: () => Promise.resolve({ kind: "absent" }),
+      probe: () => Promise.resolve(true),
+      which: () => "/mock/binary",
+      readPairingState: () => null,
+    });
+    expect(lines.some((line) => line.name === "Classifier")).toBe(false);
+  });
+
+  test("reports the classifier as its own row, probed separately from the reply model", async () => {
+    const config = runtimeConfig((raw) => {
+      raw.headless = true;
+      raw.brain = { backend: "acp", mode: "subprocess", binary: "hermes" };
+      raw.llm = { backend: "llama-cpp", host: "reply-box.test", port: 9200, model: "big" };
+      raw.classifier = { backend: "llama-cpp", host: "classifier-box.test", port: 9300, model: "tiny" };
+    });
+    const requests: StatusProbeRequest[] = [];
+    const lines = await collectStatus(config, {
+      inspectDaemon: () => Promise.resolve({ kind: "absent" }),
+      probe: (request) => { requests.push(request); return Promise.resolve(true); },
+      which: () => "/mock/binary",
+      readPairingState: () => null,
+    });
+
+    const names = lines.map((line) => line.name);
+    expect(names).toContain("Classifier");
+    // It sits next to the reply model, not in place of it.
+    expect(names.indexOf("Classifier")).toBe(names.indexOf("LLM") + 1);
+    // Two distinct endpoints were probed, so the row cannot be reporting the
+    // reply model's health under a different name.
+    const urls = requests.map((r) => r.url).join(" ");
+    expect(urls).toContain("classifier-box.test:9300");
+    expect(urls).toContain("reply-box.test:9200");
+  });
+
   test("reports resolved remote backends and skips irrelevant terminal and hotkey checks", async () => {
     const config = runtimeConfig((raw) => {
       raw.headless = true;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -423,6 +423,44 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice/);
   });
 
+  // Round 10 (Codex): a wildcard bind takes the port on every interface, so it
+  // contends with an interface-specific listener even though neither host
+  // string matches the other. The classifier wins the race (providers start
+  // before the web server), web voice then fails its bind and startup aborts.
+  test("a wildcard classifier collides with an interface-specific web bind", () => {
+    expect(loadYaml([
+      "web_voice:",
+      "  enabled: true",
+      "  host: 192.168.1.5",
+      "  port: 8090",
+      "  token: a-token-that-is-long-enough",
+      "classifier:",
+      "  backend: ollama",
+      "  host: 0.0.0.0",
+      "  port: 8090",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice/);
+  });
+
+  // The mirror image: an interface-specific classifier against the wildcard
+  // bind web voice takes by default.
+  test("an interface-specific classifier collides with a wildcard web bind", () => {
+    expect(loadYaml([
+      "web_voice:",
+      "  enabled: true",
+      "  host: 0.0.0.0",
+      "  port: 8090",
+      "  token: a-token-that-is-long-enough",
+      "classifier:",
+      "  backend: ollama",
+      "  host: 127.0.0.1",
+      "  port: 8090",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice/);
+  });
+
   test("a remote classifier is not compared against local ports", () => {
     expect(() => loadYaml([
       "web_voice:",
@@ -645,14 +683,13 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))()).not.toThrow();
   });
 
-  // Round 9 (Codex): the remediation this check recommends — drop classifier.model
-  // to share the reply model — is only true where the model field is
-  // informational. Ollama SELECTS a model per request, so an unset one resolves
-  // to that backend's own default (qwen3.5:0.8b), not to the loaded reply model.
-  // Startup would not notice either: the shared server is adopted on a health
-  // probe that never mentions a model.
-  test("sharing an ollama server with no classifier model is refused, not accepted", () => {
-    const failure = loadYaml([
+  // Round 10 (Codex): an ollama server SELECTS a model per request, so two
+  // roles sharing one is not a conflict at all -- it is how you run a small
+  // classifier beside a large reply model on one server. Refusing it was wrong,
+  // including the plainest case of all: neither role naming a model, both
+  // resolving to the same default.
+  test("sharing an ollama server without naming the classifier model is accepted", () => {
+    expect(() => loadYaml([
       "llm:",
       "  backend: ollama",
       "  port: 11434",
@@ -661,11 +698,68 @@ describe("Config — fail-fast validation", () => {
       "  backend: ollama",
       "  port: 11434",
       "",
-    ].join("\n"));
-    expect(failure).toThrow(/selects a model per request/);
-    // And it says exactly what to write, rather than repeating advice that does
-    // not hold for this backend.
-    expect(failure).toThrow(/Set classifier\.model to big-reply-model/);
+    ].join("\n"))()).not.toThrow();
+  });
+
+  test("two ollama roles that both take the default model are accepted", () => {
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: ollama",
+      "  port: 11434",
+      "classifier:",
+      "  backend: ollama",
+      "  port: 11434",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
+  // A local vLLM or llama-swap multiplexes by model exactly like a cloud API
+  // does. Treating loopback as single-model on its own rejected a setup this
+  // repo explicitly supports.
+  test("a local OpenAI-compatible server may serve both roles with different models", () => {
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: openai-compatible",
+      "  baseUrl: http://127.0.0.1:8000/v1",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: openai-compatible",
+      "  baseUrl: http://127.0.0.1:8000/v1",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
+  // A single-model server is still a single-model server: llama-server loads
+  // one model and the request's `model` field is informational.
+  test("a shared llama-cpp server naming a second model is still refused", () => {
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/it serves one model/);
+  });
+
+  // One port, two DIFFERENT servers this daemon launches: whichever loses the
+  // race is adopted by the other, which then speaks the wrong protocol to it.
+  test("a shared port with a launched server on one side and a different backend is refused", () => {
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 11434",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: ollama",
+      "  port: 11434",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/names a different backend/);
   });
 
   test("naming the shared ollama model explicitly is accepted", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -645,6 +645,60 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))()).not.toThrow();
   });
 
+  // Round 9 (Codex): the remediation this check recommends — drop classifier.model
+  // to share the reply model — is only true where the model field is
+  // informational. Ollama SELECTS a model per request, so an unset one resolves
+  // to that backend's own default (qwen3.5:0.8b), not to the loaded reply model.
+  // Startup would not notice either: the shared server is adopted on a health
+  // probe that never mentions a model.
+  test("sharing an ollama server with no classifier model is refused, not accepted", () => {
+    const failure = loadYaml([
+      "llm:",
+      "  backend: ollama",
+      "  port: 11434",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: ollama",
+      "  port: 11434",
+      "",
+    ].join("\n"));
+    expect(failure).toThrow(/selects a model per request/);
+    // And it says exactly what to write, rather than repeating advice that does
+    // not hold for this backend.
+    expect(failure).toThrow(/Set classifier\.model to big-reply-model/);
+  });
+
+  test("naming the shared ollama model explicitly is accepted", () => {
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: ollama",
+      "  port: 11434",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: ollama",
+      "  port: 11434",
+      "  model: big-reply-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
+  // llama-cpp serves the one model it loaded and treats the field as
+  // informational, so dropping it there really does share — that remediation is
+  // unchanged, and the message must not start recommending the ollama one.
+  test("the llama-cpp remediation still says to drop the model", () => {
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/drop classifier\.model to share the reply model/);
+  });
+
   // A listener that is off binds nothing, so it is not in the way.
   test("a disabled listener does not reserve its default port", () => {
     expect(() => loadYaml([

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -326,6 +326,103 @@ describe("Config — fail-fast validation", () => {
     expect(() => loadYaml(yaml)()).not.toThrow();
   });
 
+  // Round 4 (Codex): the classifier block ships COMMENTED OUT, so schema
+  // validation never saw it — and it shipped on web_voice's port, which any
+  // operator following the instructions would have copied verbatim.
+  test("every commented example block is valid once uncommented in place", () => {
+    const yaml = readFileSync(join(import.meta.dir, "..", "config.yaml.example"), "utf8");
+    const lines = yaml.split("\n");
+    // Find each commented-out top-level block: a "# key:" line plus the
+    // indented "#   ..." lines under it.
+    const blocks: Array<{ start: number; end: number; key: string }> = [];
+    let current: { start: number; end: number; key: string } | null = null;
+    for (const [index, line] of lines.entries()) {
+      const opener = /^# {0,2}([a-z_]+):\s*$/.exec(line);
+      if (opener) {
+        current = { start: index, end: index, key: opener[1]! };
+        blocks.push(current);
+        continue;
+      }
+      if (current && /^# {3,}\S/.test(line)) {
+        current.end = index;
+        continue;
+      }
+      current = null;
+    }
+    expect(blocks.map((block) => block.key)).toContain("classifier");
+
+    // Uncommenting one IN PLACE is what an operator actually does, so validate
+    // it against the rest of the shipped file — a block that is fine alone can
+    // still collide with an active listener's port.
+    for (const block of blocks) {
+      const merged = lines.map((line, index) =>
+        index >= block.start && index <= block.end ? line.replace(/^# ?/, "") : line);
+      expect(() => loadYaml(merged.join("\n"))(), `uncommenting ${block.key}:`).not.toThrow();
+    }
+  });
+
+  // Round 4 (Codex): startManagedServer() adopts a server already healthy on a
+  // port instead of starting one, and a chat request's `model` is informational
+  // to llama-server — so a classifier pointed at another listener's port never
+  // loads its model, classifies on whatever is there, and reports healthy.
+  test("a classifier sharing the reply model's endpoint with a different model is refused", () => {
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier resolves to the same endpoint as llm but names a different model/);
+  });
+
+  test("deliberately sharing one server for both roles stays allowed", () => {
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: one-model-for-both",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: one-model-for-both",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
+  test("a classifier port already used by another local listener is refused", () => {
+    expect(loadYaml([
+      "web_voice:",
+      "  enabled: true",
+      "  port: 8090",
+      "  token: a-token-that-is-long-enough",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  host: 127.0.0.1",
+      "  port: 8090",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice\.port/);
+  });
+
+  test("a remote classifier is not compared against local ports", () => {
+    expect(() => loadYaml([
+      "web_voice:",
+      "  enabled: true",
+      "  port: 8090",
+      "  token: a-token-that-is-long-enough",
+      "classifier:",
+      "  backend: openai-compatible",
+      "  host: classifier.example",
+      "  port: 8090",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
   test("rejects unknown built-in keys with actionable suggestions", () => {
     expect(loadYaml([
       "headles: true",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -376,7 +376,7 @@ describe("Config — fail-fast validation", () => {
       "  port: 8080",
       "  model: small-classifier-model",
       "",
-    ].join("\n"))).toThrow(/classifier resolves to the same endpoint as llm but names a different model/);
+    ].join("\n"))).toThrow(/classifier resolves to the same endpoint as llm \(127\.0\.0\.1:8080\) but names a different model/);
   });
 
   test("deliberately sharing one server for both roles stays allowed", () => {
@@ -393,6 +393,21 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))()).not.toThrow();
   });
 
+  // The refusal tells the operator to drop classifier.model; that has to be a
+  // config this check then accepts.
+  test("the remediation the error names is itself accepted", () => {
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
   test("a classifier port already used by another local listener is refused", () => {
     expect(loadYaml([
       "web_voice:",
@@ -405,7 +420,7 @@ describe("Config — fail-fast validation", () => {
       "  port: 8090",
       "  model: small-classifier-model",
       "",
-    ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice\.port/);
+    ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice/);
   });
 
   test("a remote classifier is not compared against local ports", () => {
@@ -421,6 +436,108 @@ describe("Config — fail-fast validation", () => {
       "  model: small-classifier-model",
       "",
     ].join("\n"))()).not.toThrow();
+  });
+
+  // Round 5 (Codex): every one of these roles binds a DEFAULT when its port —
+  // or its whole section — is omitted, and validation was comparing only the
+  // literal config values. So the collisions it caught were exactly the ones an
+  // operator had already written down, and the silent ones went through.
+  test("an omitted llm section still occupies the reply model's default seat", () => {
+    // No `llm:` at all — RuntimeConfig synthesizes mlx-lm on servers.router.port.
+    expect(loadYaml([
+      "classifier:",
+      "  backend: mlx-lm",
+      "  port: 8081",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/same endpoint as llm \(127\.0\.0\.1:8081\)/);
+  });
+
+  test("an omitted port still occupies its backend's default seat", () => {
+    // Neither role names a port; both llama-cpp providers bind 8080.
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/same endpoint as llm \(127\.0\.0\.1:8080\)/);
+
+    // ...and the mixed case: one spelled out, one defaulted.
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/same endpoint as llm/);
+  });
+
+  test("an enabled listener with no port still holds its default port", () => {
+    expect(loadYaml([
+      "web_voice:",
+      "  enabled: true",
+      "  token: a-token-that-is-long-enough",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8090",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice/);
+  });
+
+  // A listener that is off binds nothing, so it is not in the way.
+  test("a disabled listener does not reserve its default port", () => {
+    expect(() => loadYaml([
+      "tone:",
+      "  enabled: false",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8091",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
+  // Round 5 (Codex): a REMOTE peer starts no local process, so its port is not
+  // occupied on this box — refusing that config blocked a legitimate setup.
+  test("a local classifier may reuse the port number of a remote llm", () => {
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  host: 192.0.2.10",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  host: 127.0.0.1",
+      "  port: 8080",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
+  // But the same REMOTE seat shared by both roles is still one server with one
+  // model loaded, wherever it runs.
+  test("two roles sharing one remote server with different models is refused", () => {
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  host: 192.0.2.10",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  host: 192.0.2.10",
+      "  port: 8080",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/same endpoint as llm \(192\.0\.2\.10:8080\)/);
   });
 
   test("rejects unknown built-in keys with actionable suggestions", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -592,6 +592,59 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))()).not.toThrow();
   });
 
+  // Round 8 (Codex): only the OpenAI-compatible family reads baseUrl. LlamaCpp
+  // selects host/port and ignores it, so a classifier carrying baseUrl was
+  // validated against an endpoint the runtime never contacts — it actually
+  // targeted 8080 and adopted the reply server. Refusing the key beats
+  // mirroring a setting that silently does nothing.
+  test("a baseUrl on a backend that ignores it is refused, not silently honoured", () => {
+    expect(loadYaml([
+      "classifier:",
+      "  backend: llama-cpp",
+      "  baseUrl: http://127.0.0.1:8093/v1",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.baseUrl is set but the 'llama-cpp' backend ignores it/);
+  });
+
+  test("the same key on an OpenAI-compatible backend stays valid", () => {
+    expect(() => loadYaml([
+      "classifier:",
+      "  backend: openai-compatible",
+      "  baseUrl: http://127.0.0.1:8093/v1",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
+  // Round 8 (Codex): a shared endpoint only forces one model when it is one
+  // model server. A cloud API multiplexes, and a cheap classifier beside an
+  // expensive reply model on the same API is the ordinary way to run this.
+  test("two cloud roles on one API with different models is allowed", () => {
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: openai",
+      "  baseUrl: https://api.openai.com/v1",
+      "  model: gpt-4.1",
+      "classifier:",
+      "  backend: openai",
+      "  baseUrl: https://api.openai.com/v1",
+      "  model: gpt-4.1-mini",
+      "",
+    ].join("\n"))()).not.toThrow();
+
+    // And with the URLs left implicit, which resolves to the same endpoint.
+    expect(() => loadYaml([
+      "llm:",
+      "  backend: openai",
+      "  model: gpt-4.1",
+      "classifier:",
+      "  backend: openai",
+      "  model: gpt-4.1-mini",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
   // A listener that is off binds nothing, so it is not in the way.
   test("a disabled listener does not reserve its default port", () => {
     expect(() => loadYaml([

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -529,6 +529,69 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))()).not.toThrow();
   });
 
+  // Round 7 (Codex): an OpenAI-compatible backend addresses a URL and has no
+  // default port, so a classifier configured only with baseUrl resolved to no
+  // port at all and skipped every comparison — while pointing at the reply
+  // server's socket and adopting the reply model, exactly as a bare port would.
+  test("a classifier baseUrl aimed at the reply server is refused", () => {
+    expect(loadYaml([
+      "llm:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: openai-compatible",
+      "  baseUrl: http://127.0.0.1:8080/v1",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/same endpoint as llm \(127\.0\.0\.1:8080\)/);
+  });
+
+  test("a classifier baseUrl colliding with another local listener is refused", () => {
+    expect(loadYaml([
+      "web_voice:",
+      "  enabled: true",
+      "  port: 8090",
+      "  token: a-token-that-is-long-enough",
+      "classifier:",
+      "  backend: openai-compatible",
+      "  baseUrl: http://localhost:8090/v1",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice/);
+  });
+
+  // The reverse pairing too: the reply model behind a URL, the classifier on a
+  // bare port. One seat, named two ways.
+  test("an llm baseUrl is resolved to the same seat as a classifier port", () => {
+    expect(loadYaml([
+      "llm:",
+      "  backend: openai-compatible",
+      "  baseUrl: http://127.0.0.1:8080/v1",
+      "  model: big-reply-model",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8080",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/same endpoint as llm \(127\.0\.0\.1:8080\)/);
+  });
+
+  // A genuinely remote URL still binds nothing here.
+  test("a remote classifier baseUrl is not compared against local ports", () => {
+    expect(() => loadYaml([
+      "web_voice:",
+      "  enabled: true",
+      "  port: 8090",
+      "  token: a-token-that-is-long-enough",
+      "classifier:",
+      "  backend: openai-compatible",
+      "  baseUrl: https://classifier.example/v1",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
   // A listener that is off binds nothing, so it is not in the way.
   test("a disabled listener does not reserve its default port", () => {
     expect(() => loadYaml([

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -491,6 +491,44 @@ describe("Config — fail-fast validation", () => {
     ].join("\n"))).toThrow(/classifier\.port 8090 is already used by web_voice/);
   });
 
+  // Round 6 (Codex): the dashboard is default-ON and starts BEFORE any
+  // provider, so it holds 8086 in every config that does not switch it off —
+  // and it answers 404 on /health, so the classifier's probe does not adopt it
+  // either; llama-server then cannot bind and the role is silently unavailable.
+  test("the default-on dashboard holds its port against a classifier", () => {
+    expect(loadYaml([
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8086",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.port 8086 is already used by dashboard/);
+
+    // Explicitly on, non-default port: still held.
+    expect(loadYaml([
+      "dashboard:",
+      "  enabled: true",
+      "  port: 8099",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8099",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))).toThrow(/classifier\.port 8099 is already used by dashboard/);
+  });
+
+  test("a dashboard switched off frees its port", () => {
+    expect(() => loadYaml([
+      "dashboard:",
+      "  enabled: false",
+      "classifier:",
+      "  backend: llama-cpp",
+      "  port: 8086",
+      "  model: small-classifier-model",
+      "",
+    ].join("\n"))()).not.toThrow();
+  });
+
   // A listener that is off binds nothing, so it is not in the way.
   test("a disabled listener does not reserve its default port", () => {
     expect(() => loadYaml([

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -917,4 +917,76 @@ describe("CiceroDaemon lifecycle", () => {
       throw new Error(`optional warmup test failed: ${(error as Error).message}`, { cause: error });
     }
   });
+
+  // The classifier role exists to answer fast, and its docs promise a model that
+  // is already warm. Startup only ever probed its health — which does not load a
+  // model on any backend: ollama's /api/tags lists what is available, and an
+  // adopted llama-server says nothing about which model is resident. The first
+  // real classification would therefore pay the cold load the role exists to
+  // avoid, so a configured classifier gets a real completion at startup.
+  test("a configured classifier is warmed with a completion, not just health-probed", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cicero-classifier-warmup-test-"));
+    const config = loadConfig({}, { home });
+    config.raw.headless = true;
+    config.raw.dashboard = { enabled: false };
+    config.raw.classifier = { backend: "company-llm-plugin", port: 8093, model: "small-classifier" };
+    // Headless has no local mic or speakers, so a client has to be reachable.
+    config.raw.web_voice = {
+      enabled: true,
+      port: 0,
+      token: "test-token-that-is-long-enough",
+      tls: { enabled: false },
+    };
+    config.raw.brain = {
+      ...config.raw.brain,
+      backend: "qwen",
+      mode: "subprocess",
+      binary: process.execPath,
+      binary_args: ["-e", "console.log('ok')"],
+      thinking_filler: false,
+    };
+    const completions: string[] = [];
+    const health: string[] = [];
+    const daemon = new CiceroDaemon(config, {
+      pidFile: join(home, "cicero.pid"),
+      webVoiceServerStarter: () => ({
+        scheme: "http",
+        port: 18_444,
+        clientCount: () => 0,
+        notify: () => Promise.resolve(null),
+        stop: () => Promise.resolve(),
+      }),
+      providerFactory: () => ({
+        stt: {
+          name: "company-stt-plugin",
+          transcribe: () => Promise.resolve(null),
+          health: () => Promise.resolve(true),
+        },
+        tts: {
+          name: "company-tts-plugin",
+          generateAudio: () => Promise.resolve(new ArrayBuffer(0)),
+          health: () => Promise.resolve(true),
+        },
+        llm: {
+          name: "company-llm-plugin",
+          chatCompletion: () => { completions.push("llm"); return Promise.resolve("ok"); },
+          health: () => Promise.resolve(true),
+        },
+        classifier: {
+          name: "company-classifier-plugin",
+          chatCompletion: () => { completions.push("classifier"); return Promise.resolve("ok"); },
+          health: () => { health.push("classifier"); return Promise.resolve(true); },
+        },
+      }),
+    });
+
+    try {
+      await daemon.start();
+      await Bun.sleep(20);
+      expect(health).toContain("classifier");
+      expect(completions).toContain("classifier");
+    } finally {
+      await daemon.stop().catch(() => {});
+    }
+  });
 });

--- a/tests/daemon-operational-context.test.ts
+++ b/tests/daemon-operational-context.test.ts
@@ -2,7 +2,7 @@ import { afterEach, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig } from "../src/config";
+import { DEFAULT_CONFIG, RuntimeConfig, loadConfig } from "../src/config";
 import { CiceroDaemon, runOperatorChatTurn } from "../src/daemon";
 import { ContextStore } from "../src/brain/context-store";
 import { ActionExecutor } from "../src/executor";
@@ -795,4 +795,38 @@ test("a Telegram/shell health log lands in the daemon store and is visible to th
   expect((await daemon.healthStore!.recent(1))[0]?.value).toBe(82.4);
   // ...and is immediately visible to the snapshot, which reads the store fresh.
   expect(await daemon.operationalContext()).toContain("weight 82.4");
+});
+
+// The classifier takes the same credential fields as the reply model. A key
+// configured there is no less a key, and must never reach a log, a runtime
+// error, or a dashboard event.
+test("daemon secret inventory covers classifier credentials", () => {
+  const inlineKey = "sk-test-CLASSIFIER-INLINE-000000000000";
+  const envKey = "sk-test-CLASSIFIER-ENV-1111111111111111";
+  const headerValue = "Bearer test-CLASSIFIER-HEADER-2222222222";
+  const urlPassword = "test-CLASSIFIER-URLPASS-333333333333";
+  process.env.CICERO_TEST_CLASSIFIER_KEY = envKey;
+  try {
+    // A real RuntimeConfig: classifierBackend is a getter, so a plain object
+    // would silently resolve to undefined and the test would prove nothing.
+    const config = new RuntimeConfig({
+      ...structuredClone(DEFAULT_CONFIG),
+      classifier: {
+        backend: "openai",
+        baseUrl: `https://user:${urlPassword}@classifier.example.test/v1`,
+        apiKey: inlineKey,
+        apiKeyEnv: "CICERO_TEST_CLASSIFIER_KEY",
+        extraHeaders: { Authorization: headerValue },
+      },
+    });
+    const daemon = new CiceroDaemon(config) as unknown as OperationalDaemonHarness;
+
+    const secrets = daemon.snapshotKnownSecrets();
+    expect(secrets).toContain(inlineKey);
+    expect(secrets).toContain(envKey);
+    expect(secrets).toContain(headerValue);
+    expect(secrets).toContain(urlPassword);
+  } finally {
+    delete process.env.CICERO_TEST_CLASSIFIER_KEY;
+  }
 });


### PR DESCRIPTION
## What

Cicero has one model, and it writes replies. But a whole class of decisions are not replies — *was that utterance addressed to me*, *what kind of request is this*, *where should this route* — and those run **per utterance**. Borrowing the reply model for them is not affordable, and on a single-GPU box it is not even schedulable alongside the STT and TTS seats.

This adds a `classifier` role alongside `stt`/`tts`/`llm`: a second, smaller `LLMProvider`, configured separately.

```yaml
classifier:
  backend: llama-cpp        # any backend the llm role supports
  host: 127.0.0.1
  port: 8090
  model: your-small-model
```

Same config shape as `llm:` and the same construction path, so every backend the reply model supports works here too. Registry, runtime factory, startup policy, config schema, `doctor`, `status`, `config.yaml.example` and docs all move together, as `AGENTS.md` requires.

**Nothing consumes it yet.** It is the affordability precondition for Spec 3 (the LLM intent judge) and anything else that wants a per-utterance verdict. Implements Spec 4 from `docs/superpowers/specs/2026-07-28-upstream-findings.md` (PR #60).

## Two things it deliberately does not do

**Absence does not fall back to the reply model.** That fallback is the exact failure this role exists to prevent: it would look like a working feature while quietly costing a full reply per utterance, and it would contend with the STT/TTS seat on a tight box. An absent section means the role is unconfigured, and dependent features stay off and log why. Unlike `llm`, there is no implicit default either.

**A configured-but-unsupported backend is an error, not a fallback** — and the message names `classifier.backend`, not `llm.backend`, since the two are configured separately and either could be the broken one.

It is also never a required primary: a per-utterance helper being down must not stop a daemon that can still hold a conversation.

## A real bug this surfaced

`ServerManager.start()` iterated `providerEntries()` while `stop()` iterated a separate hand-written `[stt, tts, llm]` literal. Adding a role to the first started it and **never stopped it** — a resident model still holding its seat after the daemon reported stopped. Both paths now walk `providerEntries`, so a future role cannot be half-wired the same way. Fixed in `350244d` with a regression that fails against the old literal.

## Review

Codex (`gpt-5.6-sol`, high) reviewed the branch. It confirmed the unsupported-backend error, the no-fallback guarantee, and the lifecycle, and found real gaps fixed in `b5f55ae`:

- **Secret handling.** The classifier takes the same credential fields as the reply model — `apiKey`, `apiKeyEnv`, `extraHeaders`, and a `baseUrl` that can carry userinfo — and **none were in the daemon's secret inventory**. A key configured there could have reached a log, a runtime error, or a dashboard event. Now inventoried exactly like `llm`'s, with a regression that fails when the inventory is removed.
- `doctor` treated only role `llm` as an LLM role, so an `mlx-lm` classifier with no explicit port was diagnosed against `host:undefined` instead of the runtime default.
- Nine `doctor` hints hard-coded `llm.host`/`llm.port`/`llm.model`/`llm.baseUrl` and were being handed to operators debugging their *classifier*.
- Two `docs/classifier.md` sentences described behavior the code does not have (the error names the role, not `classifier.backend`; `doctor` fails rather than warns).
- Three tests read stronger than they were — the remote-vs-local-managed pair differed only in URL construction, never showing the distinction that matters, and the doctor test asserted `level !== "ok"` while excluding only `llm.backend`.

## Verification

- `bun run typecheck` clean, `git diff --check` clean
- `bun test` — 2063 pass, 2 fail; **both fail identically on clean `origin/main`** (an ANSI-colored stderr assertion in `terminal-send-errors`, a "Phone pairing" row in `cli/status`). Neither is touched here.
- 19 new tests: registry construction, the unsupported-backend error, remote-host **and** local-managed modes separately, startup-policy shape, config validation (including that a typo inside the section is still rejected under fail-fast), `doctor` silence-when-absent vs warn-when-unreachable, `status` row placement, and start/stop symmetry.
- Key tests were checked by reverting the code they cover and confirming they fail — including the silent-fallback case and the shutdown literal.
- No live model needed for any of them.

Docs: new `docs/classifier.md`, linked from `docs/README.md` and `docs/configuration.md`.
