### PR TITLE
bench(stt): measure streaming time-to-final, not just batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bench/stt/clips/*.wav
 bench/stt/clips/*.txt
 bench/stt/candidates.json
 bench/stt/last-results.md
+bench/stt/results/
 
 # TTS bench + audiocpp spike artifacts (machine-local / regenerated).
 bench/tts/last-results.md

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -273,7 +273,10 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
     deltasDuringAudio += clipDeltasDuringAudio;
     const { wer } = wordErrorRate(clip.reference, transcript);
     wers.push(wer * 100);
-    if (clipFirst.length) firstDeltas.push(median(clipFirst));
+    // A missing partial is a measured absence, not a sample to discard. Other
+    // latency columns include every successful repetition, so this clip only
+    // contributes first-delta latency when every repetition produced one.
+    if (clipFirst.length === runs) firstDeltas.push(median(clipFirst));
     if (clipFinal.length) finals.push(median(clipFinal));
     if (clipTotal.length) totals.push(median(clipTotal));
   }
@@ -292,7 +295,7 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
     streaming: {
       // NaN, not 0, when a model emitted no partial at all — 0 would read as
       // "instant" in a latency column, which is the opposite of what happened.
-      firstDeltaMs: paced && firstDeltas.length ? median(firstDeltas) : NaN,
+      firstDeltaMs: paced && firstDeltas.length === wers.length ? median(firstDeltas) : NaN,
       finalAfterAudioMs: paced ? median(finals) : NaN,
       deltasDuringAudio: paced ? deltasDuringAudio : NaN,
       paced,

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -231,6 +231,12 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
     const clipFinal: number[] = [];
     const clipTotal: number[] = [];
     let transcript = "";
+    // Staged, not accumulated: run 0's counts belong to a clip that has not
+    // finished its repetitions yet, and folding them in here left the deltas of
+    // a clip rejected by a later failed run standing in the candidate's totals —
+    // a table reading "10 / 11" for a candidate that scored no clips at all.
+    let clipDeltasDuringAudio = 0;
+    let clipDeltas = 0;
     let failed = false;
     for (let r = 0; r < runs; r++) {
       const t0 = performance.now();
@@ -241,8 +247,8 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
         if (res.firstDeltaMs !== null) clipFirst.push(res.firstDeltaMs);
         if (r === 0) {
           transcript = res.text;
-          deltas += res.deltas;
-          deltasDuringAudio += res.deltasDuringAudio;
+          clipDeltas = res.deltas;
+          clipDeltasDuringAudio = res.deltasDuringAudio;
         }
       } catch (err: unknown) {
         failed = true;
@@ -255,6 +261,10 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
     // median over three, and reports errors=0 for a clip that errored.
     if (failed || !transcript) { errors++; continue; }
 
+    // Committed at the same point as the WER and latency medians below: past
+    // the rejection, where the clip is known to have completed every run.
+    deltas += clipDeltas;
+    deltasDuringAudio += clipDeltasDuringAudio;
     const { wer } = wordErrorRate(clip.reference, transcript);
     wers.push(wer * 100);
     if (clipFirst.length) firstDeltas.push(median(clipFirst));

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -136,6 +136,13 @@ interface StreamStats {
   finalAfterAudioMs: number; // median; negative = transcript done before the audio ended
   deltasDuringAudio: number; // summed over clips (first run)
   deltas: number;            // summed over clips (first run)
+  /**
+   * The audio was fed at real time. When it was not (`pace: "fast"`), every
+   * latency here is measured against a clock the model never had to keep, so
+   * they are withheld rather than printed — a fast probe answers "does it
+   * respond at all", not "how quickly does it answer a speaker".
+   */
+  paced: boolean;
 }
 
 interface Row {
@@ -248,6 +255,11 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
     if (clipTotal.length) totals.push(median(clipTotal));
   }
 
+  // A fast upload finishes long before the clip would have been spoken, so
+  // "before the audio ended" is measured against an instant that never
+  // happened: a 10s clip answered at 100ms records -9,900ms time-to-final and
+  // counts every delta as arriving "during" audio. Those are not latencies.
+  const paced = c.pace !== "fast";
   return {
     ...emptyRow(c.name, true),
     meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : NaN,
@@ -257,9 +269,10 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
     streaming: {
       // NaN, not 0, when a model emitted no partial at all — 0 would read as
       // "instant" in a latency column, which is the opposite of what happened.
-      firstDeltaMs: firstDeltas.length ? median(firstDeltas) : NaN,
-      finalAfterAudioMs: median(finals),
-      deltasDuringAudio,
+      firstDeltaMs: paced && firstDeltas.length ? median(firstDeltas) : NaN,
+      finalAfterAudioMs: paced ? median(finals) : NaN,
+      deltasDuringAudio: paced ? deltasDuringAudio : NaN,
+      paced,
       deltas,
     },
   };
@@ -368,8 +381,12 @@ export function renderStreamingTable(rows: Row[]): string {
   const sep = "|---|---:|---:|---:|---:|---:|---:|";
   const lines = avail.map((r) => {
     const s = r.streaming!;
-    const during = s.deltas ? `${s.deltasDuringAudio} / ${s.deltas}` : "0";
-    return `| ${r.name} | ${fmt(r.meanWerPct)} | ${fmt(s.firstDeltaMs, 0)} | ${during} | ${fmt(s.finalAfterAudioMs, 0)} | ${r.errors} | ${r.clips} |`;
+    const during = !s.paced ? "n/a"
+      : s.deltas ? `${s.deltasDuringAudio} / ${s.deltas}` : "0";
+    // A fast probe is still a real accuracy measurement, so it is ranked — but
+    // it is named as what it is, because every latency on its row is withheld.
+    const name = s.paced ? r.name : `${r.name} (fast probe)`;
+    return `| ${name} | ${fmt(r.meanWerPct)} | ${fmt(s.firstDeltaMs, 0)} | ${during} | ${fmt(s.finalAfterAudioMs, 0)} | ${r.errors} | ${r.clips} |`;
   });
   return [
     "### Streaming (real-time feed, `/v1/audio/transcriptions/live`)",
@@ -381,6 +398,11 @@ export function renderStreamingTable(rows: Row[]): string {
     + " relative to the last sample (negative = done before the audio ended). `n/a` first delta"
     + " means the model emitted no partial at all — it buffers internally and behaves like a"
     + " batch model over this endpoint._",
+    "",
+    "_A `(fast probe)` row was fed as quickly as the socket accepted it rather than at real"
+    + " time, so its latency columns are withheld: they would be measured against a clock the"
+    + " model never had to keep. Its WER is a real measurement. Re-run it without"
+    + " `\"pace\": \"fast\"` to get latencies._",
   ].join("\n");
 }
 

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -7,14 +7,19 @@
  * (process-time / audio-duration), then prints a ranked table and writes a
  * markdown report.
  *
- * SCOPE / HONEST LIMITATION: this is a *batch* bench — it transcribes whole
- * clips. That's the right axis for accuracy (WER) and throughput (RTF), and it
- * surfaces cold-vs-warm load cost. It does NOT measure true *streaming*
- * time-to-first-partial / time-to-final, which is what a live loop actually feels
- * (see realtime-stt-selection-jun2026.md: STT streams while the user talks, so
- * its marginal latency is small and the LLM TTFT dominates). Use this to compare
- * accuracy + footprint + batch speed; confirm streaming feel with a live mic test
- * on the model you shortlist.
+ * Two measurement modes, reported in separate tables because their latencies are
+ * not comparable:
+ *
+ *  - `provider` / `command` candidates are **batch**: transcribe a whole clip,
+ *    time it end to end. Right axis for accuracy (WER) and throughput (RTF), and
+ *    it surfaces cold-vs-warm load cost.
+ *  - `stream` candidates drive audio.cpp's `POST /v1/audio/transcriptions/live`,
+ *    feeding PCM at real-time pace and timing the SSE deltas: first partial,
+ *    partials arriving *during* capture, and time-to-final measured from the end
+ *    of the audio. This is what a live loop actually feels.
+ *
+ * Streaming still doesn't tell you how a model handles your room and your mic —
+ * every clip here is a recording. Confirm the shortlist with a live mic test.
  *
  * Run:  bun run bench:stt
  *       bun run bench/stt-bench.ts --clips bench/stt/clips --candidates bench/stt/candidates.json --runs 3
@@ -26,7 +31,8 @@ import { MlxWhisperProvider } from "../src/backends/stt/mlx-whisper";
 import { FasterWhisperProvider } from "../src/backends/stt/faster-whisper";
 import type { STTProvider } from "../src/backends/stt/provider";
 import { wordErrorRate } from "./stt/wer";
-import type { Candidate, Clip, ProviderCandidate } from "./stt/types";
+import { transcribeLive } from "./stt/live-stream";
+import type { Candidate, Clip, ProviderCandidate, StreamCandidate } from "./stt/types";
 
 interface Args { clipsDir: string; candidatesFile: string; runs: number }
 
@@ -88,8 +94,10 @@ function makeProvider(c: ProviderCandidate): STTProvider {
   return c.backend === "faster-whisper" ? new FasterWhisperProvider(cfg) : new MlxWhisperProvider(cfg);
 }
 
-/** Build a transcribe(path)→text fn for a candidate, or null if it's unavailable. */
-async function makeRunner(c: Candidate): Promise<((audioPath: string) => Promise<string>) | null> {
+/** Build a transcribe(path)→text fn for a batch candidate, or null if it's unavailable. */
+async function makeRunner(
+  c: Exclude<Candidate, StreamCandidate>,
+): Promise<((audioPath: string) => Promise<string>) | null> {
   if (c.kind === "provider") {
     const provider = makeProvider(c);
     if (!(await provider.health())) {
@@ -119,6 +127,14 @@ const median = (xs: number[]): number => {
   return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
 };
 
+/** Streaming-only metrics; absent on batch rows, which have no meaningful value for them. */
+interface StreamStats {
+  firstDeltaMs: number;      // median across clips, from the first PCM byte
+  finalAfterAudioMs: number; // median; negative = transcript done before the audio ended
+  deltasDuringAudio: number; // summed over clips (first run)
+  deltas: number;            // summed over clips (first run)
+}
+
 interface Row {
   name: string;
   available: boolean;
@@ -128,11 +144,94 @@ interface Row {
   rtf: number;          // warmMs / audioDuration; <1 = faster than realtime
   errors: number;       // clips that failed/empty
   clips: number;
+  streaming?: StreamStats;
+}
+
+const emptyRow = (name: string, available: boolean): Row =>
+  ({ name, available, meanWerPct: 0, warmMs: 0, coldMs: 0, rtf: 0, errors: 0, clips: 0 });
+
+/** Cheap liveness probe — a stream candidate has no provider `health()` to ask. */
+async function portOpen(host: string, port: number): Promise<boolean> {
+  try {
+    const sock = await Bun.connect({ hostname: host, port, socket: { data: () => {} } });
+    sock.end();
+    return true;
+  } catch { return false; }
+}
+
+/**
+ * Feed each clip at real-time pace and time the deltas. Note the wall-clock cost:
+ * a real-time feed spends at least the clip's duration per run, so a 75s clip set
+ * at 3 runs is ~4 minutes per candidate before the model does any work.
+ */
+async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], runs: number): Promise<Row> {
+  const host = c.host ?? "127.0.0.1";
+  if (!(await portOpen(host, c.port))) {
+    console.warn(`  ⚠️  ${c.name}: nothing listening on ${host}:${c.port} — skipping`);
+    return emptyRow(c.name, false);
+  }
+
+  const wers: number[] = [];
+  const firstDeltas: number[] = [];
+  const finals: number[] = [];
+  const totals: number[] = [];
+  let deltasDuringAudio = 0;
+  let deltas = 0;
+  let errors = 0;
+
+  for (const clip of clips) {
+    const clipFirst: number[] = [];
+    const clipFinal: number[] = [];
+    const clipTotal: number[] = [];
+    let transcript = "";
+    for (let r = 0; r < runs; r++) {
+      const t0 = performance.now();
+      try {
+        const res = await transcribeLive(clip.path, c);
+        clipTotal.push(performance.now() - t0);
+        clipFinal.push(res.finalAfterAudioMs);
+        if (res.firstDeltaMs !== null) clipFirst.push(res.firstDeltaMs);
+        if (r === 0) {
+          transcript = res.text;
+          deltas += res.deltas;
+          deltasDuringAudio += res.deltasDuringAudio;
+        }
+      } catch (err: unknown) {
+        console.warn(`  ⚠️  ${c.name} / ${clip.name}: ${err instanceof Error ? err.message : String(err)}`);
+        break;
+      }
+    }
+    if (!transcript) { errors++; continue; }
+
+    const { wer } = wordErrorRate(clip.reference, transcript);
+    wers.push(wer * 100);
+    if (clipFirst.length) firstDeltas.push(median(clipFirst));
+    if (clipFinal.length) finals.push(median(clipFinal));
+    if (clipTotal.length) totals.push(median(clipTotal));
+  }
+
+  return {
+    ...emptyRow(c.name, true),
+    meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : 0,
+    warmMs: median(totals),
+    errors,
+    clips: wers.length,
+    streaming: {
+      // NaN, not 0, when a model emitted no partial at all — 0 would read as
+      // "instant" in a latency column, which is the opposite of what happened.
+      firstDeltaMs: firstDeltas.length ? median(firstDeltas) : NaN,
+      finalAfterAudioMs: median(finals),
+      deltasDuringAudio,
+      deltas,
+    },
+  };
 }
 
 async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promise<Row> {
+  if (c.kind === "stream") return benchStreamCandidate(c, clips, runs);
+
   const runner = await makeRunner(c);
-  if (!runner) return { name: c.name, available: false, meanWerPct: 0, warmMs: 0, coldMs: 0, rtf: 0, errors: 0, clips: 0 };
+  if (!runner) return emptyRow(c.name, false);
 
   const wers: number[] = [];
   const warmTimes: number[] = [];
@@ -182,16 +281,45 @@ async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promis
   };
 }
 
+const fmt = (n: number, d = 1) => (Number.isFinite(n) ? n.toFixed(d) : "n/a");
+
 function renderTable(rows: Row[]): string {
-  const avail = rows.filter((r) => r.available).sort((a, b) => a.meanWerPct - b.meanWerPct);
+  const avail = rows.filter((r) => r.available && !r.streaming).sort((a, b) => a.meanWerPct - b.meanWerPct);
   const header = "| Candidate | WER % | warm ms | cold ms | RTF | errors | clips |";
   const sep = "|---|---:|---:|---:|---:|---:|---:|";
-  const fmt = (n: number, d = 1) => (Number.isFinite(n) ? n.toFixed(d) : "n/a");
   const lines = avail.map((r) =>
     `| ${r.name} | ${fmt(r.meanWerPct)} | ${fmt(r.warmMs, 0)} | ${fmt(r.coldMs, 0)} | ${r.rtf ? fmt(r.rtf, 3) : "n/a"} | ${r.errors} | ${r.clips} |`,
   );
   const skipped = rows.filter((r) => !r.available).map((r) => `- ${r.name} (unavailable — server down or command missing)`);
   return [header, sep, ...lines, ...(skipped.length ? ["", "**Skipped:**", ...skipped] : [])].join("\n");
+}
+
+/**
+ * Streaming rows get their own table: "warm ms" for a real-time feed is dominated
+ * by the clip's own duration, so putting it beside a batch latency would invite a
+ * comparison that means nothing. Time-to-final is measured from the end of the
+ * audio, which is the number a live loop actually waits out.
+ */
+function renderStreamingTable(rows: Row[]): string {
+  const avail = rows.filter((r) => r.available && r.streaming).sort((a, b) => a.meanWerPct - b.meanWerPct);
+  if (!avail.length) return "";
+  const header = "| Candidate | WER % | first delta ms | deltas during audio | final after audio ms | errors | clips |";
+  const sep = "|---|---:|---:|---:|---:|---:|---:|";
+  const lines = avail.map((r) => {
+    const s = r.streaming!;
+    const during = s.deltas ? `${s.deltasDuringAudio} / ${s.deltas}` : "0";
+    return `| ${r.name} | ${fmt(r.meanWerPct)} | ${fmt(s.firstDeltaMs, 0)} | ${during} | ${fmt(s.finalAfterAudioMs, 0)} | ${r.errors} | ${r.clips} |`;
+  });
+  return [
+    "### Streaming (real-time feed, `/v1/audio/transcriptions/live`)",
+    "",
+    header, sep, ...lines,
+    "",
+    "_`first delta` is from the first PCM byte; `final after audio` is `transcript.text.done`"
+    + " relative to the last sample (negative = done before the audio ended). `n/a` first delta"
+    + " means the model emitted no partial at all — it buffers internally and behaves like a"
+    + " batch model over this endpoint._",
+  ].join("\n");
 }
 
 async function main(): Promise<void> {
@@ -215,22 +343,33 @@ async function main(): Promise<void> {
   }
 
   const table = renderTable(rows);
+  const streamTable = renderStreamingTable(rows);
   console.log(`\n${table}\n`);
-  console.log("RTF < 1 = faster than real-time. WER lower = better. Batch latency only — confirm streaming feel live.");
+  if (streamTable) console.log(`${streamTable}\n`);
+  console.log("RTF < 1 = faster than real-time. WER lower = better. Recorded clips only — confirm the shortlist with a live mic test.");
 
+  const stamp = new Date().toISOString();
   const report = [
-    `# STT bench — ${new Date().toISOString()}`,
+    `# STT bench — ${stamp}`,
     "",
     `Clips: ${clips.length} (${totalAudio.toFixed(1)}s), runs/clip: ${args.runs}`,
     "",
-    table,
+    "### Batch (whole-clip transcribe)",
     "",
-    "_Batch transcribe latency + accuracy. Does NOT measure streaming time-to-final — confirm that with a live mic test._",
+    table,
+    ...(streamTable ? ["", streamTable] : []),
+    "",
+    "_Every clip here is a recording: this measures accuracy, batch latency and streaming"
+    + " time-to-final, not how a model copes with your room and mic._",
     "",
   ].join("\n");
+  // Archived under a run stamp as well, because last-results.md is overwritten on
+  // every run — losing a sweep to a one-candidate re-run is otherwise easy.
+  const archivePath = resolve(`bench/stt/results/${stamp.replace(/[:.]/g, "-")}.md`);
   const reportPath = resolve("bench/stt/last-results.md");
+  await Bun.write(archivePath, report);
   await Bun.write(reportPath, report);
-  console.log(`\nReport written to ${reportPath}`);
+  console.log(`\nReport written to ${reportPath} (archived: ${archivePath})`);
 }
 
 main().catch((err: unknown) => {

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -31,7 +31,7 @@ import { MlxWhisperProvider } from "../src/backends/stt/mlx-whisper";
 import { FasterWhisperProvider } from "../src/backends/stt/faster-whisper";
 import type { STTProvider } from "../src/backends/stt/provider";
 import { wordErrorRate } from "./stt/wer";
-import { transcribeLive } from "./stt/live-stream";
+import { transcribeLive, type LiveStreamConnect } from "./stt/live-stream";
 import type { Candidate, Clip, ProviderCandidate, StreamCandidate } from "./stt/types";
 
 interface Args { clipsDir: string; candidatesFile: string; runs: number }
@@ -150,13 +150,43 @@ interface Row {
 const emptyRow = (name: string, available: boolean): Row =>
   ({ name, available, meanWerPct: 0, warmMs: 0, coldMs: 0, rtf: 0, errors: 0, clips: 0 });
 
+/*
+ * A candidate host that silently drops SYNs would otherwise hold this probe for
+ * the OS TCP timeout — minutes, before the bench has measured anything. Five
+ * seconds is generous for a reachable host on a LAN or over a VPN, and a host
+ * slower than that is not one these timings would mean anything against.
+ */
+const PORT_PROBE_TIMEOUT_MS = 5_000;
+
 /** Cheap liveness probe — a stream candidate has no provider `health()` to ask. */
-async function portOpen(host: string, port: number): Promise<boolean> {
+export async function portOpen(
+  host: string,
+  port: number,
+  options: { timeoutMs?: number; connect?: LiveStreamConnect } = {},
+): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? PORT_PROBE_TIMEOUT_MS;
+  const connect = options.connect ?? ((connectOptions) => Bun.connect(connectOptions));
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let expired = false;
+  const connecting = connect({ hostname: host, port, socket: { data: () => {} } });
+  // A socket that arrives after the probe gave up still has to be released, or
+  // the bench leaks one per unreachable candidate.
+  void connecting.then((sock) => { if (expired) sock.terminate(); }, () => {});
   try {
-    const sock = await Bun.connect({ hostname: host, port, socket: { data: () => {} } });
+    const sock = await Promise.race([
+      connecting,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          expired = true;
+          reject(new Error(`no connection to ${host}:${port} within ${timeoutMs} ms`));
+        }, timeoutMs);
+      }),
+    ]);
     sock.end();
     return true;
-  } catch { return false; }
+  } catch { return false; } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**
@@ -372,7 +402,12 @@ async function main(): Promise<void> {
   console.log(`\nReport written to ${reportPath} (archived: ${archivePath})`);
 }
 
-main().catch((err: unknown) => {
-  console.error(`STT bench failed: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-});
+// Only run the sweep when this file IS the entry point. Without the guard,
+// importing anything from here — as the liveness-probe regression does — starts
+// a whole bench run as a side effect of the import.
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error(`STT bench failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -120,8 +120,11 @@ async function makeRunner(
   };
 }
 
-const median = (xs: number[]): number => {
-  if (!xs.length) return 0;
+export const median = (xs: number[]): number => {
+  // NaN, not 0, for no samples. Every consumer of this is a latency or accuracy
+  // column, where 0 reads as "instant" or "perfect" — the opposite of "we never
+  // got a measurement". `fmt` renders non-finite as "n/a".
+  if (!xs.length) return NaN;
   const s = [...xs].sort((a, b) => a - b);
   const mid = Math.floor(s.length / 2);
   return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
@@ -148,7 +151,7 @@ interface Row {
 }
 
 const emptyRow = (name: string, available: boolean): Row =>
-  ({ name, available, meanWerPct: 0, warmMs: 0, coldMs: 0, rtf: 0, errors: 0, clips: 0 });
+  ({ name, available, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 });
 
 /*
  * A candidate host that silently drops SYNs would otherwise hold this probe for
@@ -194,7 +197,7 @@ export async function portOpen(
  * a real-time feed spends at least the clip's duration per run, so a 75s clip set
  * at 3 runs is ~4 minutes per candidate before the model does any work.
  */
-async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], runs: number): Promise<Row> {
+export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], runs: number): Promise<Row> {
   const host = c.host ?? "127.0.0.1";
   if (!(await portOpen(host, c.port))) {
     console.warn(`  ⚠️  ${c.name}: nothing listening on ${host}:${c.port} — skipping`);
@@ -214,6 +217,7 @@ async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], runs: num
     const clipFinal: number[] = [];
     const clipTotal: number[] = [];
     let transcript = "";
+    let failed = false;
     for (let r = 0; r < runs; r++) {
       const t0 = performance.now();
       try {
@@ -227,11 +231,15 @@ async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], runs: num
           deltasDuringAudio += res.deltasDuringAudio;
         }
       } catch (err: unknown) {
+        failed = true;
         console.warn(`  ⚠️  ${c.name} / ${clip.name}: ${err instanceof Error ? err.message : String(err)}`);
         break;
       }
     }
-    if (!transcript) { errors++; continue; }
+    // A clip counts only when every repetition finished. Scoring one that
+    // failed run 2 of 3 mixes a median over one sample into a column read as a
+    // median over three, and reports errors=0 for a clip that errored.
+    if (failed || !transcript) { errors++; continue; }
 
     const { wer } = wordErrorRate(clip.reference, transcript);
     wers.push(wer * 100);
@@ -242,7 +250,7 @@ async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], runs: num
 
   return {
     ...emptyRow(c.name, true),
-    meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : 0,
+    meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : NaN,
     warmMs: median(totals),
     errors,
     clips: wers.length,
@@ -287,7 +295,7 @@ async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promis
         break;
       }
     }
-    if (failed && !transcript) { errors++; continue; }
+    if (failed || !transcript) { errors++; continue; }
 
     const { wer } = wordErrorRate(clip.reference, transcript);
     wers.push(wer * 100);
@@ -302,7 +310,7 @@ async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promis
   return {
     name: c.name,
     available: true,
-    meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : 0,
+    meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : NaN,
     warmMs: median(warmTimes),
     coldMs: median(coldTimes),
     rtf: median(rtfs),
@@ -313,15 +321,37 @@ async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promis
 
 const fmt = (n: number, d = 1) => (Number.isFinite(n) ? n.toFixed(d) : "n/a");
 
-function renderTable(rows: Row[]): string {
-  const avail = rows.filter((r) => r.available && !r.streaming).sort((a, b) => a.meanWerPct - b.meanWerPct);
+/**
+ * Rows that scored at least one clip, best WER first. A candidate whose every
+ * run failed is deliberately NOT here: it has no WER to rank by, and leaving it
+ * in put it at the top of a table sorted ascending — a candidate that produced
+ * nothing rendered as the most accurate one.
+ */
+const ranked = (rows: Row[], streaming: boolean): Row[] =>
+  rows.filter((r) => r.available && !!r.streaming === streaming && r.clips > 0)
+    .sort((a, b) => a.meanWerPct - b.meanWerPct);
+
+/** Reachable, but every run failed — reported, never ranked. */
+const allFailed = (rows: Row[], streaming: boolean): Row[] =>
+  rows.filter((r) => r.available && !!r.streaming === streaming && r.clips === 0);
+
+const failedLine = (r: Row): string =>
+  `- ${r.name} (reachable, but every clip failed — ${r.errors} ${r.errors === 1 ? "error" : "errors"}; no metrics)`;
+
+export function renderTable(rows: Row[]): string {
+  const avail = ranked(rows, false);
   const header = "| Candidate | WER % | warm ms | cold ms | RTF | errors | clips |";
   const sep = "|---|---:|---:|---:|---:|---:|---:|";
   const lines = avail.map((r) =>
     `| ${r.name} | ${fmt(r.meanWerPct)} | ${fmt(r.warmMs, 0)} | ${fmt(r.coldMs, 0)} | ${r.rtf ? fmt(r.rtf, 3) : "n/a"} | ${r.errors} | ${r.clips} |`,
   );
+  const failed = allFailed(rows, false).map(failedLine);
   const skipped = rows.filter((r) => !r.available).map((r) => `- ${r.name} (unavailable — server down or command missing)`);
-  return [header, sep, ...lines, ...(skipped.length ? ["", "**Skipped:**", ...skipped] : [])].join("\n");
+  return [
+    header, sep, ...lines,
+    ...(failed.length ? ["", "**Failed:**", ...failed] : []),
+    ...(skipped.length ? ["", "**Skipped:**", ...skipped] : []),
+  ].join("\n");
 }
 
 /**
@@ -330,9 +360,10 @@ function renderTable(rows: Row[]): string {
  * comparison that means nothing. Time-to-final is measured from the end of the
  * audio, which is the number a live loop actually waits out.
  */
-function renderStreamingTable(rows: Row[]): string {
-  const avail = rows.filter((r) => r.available && r.streaming).sort((a, b) => a.meanWerPct - b.meanWerPct);
-  if (!avail.length) return "";
+export function renderStreamingTable(rows: Row[]): string {
+  const avail = ranked(rows, true);
+  const failed = allFailed(rows, true);
+  if (!avail.length && !failed.length) return "";
   const header = "| Candidate | WER % | first delta ms | deltas during audio | final after audio ms | errors | clips |";
   const sep = "|---|---:|---:|---:|---:|---:|---:|";
   const lines = avail.map((r) => {
@@ -344,6 +375,7 @@ function renderStreamingTable(rows: Row[]): string {
     "### Streaming (real-time feed, `/v1/audio/transcriptions/live`)",
     "",
     header, sep, ...lines,
+    ...(failed.length ? ["", "**Failed:**", ...failed.map(failedLine)] : []),
     "",
     "_`first delta` is from the first PCM byte; `final after audio` is `transcript.text.done`"
     + " relative to the last sample (negative = done before the audio ended). `n/a` first delta"

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -147,6 +147,13 @@ interface StreamStats {
 
 interface Row {
   name: string;
+  /**
+   * Which table this row belongs in. Explicit rather than inferred from the
+   * presence of `streaming`, because a candidate that never started has no
+   * metrics to infer from — an unreachable streaming server was being listed
+   * as skipped under the batch heading.
+   */
+  kind: "batch" | "stream";
   available: boolean;
   meanWerPct: number;
   warmMs: number;       // median warm transcribe time
@@ -157,8 +164,8 @@ interface Row {
   streaming?: StreamStats;
 }
 
-const emptyRow = (name: string, available: boolean): Row =>
-  ({ name, available, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 });
+const emptyRow = (name: string, available: boolean, kind: Row["kind"]): Row =>
+  ({ name, kind, available, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 });
 
 /*
  * A candidate host that silently drops SYNs would otherwise hold this probe for
@@ -208,7 +215,7 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
   const host = c.host ?? "127.0.0.1";
   if (!(await portOpen(host, c.port))) {
     console.warn(`  ⚠️  ${c.name}: nothing listening on ${host}:${c.port} — skipping`);
-    return emptyRow(c.name, false);
+    return emptyRow(c.name, false, "stream");
   }
 
   const wers: number[] = [];
@@ -261,7 +268,7 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
   // counts every delta as arriving "during" audio. Those are not latencies.
   const paced = c.pace !== "fast";
   return {
-    ...emptyRow(c.name, true),
+    ...emptyRow(c.name, true, "stream"),
     meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : NaN,
     warmMs: median(totals),
     errors,
@@ -282,7 +289,7 @@ async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promis
   if (c.kind === "stream") return benchStreamCandidate(c, clips, runs);
 
   const runner = await makeRunner(c);
-  if (!runner) return emptyRow(c.name, false);
+  if (!runner) return emptyRow(c.name, false, "batch");
 
   const wers: number[] = [];
   const warmTimes: number[] = [];
@@ -322,6 +329,7 @@ async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promis
 
   return {
     name: c.name,
+    kind: "batch",
     available: true,
     meanWerPct: wers.length ? wers.reduce((a, b) => a + b, 0) / wers.length : NaN,
     warmMs: median(warmTimes),
@@ -340,30 +348,37 @@ const fmt = (n: number, d = 1) => (Number.isFinite(n) ? n.toFixed(d) : "n/a");
  * in put it at the top of a table sorted ascending — a candidate that produced
  * nothing rendered as the most accurate one.
  */
-const ranked = (rows: Row[], streaming: boolean): Row[] =>
-  rows.filter((r) => r.available && !!r.streaming === streaming && r.clips > 0)
+const ranked = (rows: Row[], kind: Row["kind"]): Row[] =>
+  rows.filter((r) => r.kind === kind && r.available && r.clips > 0)
     .sort((a, b) => a.meanWerPct - b.meanWerPct);
 
 /** Reachable, but every run failed — reported, never ranked. */
-const allFailed = (rows: Row[], streaming: boolean): Row[] =>
-  rows.filter((r) => r.available && !!r.streaming === streaming && r.clips === 0);
+const allFailed = (rows: Row[], kind: Row["kind"]): Row[] =>
+  rows.filter((r) => r.kind === kind && r.available && r.clips === 0);
+
+/** Never started at all — listed under its own kind's table, not somebody else's. */
+const skipped = (rows: Row[], kind: Row["kind"]): Row[] =>
+  rows.filter((r) => r.kind === kind && !r.available);
+
+const skippedLine = (r: Row): string =>
+  `- ${r.name} (unavailable — server down or command missing)`;
 
 const failedLine = (r: Row): string =>
   `- ${r.name} (reachable, but every clip failed — ${r.errors} ${r.errors === 1 ? "error" : "errors"}; no metrics)`;
 
 export function renderTable(rows: Row[]): string {
-  const avail = ranked(rows, false);
+  const avail = ranked(rows, "batch");
   const header = "| Candidate | WER % | warm ms | cold ms | RTF | errors | clips |";
   const sep = "|---|---:|---:|---:|---:|---:|---:|";
   const lines = avail.map((r) =>
     `| ${r.name} | ${fmt(r.meanWerPct)} | ${fmt(r.warmMs, 0)} | ${fmt(r.coldMs, 0)} | ${r.rtf ? fmt(r.rtf, 3) : "n/a"} | ${r.errors} | ${r.clips} |`,
   );
-  const failed = allFailed(rows, false).map(failedLine);
-  const skipped = rows.filter((r) => !r.available).map((r) => `- ${r.name} (unavailable — server down or command missing)`);
+  const failed = allFailed(rows, "batch").map(failedLine);
+  const notStarted = skipped(rows, "batch").map(skippedLine);
   return [
     header, sep, ...lines,
     ...(failed.length ? ["", "**Failed:**", ...failed] : []),
-    ...(skipped.length ? ["", "**Skipped:**", ...skipped] : []),
+    ...(notStarted.length ? ["", "**Skipped:**", ...notStarted] : []),
   ].join("\n");
 }
 
@@ -374,9 +389,10 @@ export function renderTable(rows: Row[]): string {
  * audio, which is the number a live loop actually waits out.
  */
 export function renderStreamingTable(rows: Row[]): string {
-  const avail = ranked(rows, true);
-  const failed = allFailed(rows, true);
-  if (!avail.length && !failed.length) return "";
+  const avail = ranked(rows, "stream");
+  const failed = allFailed(rows, "stream");
+  const notStarted = skipped(rows, "stream");
+  if (!avail.length && !failed.length && !notStarted.length) return "";
   const header = "| Candidate | WER % | first delta ms | deltas during audio | final after audio ms | errors | clips |";
   const sep = "|---|---:|---:|---:|---:|---:|---:|";
   const lines = avail.map((r) => {
@@ -393,6 +409,7 @@ export function renderStreamingTable(rows: Row[]): string {
     "",
     header, sep, ...lines,
     ...(failed.length ? ["", "**Failed:**", ...failed.map(failedLine)] : []),
+    ...(notStarted.length ? ["", "**Skipped:**", ...notStarted.map(skippedLine)] : []),
     "",
     "_`first delta` is from the first PCM byte; `final after audio` is `transcript.text.done`"
     + " relative to the last sample (negative = done before the audio ended). `n/a` first delta"

--- a/bench/stt-bench.ts
+++ b/bench/stt-bench.ts
@@ -30,11 +30,17 @@ import { decodeWav } from "../src/platform/wav";
 import { MlxWhisperProvider } from "../src/backends/stt/mlx-whisper";
 import { FasterWhisperProvider } from "../src/backends/stt/faster-whisper";
 import type { STTProvider } from "../src/backends/stt/provider";
+import { sanitizeLabel } from "../src/text-utils";
 import { wordErrorRate } from "./stt/wer";
 import { transcribeLive, type LiveStreamConnect } from "./stt/live-stream";
 import type { Candidate, Clip, ProviderCandidate, StreamCandidate } from "./stt/types";
 
 interface Args { clipsDir: string; candidatesFile: string; runs: number }
+
+const MAX_SURFACED_ERROR_CHARS = 512;
+
+const surfacedError = (error: unknown): string =>
+  sanitizeLabel(error instanceof Error ? error.message : String(error), MAX_SURFACED_ERROR_CHARS);
 
 function parseArgs(argv: string[]): Args {
   const get = (flag: string): string | undefined => {
@@ -252,7 +258,7 @@ export async function benchStreamCandidate(c: StreamCandidate, clips: Clip[], ru
         }
       } catch (err: unknown) {
         failed = true;
-        console.warn(`  ⚠️  ${c.name} / ${clip.name}: ${err instanceof Error ? err.message : String(err)}`);
+        console.warn(`  ⚠️  ${c.name} / ${clip.name}: ${surfacedError(err)}`);
         break;
       }
     }
@@ -321,7 +327,7 @@ async function benchCandidate(c: Candidate, clips: Clip[], runs: number): Promis
         if (!text) failed = true;
       } catch (err: unknown) {
         failed = true;
-        console.warn(`  ⚠️  ${c.name} / ${clip.name}: ${err instanceof Error ? err.message : String(err)}`);
+        console.warn(`  ⚠️  ${c.name} / ${clip.name}: ${surfacedError(err)}`);
         break;
       }
     }

--- a/bench/stt/README.md
+++ b/bench/stt/README.md
@@ -22,18 +22,26 @@ Drop test audio in `bench/stt/clips/` as **`name.wav` + `name.txt`** (the `.txt`
 
 ## 2. Pick candidates
 
-Copy `candidates.example.json` → `candidates.json` and edit. Two kinds:
+Copy `candidates.example.json` → `candidates.json` and edit. Three kinds:
 
 - **`provider`** — an integrated Cicero backend (`mlx-whisper`, `faster-whisper`). Its server must already be running (the bench health-checks and skips it if down).
 - **`command`** — any CLI model not yet wired into Cicero (Kyutai, parakeet-mlx, Moonshine). It must print **only the transcript** to stdout; `{audio}` is replaced with the WAV path. This is how you compare a candidate *before* writing a full backend for it.
+- **`stream`** — an audio.cpp model driven over `POST /v1/audio/transcriptions/live`: PCM fed up a chunked request body at real-time pace, SSE deltas timed as they arrive. The only kind that measures streaming time-to-final. Needs a `mode: "streaming"` model and an audio.cpp build with that endpoint (upstream PR #144).
 
-The example file has templates for the June-2026 research picks — install the model, fix the command to match its CLI, and move it into the `candidates` array.
+The example file carries templates under `_templates` for the June-2026 research picks and the audio.cpp seats — install the model, fix the command to match its CLI, and move the entry into the `candidates` array. (Only `candidates` is read; anything else in the file is ignored, so templates can sit there indefinitely.)
+
+**Point audio.cpp candidates at an isolated server, not the live seat.** Both `command` and `stream` candidates hold the model lock for the whole run; aimed at the seat Cicero is using, they will stall your voice loop.
 
 ## What it measures — and what it doesn't
 
 - ✅ **WER** vs your references (normalized: case/punctuation-insensitive).
 - ✅ **Latency**: cold (first run, includes model load) vs warm (median of the rest).
 - ✅ **RTF** = warm transcribe time ÷ audio duration; `< 1` is faster than real-time.
-- ❌ **Streaming time-to-final** — this is a *batch* bench (whole-clip transcribe). In the live loop STT streams while you talk, so its marginal latency is small and the LLM TTFT dominates (see `wiki/research/cicero/realtime-stt-selection-jun2026.md`). Use this for accuracy + footprint + batch speed, then confirm the streaming *feel* of your shortlist with a live mic test.
+- ✅ **Streaming time-to-final** (`stream` candidates only) — time to the first partial, how many partials landed *while the audio was still uploading*, and when the final transcript arrived relative to the end of the audio. Reported in its own table: a real-time feed spends at least the clip's duration by construction, so its wall-clock is not comparable to a batch latency.
+- ❌ **Your room and your mic.** Every clip here is a recording, replayed. Streaming timings tell you whether a model emits during capture; they say nothing about how it copes with a noisy room, a far mic, or a false VAD cut. Confirm the shortlist live.
 
-Results print to the console and write to `bench/stt/last-results.md`.
+Whether partials arrive during capture is a property of the **model**, not the endpoint. A model that buffers internally reports `n/a` first delta and `0` deltas during audio — that is the real answer, and it means streaming buys you only the emission tail.
+
+**Cost warning:** a real-time `stream` run takes at least the total clip duration per run. 75 s of clips × 3 runs ≈ 4 minutes per candidate before the model does any work. Set `"pace": "fast"` to check a model responds at all — but the resulting timings are not streaming latencies and shouldn't be quoted as any.
+
+Results print to the console and write to `bench/stt/last-results.md`, plus a run-stamped copy under `bench/stt/results/` (both git-ignored). `last-results.md` is **overwritten every run** — keep notes and merged comparisons somewhere else.

--- a/bench/stt/candidates.example.json
+++ b/bench/stt/candidates.example.json
@@ -1,14 +1,18 @@
 {
-  "_comment": "Copy to candidates.json and edit. 'provider' = an integrated Cicero backend (its server must be running). 'command' = any CLI model not yet wired in; it must print ONLY the transcript to stdout, with {audio} replaced by the WAV path. Uncomment (remove the leading _) the models you've installed.",
+  "_comment": "Copy to candidates.json and edit. Three kinds: 'provider' = an integrated Cicero backend (its server must be running). 'command' = any CLI model not yet wired in; it must print ONLY the transcript to stdout, with {audio} replaced by the WAV path. 'stream' = an audio.cpp model fed at real-time pace over POST /v1/audio/transcriptions/live, which is the only kind that measures streaming time-to-final. Move the templates you want out of _templates and into candidates.",
+  "_warning": "Point audio.cpp candidates at an ISOLATED server, never the seat Cicero is live on — a bench run holds the model lock for its whole duration. A 'stream' run also costs at least the total clip duration per run, by construction.",
 
   "candidates": [
-    { "name": "mlx-whisper (current)", "kind": "provider", "backend": "mlx-whisper", "port": 8083 },
+    { "name": "mlx-whisper (current)", "kind": "provider", "backend": "mlx-whisper", "port": 8083 }
+  ],
 
-    "--- templates below: rename the model CLIs to match your install, then move into the array ---",
+  "_templates": {
+    "kyutai":    { "name": "kyutai-stt-1b (mlx)", "kind": "command", "command": "python -m moshi_mlx.run_stt {audio}" },
+    "parakeet":  { "name": "parakeet-mlx",        "kind": "command", "command": "parakeet-mlx transcribe {audio} --output-format txt" },
+    "moonshine": { "name": "moonshine-base",      "kind": "command", "command": "moonshine transcribe --model base {audio}" },
+    "faster":    { "name": "faster-whisper", "kind": "provider", "backend": "faster-whisper", "port": 8083 },
 
-    "_kyutai":    { "name": "kyutai-stt-1b (mlx)", "kind": "command", "command": "python -m moshi_mlx.run_stt {audio}" },
-    "_parakeet":  { "name": "parakeet-mlx",        "kind": "command", "command": "parakeet-mlx transcribe {audio} --output-format txt" },
-    "_moonshine": { "name": "moonshine-base",      "kind": "command", "command": "moonshine transcribe --model base {audio}" },
-    "_faster":    { "name": "faster-whisper", "kind": "provider", "backend": "faster-whisper", "port": 8083 }
-  ]
+    "audiocpp_batch":  { "name": "audiocpp nemotron (batch)", "kind": "command", "command": "curl -s -F file=@{audio} -F model=nemotron http://127.0.0.1:8093/v1/audio/transcriptions | jq -r .text" },
+    "audiocpp_stream": { "name": "audiocpp voxtral-realtime (streaming)", "kind": "stream", "model": "voxtral-realtime", "port": 8093 }
+  }
 }

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -441,12 +441,22 @@ export async function transcribeLive(
     sseBytes += bytes;
   };
 
+  /**
+   * A whole, properly delimited event whose payload will not parse is a
+   * malformed response, not a no-op. Dropping it silently left the run scored
+   * on whatever the previous delta said — the same lie as a truncated stream,
+   * arriving through the ordinary path rather than the residual one.
+   */
+  const takeEvent = (block: string): void => {
+    if (!consumeEvent(block)) failure ??= new Error("malformed SSE event");
+    sse = "";
+    sseBytes = 0;
+  };
+
   const consumeEvents = (text: string): void => {
     let offset = 0;
     if (sse.endsWith("\n") && text.startsWith("\n")) {
-      consumeEvent(sse.slice(0, -1));
-      sse = "";
-      sseBytes = 0;
+      takeEvent(sse.slice(0, -1));
       offset = 1;
     }
     for (;;) {
@@ -456,9 +466,7 @@ export async function transcribeLive(
         return;
       }
       appendEventFragment(text.slice(offset, end));
-      consumeEvent(sse);
-      sse = "";
-      sseBytes = 0;
+      takeEvent(sse);
       offset = end + 2;
     }
   };

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -34,8 +34,32 @@ export interface LiveStreamResult {
   finalAfterAudioMs: number;
 }
 
+export interface LiveStreamResponseLimits {
+  maxHeaderBytes: number;
+  maxChunkBytes: number;
+  maxEventBytes: number;
+  maxBodyBytes: number;
+}
+
+export interface LiveStreamOptions {
+  timeoutMs?: number;
+  limits?: Partial<LiveStreamResponseLimits>;
+  /** Injectable monotonic clock for deterministic timing regressions. */
+  now?: () => number;
+}
+
 const DEFAULT_CHUNK_MS = 100;
 const DEFAULT_TIMEOUT_MS = 180_000;
+// Bench responses are transcript text, so 64 KiB of headers, 4 MiB per HTTP
+// chunk, 1 MiB per SSE event, and 16 MiB overall are generous while still
+// bounding every unit retained from a remote provider.
+const DEFAULT_RESPONSE_LIMITS: LiveStreamResponseLimits = {
+  maxHeaderBytes: 64 * 1024,
+  maxChunkBytes: 4 * 1024 * 1024,
+  maxEventBytes: 1024 * 1024,
+  maxBodyBytes: 16 * 1024 * 1024,
+};
+const MAX_CHUNK_LINE_BYTES = 128;
 
 /** Float samples in [-1,1] → little-endian 16-bit PCM, the endpoint's default format. */
 function toS16le(samples: Float32Array): Uint8Array {
@@ -54,59 +78,166 @@ function toS16le(samples: Float32Array): Uint8Array {
  * split on event boundaries.
  */
 class ChunkedResponseReader {
-  private buf = new Uint8Array(0);
-  private headersDone = false;
-  private decoder = new TextDecoder();
+  private state: "headers" | "size" | "size-lf" | "data" | "data-cr" | "data-lf" | "done" = "headers";
+  private header = new Uint8Array(1024);
+  private headerLength = 0;
+  private headerEndMatched = 0;
+  private sizeLine = new Uint8Array(32);
+  private sizeLineLength = 0;
+  private chunkRemaining = 0;
+  private bodyBytes = 0;
+  private readonly decoder = new TextDecoder();
   status = 0;
+
+  constructor(private readonly limits: LiveStreamResponseLimits) {}
 
   /** Returns any newly decoded body text. Throws on a malformed response. */
   push(chunk: Uint8Array): string {
-    const merged = new Uint8Array(this.buf.length + chunk.length);
-    merged.set(this.buf);
-    merged.set(chunk, this.buf.length);
-    this.buf = merged;
+    const text: string[] = [];
+    let offset = 0;
+    while (offset < chunk.length && this.state !== "done") {
+      const byte = chunk[offset]!;
+      if (this.state === "headers") {
+        this.appendHeaderByte(byte);
+        offset++;
+        continue;
+      }
+      if (this.state === "size") {
+        if (byte === CR) {
+          this.state = "size-lf";
+        } else {
+          this.appendSizeByte(byte);
+        }
+        offset++;
+        continue;
+      }
+      if (this.state === "size-lf") {
+        if (byte !== LF) throw new Error("malformed chunk size line in response");
+        const tail = this.startChunk();
+        if (tail) text.push(tail);
+        offset++;
+        continue;
+      }
+      if (this.state === "data") {
+        const take = Math.min(this.chunkRemaining, chunk.length - offset);
+        text.push(this.decoder.decode(chunk.subarray(offset, offset + take), { stream: true }));
+        this.chunkRemaining -= take;
+        this.bodyBytes += take;
+        offset += take;
+        if (this.chunkRemaining === 0) this.state = "data-cr";
+        continue;
+      }
+      if (this.state === "data-cr") {
+        if (byte !== CR) throw new Error("response chunk is missing its trailing CRLF");
+        this.state = "data-lf";
+        offset++;
+        continue;
+      }
+      if (byte !== LF) throw new Error("response chunk is missing its trailing CRLF");
+      this.state = "size";
+      offset++;
+    }
+    return text.join("");
+  }
 
-    if (!this.headersDone) {
-      const end = indexOfSequence(this.buf, HEADER_END);
-      if (end < 0) return "";
-      const head = this.decoder.decode(this.buf.subarray(0, end));
-      this.status = Number(head.split("\n", 1)[0]?.split(" ")[1] ?? 0);
-      // A non-2xx reply is a plain buffered error body, not a chunked stream;
-      // surface its text rather than failing to de-frame it.
+  private appendHeaderByte(byte: number): void {
+    if (this.headerLength === this.header.length) {
+      const capacity = Math.min(
+        this.limits.maxHeaderBytes + HEADER_END.length,
+        this.header.length * 2,
+      );
+      if (capacity <= this.header.length) {
+        throw new RangeError(
+          `response header section exceeds ${this.limits.maxHeaderBytes}-byte limit`,
+        );
+      }
+      const grown = new Uint8Array(capacity);
+      grown.set(this.header);
+      this.header = grown;
+    }
+    this.header[this.headerLength++] = byte;
+    if (byte === HEADER_END[this.headerEndMatched]) {
+      this.headerEndMatched++;
+    } else {
+      this.headerEndMatched = byte === HEADER_END[0] ? 1 : 0;
+    }
+    if (this.headerEndMatched === HEADER_END.length) {
+      const sectionLength = this.headerLength - HEADER_END.length;
+      if (sectionLength > this.limits.maxHeaderBytes) {
+        throw new RangeError(
+          `response header section exceeds ${this.limits.maxHeaderBytes}-byte limit`,
+        );
+      }
+      const head = this.decoder.decode(this.header.subarray(0, sectionLength));
+      const statusLine = head.split("\r\n", 1)[0] ?? "";
+      const match = /^HTTP\/\d(?:\.\d)?\s+(\d{3})(?:\s|$)/.exec(statusLine);
+      if (!match) throw new Error("server returned a malformed HTTP status line");
+      this.status = Number(match[1]);
       if (this.status < 200 || this.status >= 300) {
-        throw new Error(`server returned ${this.status}: ${this.decoder.decode(this.buf.subarray(end + HEADER_END.length)).trim() || head.split("\n")[0]}`);
+        throw new Error(`server returned HTTP ${this.status}`);
       }
-      this.buf = this.buf.slice(end + HEADER_END.length);
-      this.headersDone = true;
+      this.header = new Uint8Array(0);
+      this.state = "size";
+    } else if (this.headerLength - this.headerEndMatched > this.limits.maxHeaderBytes) {
+      throw new RangeError(
+        `response header section exceeds ${this.limits.maxHeaderBytes}-byte limit`,
+      );
     }
+  }
 
-    let text = "";
-    for (;;) {
-      const nl = indexOfSequence(this.buf, CRLF);
-      if (nl < 0) return text;
-      const size = parseInt(this.decoder.decode(this.buf.subarray(0, nl)).split(";")[0]!.trim(), 16);
-      if (!Number.isFinite(size) || size < 0) throw new Error("malformed chunk size in response");
-      if (size === 0) {
-        this.buf = new Uint8Array(0);
-        return text;
-      }
-      const dataStart = nl + CRLF.length;
-      if (this.buf.length < dataStart + size + CRLF.length) return text; // wait for the rest
-      text += this.decoder.decode(this.buf.subarray(dataStart, dataStart + size));
-      this.buf = this.buf.slice(dataStart + size + CRLF.length);
+  private appendSizeByte(byte: number): void {
+    if (this.sizeLineLength >= MAX_CHUNK_LINE_BYTES) {
+      throw new RangeError(
+        `response chunk-size line exceeds ${MAX_CHUNK_LINE_BYTES}-byte limit`,
+      );
     }
+    if (this.sizeLineLength === this.sizeLine.length) {
+      const grown = new Uint8Array(Math.min(MAX_CHUNK_LINE_BYTES, this.sizeLine.length * 2));
+      grown.set(this.sizeLine);
+      this.sizeLine = grown;
+    }
+    this.sizeLine[this.sizeLineLength++] = byte;
+  }
+
+  private startChunk(): string {
+    const line = new TextDecoder().decode(this.sizeLine.subarray(0, this.sizeLineLength));
+    const token = line.split(";", 1)[0]!.trim();
+    if (!/^[0-9a-f]+$/i.test(token)) throw new Error("malformed chunk size in response");
+    const size = Number.parseInt(token, 16);
+    if (!Number.isSafeInteger(size)) throw new Error("malformed chunk size in response");
+    if (size > this.limits.maxChunkBytes) {
+      throw new RangeError(
+        `response chunk exceeds ${this.limits.maxChunkBytes}-byte limit (declared ${size} bytes)`,
+      );
+    }
+    if (this.bodyBytes + size > this.limits.maxBodyBytes) {
+      throw new RangeError(
+        `response decoded body exceeds ${this.limits.maxBodyBytes}-byte limit`,
+      );
+    }
+    this.sizeLineLength = 0;
+    if (size === 0) {
+      this.state = "done";
+      return this.decoder.decode();
+    }
+    this.chunkRemaining = size;
+    this.state = "data";
+    return "";
   }
 }
 
-const CRLF = new Uint8Array([13, 10]);
+const CR = 13;
+const LF = 10;
 const HEADER_END = new Uint8Array([13, 10, 13, 10]);
 
-function indexOfSequence(haystack: Uint8Array, needle: Uint8Array): number {
-  outer: for (let i = 0; i + needle.length <= haystack.length; i++) {
-    for (let j = 0; j < needle.length; j++) if (haystack[i + j] !== needle[j]) continue outer;
-    return i;
+function responseLimits(overrides: Partial<LiveStreamResponseLimits> = {}): LiveStreamResponseLimits {
+  const limits = { ...DEFAULT_RESPONSE_LIMITS, ...overrides };
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new RangeError(`${name} must be a positive safe integer`);
+    }
   }
-  return -1;
+  return limits;
 }
 
 /**
@@ -116,7 +247,17 @@ function indexOfSequence(haystack: Uint8Array, needle: Uint8Array): number {
  * duration, which is what makes the timings mean anything — a model can't be
  * credited with a partial it only produced because the whole file arrived at once.
  */
-export async function transcribeLive(audioPath: string, c: StreamCandidate): Promise<LiveStreamResult> {
+export async function transcribeLive(
+  audioPath: string,
+  c: StreamCandidate,
+  options: LiveStreamOptions = {},
+): Promise<LiveStreamResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError("timeoutMs must be a positive finite number");
+  }
+  const limits = responseLimits(options.limits);
+  const now = options.now ?? (() => performance.now());
   const { samples, sampleRate } = decodeWav(await Bun.file(audioPath).arrayBuffer());
   const pcm = toS16le(samples);
   const audioMs = (samples.length / sampleRate) * 1000;
@@ -133,9 +274,12 @@ export async function transcribeLive(audioPath: string, c: StreamCandidate): Pro
   const path = `${c.path ?? "/v1/audio/transcriptions/live"}?${query}`;
   const host = c.host ?? "127.0.0.1";
 
-  const reader = new ChunkedResponseReader();
+  const reader = new ChunkedResponseReader(limits);
+  const eventEncoder = new TextEncoder();
   let sse = "";
+  let sseBytes = 0;
   let firstDeltaMs: number | null = null;
+  let lastDeltaMs: number | null = null;
   let deltasDuringAudio = 0;
   let deltas = 0;
   let doneMs: number | null = null;
@@ -143,31 +287,97 @@ export async function transcribeLive(audioPath: string, c: StreamCandidate): Pro
   let joined = "";
   let t0 = 0; // set when the first PCM byte goes out
   let failure: Error | null = null;
-  let settle: (() => void) | null = null;
-  const closed = new Promise<void>((resolve) => { settle = resolve; });
-  let drained: (() => void) | null = null;
+  let resolveClosed!: () => void;
+  let closedSettled = false;
+  const closed = new Promise<void>((resolve) => { resolveClosed = resolve; });
+  let drainWaiter: { resolve: () => void; reject: (error: Error) => void } | null = null;
+  let paceWaiter: {
+    timer: ReturnType<typeof setTimeout>;
+    reject: (error: Error) => void;
+  } | null = null;
+  let requestBodyDone = false;
 
-  const consumeEvents = (): void => {
+  const settleClosed = (): void => {
+    if (closedSettled) return;
+    closedSettled = true;
+    resolveClosed();
+  };
+
+  const rejectPending = (error: Error): void => {
+    if (drainWaiter) {
+      const waiter = drainWaiter;
+      drainWaiter = null;
+      waiter.reject(error);
+    }
+    if (paceWaiter) {
+      const waiter = paceWaiter;
+      paceWaiter = null;
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+  };
+
+  const abortSocket = (socket: { terminate(): void }, error: Error): void => {
+    failure ??= error;
+    // Bun's terminate() is the forceful full close; end() only closes writes.
+    socket.terminate();
+    rejectPending(failure);
+    settleClosed();
+  };
+
+  const consumeEvent = (block: string): void => {
+    const payload = block.split("\n").filter((l) => l.startsWith("data:")).map((l) => l.slice(5).trim()).join("");
+    if (!payload || payload === "[DONE]") return;
+    let event: { type?: string; delta?: string; text?: string; error?: { message?: string } };
+    try { event = JSON.parse(payload); } catch { return; }
+    if (event.error) {
+      failure ??= new Error(event.error.message ?? "stream error");
+      return;
+    }
+    const at = now() - t0;
+    if (event.type === "transcript.text.delta") {
+      deltas++;
+      joined += event.delta ?? "";
+      firstDeltaMs ??= at;
+      lastDeltaMs = at;
+      if (at < audioMs) deltasDuringAudio++;
+    } else if (event.type === "transcript.text.done") {
+      doneMs ??= at;
+      finalText = event.text ?? "";
+    }
+  };
+
+  const appendEventFragment = (fragment: string): void => {
+    if (fragment.length > limits.maxEventBytes - sseBytes) {
+      throw new RangeError(`SSE event exceeds ${limits.maxEventBytes}-byte limit`);
+    }
+    const bytes = eventEncoder.encode(fragment).byteLength;
+    if (sseBytes + bytes > limits.maxEventBytes) {
+      throw new RangeError(`SSE event exceeds ${limits.maxEventBytes}-byte limit`);
+    }
+    sse += fragment;
+    sseBytes += bytes;
+  };
+
+  const consumeEvents = (text: string): void => {
+    let offset = 0;
+    if (sse.endsWith("\n") && text.startsWith("\n")) {
+      consumeEvent(sse.slice(0, -1));
+      sse = "";
+      sseBytes = 0;
+      offset = 1;
+    }
     for (;;) {
-      const end = sse.indexOf("\n\n");
-      if (end < 0) return;
-      const block = sse.slice(0, end);
-      sse = sse.slice(end + 2);
-      const payload = block.split("\n").filter((l) => l.startsWith("data:")).map((l) => l.slice(5).trim()).join("");
-      if (!payload || payload === "[DONE]") continue;
-      let event: { type?: string; delta?: string; text?: string; error?: { message?: string } };
-      try { event = JSON.parse(payload); } catch { continue; }
-      if (event.error) { failure ??= new Error(event.error.message ?? "stream error"); continue; }
-      const at = performance.now() - t0;
-      if (event.type === "transcript.text.delta") {
-        deltas++;
-        joined += event.delta ?? "";
-        firstDeltaMs ??= at;
-        if (at < audioMs) deltasDuringAudio++;
-      } else if (event.type === "transcript.text.done") {
-        doneMs ??= at;
-        finalText = event.text ?? "";
+      const end = text.indexOf("\n\n", offset);
+      if (end < 0) {
+        appendEventFragment(text.slice(offset));
+        return;
       }
+      appendEventFragment(text.slice(offset, end));
+      consumeEvent(sse);
+      sse = "";
+      sseBytes = 0;
+      offset = end + 2;
     }
   };
 
@@ -175,17 +385,29 @@ export async function transcribeLive(audioPath: string, c: StreamCandidate): Pro
     hostname: host,
     port: c.port,
     socket: {
-      data: (_s, chunk) => {
+      data: (s, chunk) => {
         try {
-          sse += reader.push(chunk);
-          consumeEvents();
+          consumeEvents(reader.push(chunk));
+          if (failure) abortSocket(s, failure);
         } catch (err: unknown) {
-          failure ??= err instanceof Error ? err : new Error(String(err));
+          abortSocket(s, err instanceof Error ? err : new Error(String(err)));
         }
       },
-      drain: () => { drained?.(); drained = null; },
-      close: () => settle?.(),
-      error: (_s, err) => { failure ??= err instanceof Error ? err : new Error(String(err)); settle?.(); },
+      drain: () => {
+        const waiter = drainWaiter;
+        drainWaiter = null;
+        waiter?.resolve();
+      },
+      close: () => {
+        if (!requestBodyDone) {
+          failure ??= new Error("connection closed before request body completed");
+          rejectPending(failure);
+        }
+        settleClosed();
+      },
+      error: (s, err) => {
+        abortSocket(s, err instanceof Error ? err : new Error(String(err)));
+      },
     },
   });
 
@@ -193,17 +415,30 @@ export async function transcribeLive(audioPath: string, c: StreamCandidate): Pro
   const writeAll = async (data: Uint8Array | string): Promise<void> => {
     let payload = typeof data === "string" ? new TextEncoder().encode(data) : data;
     while (payload.length) {
+      if (failure) throw failure;
       const n = socket.write(payload);
       if (n >= payload.length) return;
       payload = payload.subarray(Math.max(n, 0));
-      await new Promise<void>((resolve) => { drained = resolve; });
+      await new Promise<void>((resolve, reject) => {
+        drainWaiter = { resolve, reject };
+      });
     }
   };
 
+  const waitForPace = async (ms: number): Promise<void> => {
+    if (failure) throw failure;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        paceWaiter = null;
+        resolve();
+      }, ms);
+      paceWaiter = { timer, reject };
+    });
+  };
+
   const timeout = setTimeout(() => {
-    failure ??= new Error(`no response within ${DEFAULT_TIMEOUT_MS} ms`);
-    socket.end();
-  }, DEFAULT_TIMEOUT_MS);
+    abortSocket(socket, new Error(`no response within ${timeoutMs} ms`));
+  }, timeoutMs);
 
   try {
     await writeAll(
@@ -211,7 +446,7 @@ export async function transcribeLive(audioPath: string, c: StreamCandidate): Pro
       `Transfer-Encoding: chunked\r\nContent-Type: application/octet-stream\r\nAccept: text/event-stream\r\n\r\n`,
     );
 
-    t0 = performance.now();
+    t0 = now();
     for (let off = 0; off < pcm.length && !failure; off += chunkBytes) {
       const slice = pcm.subarray(off, Math.min(off + chunkBytes, pcm.length));
       await writeAll(`${slice.length.toString(16)}\r\n`);
@@ -221,15 +456,19 @@ export async function transcribeLive(audioPath: string, c: StreamCandidate): Pro
         // Sleep until this chunk's audio would have finished playing, so the
         // server never sees samples earlier than a live microphone would deliver.
         const playedMs = ((off + slice.length) / 2 / sampleRate) * 1000;
-        const wait = t0 + playedMs - performance.now();
-        if (wait > 0) await Bun.sleep(wait);
+        const wait = t0 + playedMs - now();
+        if (wait > 0) await waitForPace(wait);
       }
     }
     await writeAll("0\r\n\r\n");
+    requestBodyDone = true;
     await closed;
   } finally {
     clearTimeout(timeout);
-    socket.end();
+    const cleanupError = failure ?? new Error("live transcription request ended");
+    rejectPending(cleanupError);
+    settleClosed();
+    socket.terminate();
   }
 
   if (failure) throw failure;
@@ -242,8 +481,9 @@ export async function transcribeLive(audioPath: string, c: StreamCandidate): Pro
     firstDeltaMs,
     deltasDuringAudio,
     deltas,
-    // Falling back to firstDelta keeps the row honest for a server that streams
-    // deltas but never sends the terminal event, rather than reporting a 0.
-    finalAfterAudioMs: (doneMs ?? firstDeltaMs ?? audioMs) - audioMs,
+    // Without a terminal event, the last delta is the best available finish
+    // estimate. A negative value is still meaningful when that final available
+    // delta genuinely arrived before the audio itself finished.
+    finalAfterAudioMs: (doneMs ?? lastDeltaMs ?? audioMs) - audioMs,
   };
 }

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -14,6 +14,7 @@
  * and will report 0 deltas-during-audio here. That is a real result, not a bug.
  */
 import { decodeWav } from "../../src/platform/wav";
+import { sanitizeLabel } from "../../src/text-utils";
 import type { StreamCandidate } from "./types";
 
 export interface LiveStreamResult {
@@ -76,6 +77,7 @@ const DEFAULT_RESPONSE_LIMITS: LiveStreamResponseLimits = {
   maxBodyBytes: 16 * 1024 * 1024,
 };
 const MAX_CHUNK_LINE_BYTES = 128;
+const MAX_REMOTE_ERROR_CHARS = 512;
 
 /** Float samples in [-1,1] → little-endian 16-bit PCM, the endpoint's default format. */
 function toS16le(samples: Float32Array): Uint8Array {
@@ -396,7 +398,10 @@ export async function transcribeLive(
     let event: { type?: string; delta?: string; text?: string; error?: { message?: string } };
     try { event = JSON.parse(payload); } catch { return false; }
     if (event.error) {
-      failure ??= new Error(event.error.message ?? "stream error");
+      // JSON decoding restores escaped controls from the remote body. Replace
+      // them before retaining the message so a later warning cannot forge a
+      // benchmark line or write a terminal control sequence.
+      failure ??= new Error(sanitizeLabel(event.error.message ?? "stream error", MAX_REMOTE_ERROR_CHARS));
       return true;
     }
     const at = now() - t0;

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -1,0 +1,249 @@
+/**
+ * Client for audio.cpp's live PCM ingest endpoint (`POST
+ * /v1/audio/transcriptions/live`, upstream PR #144) — the transport that makes
+ * streaming time-to-final measurable over HTTP instead of only from a CLI pipe.
+ *
+ * It is a raw socket rather than `fetch` on purpose. This is a full-duplex
+ * exchange: PCM goes up in a chunked request body while SSE deltas come back
+ * down the same connection. `fetch` request streaming is half-duplex by
+ * specification — the response is not delivered until the request body ends —
+ * which would collapse exactly the measurement this file exists to take.
+ *
+ * Whether deltas arrive *during* capture is a property of the model, not of the
+ * transport: a model that buffers internally emits nothing until the audio ends
+ * and will report 0 deltas-during-audio here. That is a real result, not a bug.
+ */
+import { decodeWav } from "../../src/platform/wav";
+import type { StreamCandidate } from "./types";
+
+export interface LiveStreamResult {
+  /** Final transcript from `transcript.text.done` (falls back to joined deltas). */
+  text: string;
+  /** Clip length in ms — the wall-clock budget a real-time feed spends uploading. */
+  audioMs: number;
+  /** First `transcript.text.delta`, ms after the first PCM byte. null if none. */
+  firstDeltaMs: number | null;
+  /** Deltas that landed before the clip's audio would have finished playing. */
+  deltasDuringAudio: number;
+  /** Total deltas. */
+  deltas: number;
+  /**
+   * `transcript.text.done` relative to the end of the audio. Negative means the
+   * transcript was complete before the last sample was even sent.
+   */
+  finalAfterAudioMs: number;
+}
+
+const DEFAULT_CHUNK_MS = 100;
+const DEFAULT_TIMEOUT_MS = 180_000;
+
+/** Float samples in [-1,1] → little-endian 16-bit PCM, the endpoint's default format. */
+function toS16le(samples: Float32Array): Uint8Array {
+  const out = new Uint8Array(samples.length * 2);
+  const view = new DataView(out.buffer);
+  for (let i = 0; i < samples.length; i++) {
+    const clamped = Math.max(-1, Math.min(1, samples[i]!));
+    view.setInt16(i * 2, Math.round(clamped * 32767), true);
+  }
+  return out;
+}
+
+/**
+ * Incremental de-framer for the *response*: the server replies
+ * `Transfer-Encoding: chunked`, so SSE text has to be unwrapped before it can be
+ * split on event boundaries.
+ */
+class ChunkedResponseReader {
+  private buf = new Uint8Array(0);
+  private headersDone = false;
+  private decoder = new TextDecoder();
+  status = 0;
+
+  /** Returns any newly decoded body text. Throws on a malformed response. */
+  push(chunk: Uint8Array): string {
+    const merged = new Uint8Array(this.buf.length + chunk.length);
+    merged.set(this.buf);
+    merged.set(chunk, this.buf.length);
+    this.buf = merged;
+
+    if (!this.headersDone) {
+      const end = indexOfSequence(this.buf, HEADER_END);
+      if (end < 0) return "";
+      const head = this.decoder.decode(this.buf.subarray(0, end));
+      this.status = Number(head.split("\n", 1)[0]?.split(" ")[1] ?? 0);
+      // A non-2xx reply is a plain buffered error body, not a chunked stream;
+      // surface its text rather than failing to de-frame it.
+      if (this.status < 200 || this.status >= 300) {
+        throw new Error(`server returned ${this.status}: ${this.decoder.decode(this.buf.subarray(end + HEADER_END.length)).trim() || head.split("\n")[0]}`);
+      }
+      this.buf = this.buf.slice(end + HEADER_END.length);
+      this.headersDone = true;
+    }
+
+    let text = "";
+    for (;;) {
+      const nl = indexOfSequence(this.buf, CRLF);
+      if (nl < 0) return text;
+      const size = parseInt(this.decoder.decode(this.buf.subarray(0, nl)).split(";")[0]!.trim(), 16);
+      if (!Number.isFinite(size) || size < 0) throw new Error("malformed chunk size in response");
+      if (size === 0) {
+        this.buf = new Uint8Array(0);
+        return text;
+      }
+      const dataStart = nl + CRLF.length;
+      if (this.buf.length < dataStart + size + CRLF.length) return text; // wait for the rest
+      text += this.decoder.decode(this.buf.subarray(dataStart, dataStart + size));
+      this.buf = this.buf.slice(dataStart + size + CRLF.length);
+    }
+  }
+}
+
+const CRLF = new Uint8Array([13, 10]);
+const HEADER_END = new Uint8Array([13, 10, 13, 10]);
+
+function indexOfSequence(haystack: Uint8Array, needle: Uint8Array): number {
+  outer: for (let i = 0; i + needle.length <= haystack.length; i++) {
+    for (let j = 0; j < needle.length; j++) if (haystack[i + j] !== needle[j]) continue outer;
+    return i;
+  }
+  return -1;
+}
+
+/**
+ * Feed one clip at the requested pace and time what comes back.
+ *
+ * With `pace: "realtime"` (the default) the upload is throttled to the clip's own
+ * duration, which is what makes the timings mean anything — a model can't be
+ * credited with a partial it only produced because the whole file arrived at once.
+ */
+export async function transcribeLive(audioPath: string, c: StreamCandidate): Promise<LiveStreamResult> {
+  const { samples, sampleRate } = decodeWav(await Bun.file(audioPath).arrayBuffer());
+  const pcm = toS16le(samples);
+  const audioMs = (samples.length / sampleRate) * 1000;
+  const chunkMs = c.chunkMs ?? DEFAULT_CHUNK_MS;
+  const chunkBytes = Math.max(2, Math.round((sampleRate * chunkMs) / 1000) * 2);
+
+  const query = new URLSearchParams({
+    model: c.model,
+    sample_rate: String(sampleRate),
+    channels: "1",
+    sample_format: "s16le",
+  });
+  if (c.language) query.set("language", c.language);
+  const path = `${c.path ?? "/v1/audio/transcriptions/live"}?${query}`;
+  const host = c.host ?? "127.0.0.1";
+
+  const reader = new ChunkedResponseReader();
+  let sse = "";
+  let firstDeltaMs: number | null = null;
+  let deltasDuringAudio = 0;
+  let deltas = 0;
+  let doneMs: number | null = null;
+  let finalText = "";
+  let joined = "";
+  let t0 = 0; // set when the first PCM byte goes out
+  let failure: Error | null = null;
+  let settle: (() => void) | null = null;
+  const closed = new Promise<void>((resolve) => { settle = resolve; });
+  let drained: (() => void) | null = null;
+
+  const consumeEvents = (): void => {
+    for (;;) {
+      const end = sse.indexOf("\n\n");
+      if (end < 0) return;
+      const block = sse.slice(0, end);
+      sse = sse.slice(end + 2);
+      const payload = block.split("\n").filter((l) => l.startsWith("data:")).map((l) => l.slice(5).trim()).join("");
+      if (!payload || payload === "[DONE]") continue;
+      let event: { type?: string; delta?: string; text?: string; error?: { message?: string } };
+      try { event = JSON.parse(payload); } catch { continue; }
+      if (event.error) { failure ??= new Error(event.error.message ?? "stream error"); continue; }
+      const at = performance.now() - t0;
+      if (event.type === "transcript.text.delta") {
+        deltas++;
+        joined += event.delta ?? "";
+        firstDeltaMs ??= at;
+        if (at < audioMs) deltasDuringAudio++;
+      } else if (event.type === "transcript.text.done") {
+        doneMs ??= at;
+        finalText = event.text ?? "";
+      }
+    }
+  };
+
+  const socket = await Bun.connect({
+    hostname: host,
+    port: c.port,
+    socket: {
+      data: (_s, chunk) => {
+        try {
+          sse += reader.push(chunk);
+          consumeEvents();
+        } catch (err: unknown) {
+          failure ??= err instanceof Error ? err : new Error(String(err));
+        }
+      },
+      drain: () => { drained?.(); drained = null; },
+      close: () => settle?.(),
+      error: (_s, err) => { failure ??= err instanceof Error ? err : new Error(String(err)); settle?.(); },
+    },
+  });
+
+  /** Bun's `write` does not buffer the remainder, so a short write must be re-driven. */
+  const writeAll = async (data: Uint8Array | string): Promise<void> => {
+    let payload = typeof data === "string" ? new TextEncoder().encode(data) : data;
+    while (payload.length) {
+      const n = socket.write(payload);
+      if (n >= payload.length) return;
+      payload = payload.subarray(Math.max(n, 0));
+      await new Promise<void>((resolve) => { drained = resolve; });
+    }
+  };
+
+  const timeout = setTimeout(() => {
+    failure ??= new Error(`no response within ${DEFAULT_TIMEOUT_MS} ms`);
+    socket.end();
+  }, DEFAULT_TIMEOUT_MS);
+
+  try {
+    await writeAll(
+      `POST ${path} HTTP/1.1\r\nHost: ${host}:${c.port}\r\n` +
+      `Transfer-Encoding: chunked\r\nContent-Type: application/octet-stream\r\nAccept: text/event-stream\r\n\r\n`,
+    );
+
+    t0 = performance.now();
+    for (let off = 0; off < pcm.length && !failure; off += chunkBytes) {
+      const slice = pcm.subarray(off, Math.min(off + chunkBytes, pcm.length));
+      await writeAll(`${slice.length.toString(16)}\r\n`);
+      await writeAll(slice);
+      await writeAll("\r\n");
+      if (c.pace !== "fast") {
+        // Sleep until this chunk's audio would have finished playing, so the
+        // server never sees samples earlier than a live microphone would deliver.
+        const playedMs = ((off + slice.length) / 2 / sampleRate) * 1000;
+        const wait = t0 + playedMs - performance.now();
+        if (wait > 0) await Bun.sleep(wait);
+      }
+    }
+    await writeAll("0\r\n\r\n");
+    await closed;
+  } finally {
+    clearTimeout(timeout);
+    socket.end();
+  }
+
+  if (failure) throw failure;
+  const text = finalText || joined;
+  if (!text.trim()) throw new Error("stream closed without a transcript");
+
+  return {
+    text: text.trim(),
+    audioMs,
+    firstDeltaMs,
+    deltasDuringAudio,
+    deltas,
+    // Falling back to firstDelta keeps the row honest for a server that streams
+    // deltas but never sends the terminal event, rather than reporting a 0.
+    finalAfterAudioMs: (doneMs ?? firstDeltaMs ?? audioMs) - audioMs,
+  };
+}

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -55,7 +55,17 @@ export type LiveStreamConnect = (
 ) => Promise<Bun.Socket<undefined>>;
 
 const DEFAULT_CHUNK_MS = 100;
-const DEFAULT_TIMEOUT_MS = 180_000;
+// A real-time feed cannot finish sooner than the clip itself, so the deadline is
+// derived from the audio rather than fixed: decodeWav accepts up to
+// MAX_DECODED_WAV_DURATION_MS (5 min), and a fixed 180s ceiling failed every
+// legal clip longer than three minutes no matter how healthy the server was.
+// The grace covers connect, the server's own processing, and the trailing
+// response after the last sample.
+const DEFAULT_RESPONSE_GRACE_MS = 60_000;
+
+/** Default absolute deadline for one paced run of `audioMs` of audio. */
+export const liveStreamTimeoutMs = (audioMs: number): number =>
+  audioMs + DEFAULT_RESPONSE_GRACE_MS;
 // Bench responses are transcript text, so 64 KiB of headers, 4 MiB per HTTP
 // chunk, 1 MiB per SSE event, and 16 MiB overall are generous while still
 // bounding every unit retained from a remote provider.
@@ -299,8 +309,8 @@ export async function transcribeLive(
   c: StreamCandidate,
   options: LiveStreamOptions = {},
 ): Promise<LiveStreamResult> {
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+  if (options.timeoutMs !== undefined
+    && (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)) {
     throw new RangeError("timeoutMs must be a positive finite number");
   }
   const limits = responseLimits(options.limits);
@@ -310,6 +320,7 @@ export async function transcribeLive(
   const { samples, sampleRate } = decodeWav(await Bun.file(audioPath).arrayBuffer());
   const pcm = toS16le(samples);
   const audioMs = (samples.length / sampleRate) * 1000;
+  const timeoutMs = options.timeoutMs ?? liveStreamTimeoutMs(audioMs);
   const chunkMs = c.chunkMs ?? DEFAULT_CHUNK_MS;
   const chunkBytes = Math.max(2, Math.round((sampleRate * chunkMs) / 1000) * 2);
 
@@ -332,7 +343,11 @@ export async function transcribeLive(
   let deltasDuringAudio = 0;
   let deltas = 0;
   let doneMs: number | null = null;
-  let finalText = "";
+  // null (not "") so a terminal event carrying an empty transcript stays
+  // distinguishable from no terminal event at all. Collapsing the two lets an
+  // empty final fall back to the partials, which records a stale mid-stream
+  // guess as the model's answer.
+  let finalText: string | null = null;
   let joined = "";
   let t0 = 0; // set when real-time capture begins
   let failure: Error | null = null;
@@ -374,14 +389,15 @@ export async function transcribeLive(
     settleClosed();
   };
 
-  const consumeEvent = (block: string): void => {
+  /** False only when the block carried a payload that could not be parsed. */
+  const consumeEvent = (block: string): boolean => {
     const payload = block.split("\n").filter((l) => l.startsWith("data:")).map((l) => l.slice(5).trim()).join("");
-    if (!payload || payload === "[DONE]") return;
+    if (!payload || payload === "[DONE]") return true;
     let event: { type?: string; delta?: string; text?: string; error?: { message?: string } };
-    try { event = JSON.parse(payload); } catch { return; }
+    try { event = JSON.parse(payload); } catch { return false; }
     if (event.error) {
       failure ??= new Error(event.error.message ?? "stream error");
-      return;
+      return true;
     }
     const at = now() - t0;
     if (event.type === "transcript.text.delta") {
@@ -393,6 +409,23 @@ export async function transcribeLive(
     } else if (event.type === "transcript.text.done") {
       doneMs ??= at;
       finalText = event.text ?? "";
+    }
+    return true;
+  };
+
+  /**
+   * The HTTP body can end cleanly while the last SSE event is still missing its
+   * blank-line terminator. Dropping that residual silently rewrote the run's
+   * result to whatever the previous delta said — a truncated stream scored as a
+   * complete one. Consume it if it is whole, and fail the run if it is not.
+   */
+  const flushPendingEvent = (): void => {
+    if (!sse.trim()) return;
+    const block = sse;
+    sse = "";
+    sseBytes = 0;
+    if (!consumeEvent(block)) {
+      failure ??= new Error("response ended mid-event");
     }
   };
 
@@ -535,6 +568,7 @@ export async function transcribeLive(
     await writeAll("0\r\n\r\n");
     requestBodyDone = true;
     await closed;
+    flushPendingEvent();
   } finally {
     clearTimeout(timeout);
     const cleanupError = failure ?? new Error("live transcription request ended");
@@ -544,8 +578,14 @@ export async function transcribeLive(
   }
 
   if (failure) throw failure;
-  const text = finalText || joined;
-  if (!text.trim()) throw new Error("stream closed without a transcript");
+  // A terminal event wins even when it is empty: the model said it heard
+  // nothing, and the partials it has already retracted are not a substitute.
+  const text = finalText ?? joined;
+  if (!text.trim()) {
+    throw new Error(finalText === null
+      ? "stream closed without a transcript"
+      : "stream ended with an empty final transcript");
+  }
 
   return {
     text: text.trim(),

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -22,7 +22,7 @@ export interface LiveStreamResult {
   text: string;
   /** Clip length in ms — the wall-clock budget a real-time feed spends uploading. */
   audioMs: number;
-  /** First `transcript.text.delta`, ms after real-time capture begins. null if none. */
+  /** First `transcript.text.delta`, ms after the first PCM byte is written. null if none. */
   firstDeltaMs: number | null;
   /** Deltas that landed before the clip's audio would have finished playing. */
   deltasDuringAudio: number;
@@ -340,22 +340,24 @@ export async function transcribeLive(
   const eventEncoder = new TextEncoder();
   let sse = "";
   let sseBytes = 0;
-  let firstDeltaMs: number | null = null;
-  let lastDeltaMs: number | null = null;
-  let deltasDuringAudio = 0;
+  let firstDeltaAt: number | null = null;
+  let lastDeltaAt: number | null = null;
+  const deltaTimes: number[] = [];
   let deltas = 0;
-  let doneMs: number | null = null;
+  let doneAt: number | null = null;
   // null (not "") so a terminal event carrying an empty transcript stays
   // distinguishable from no terminal event at all. Collapsing the two lets an
   // empty final fall back to the partials, which records a stale mid-stream
   // guess as the model's answer.
   let finalText: string | null = null;
   let joined = "";
-  let t0 = 0; // set when real-time capture begins
+  let paceStartedAt = 0;
+  let firstPcmWrittenAt = 0;
+  let lastPcmWrittenAt = 0;
   let failure: Error | null = null;
-  let resolveClosed!: () => void;
-  let closedSettled = false;
-  const closed = new Promise<void>((resolve) => { resolveClosed = resolve; });
+  let resolveResponse!: () => void;
+  let responseSettled = false;
+  const responseComplete = new Promise<void>((resolve) => { resolveResponse = resolve; });
   let drainWaiter: { resolve: () => void; reject: (error: Error) => void } | null = null;
   let paceWaiter: {
     timer: ReturnType<typeof setTimeout>;
@@ -363,10 +365,10 @@ export async function transcribeLive(
   } | null = null;
   let requestBodyDone = false;
 
-  const settleClosed = (): void => {
-    if (closedSettled) return;
-    closedSettled = true;
-    resolveClosed();
+  const settleResponse = (): void => {
+    if (responseSettled) return;
+    responseSettled = true;
+    resolveResponse();
   };
 
   const rejectPending = (error: Error): void => {
@@ -383,17 +385,24 @@ export async function transcribeLive(
     }
   };
 
+  let socketReleased = false;
+  const releaseSocket = (socket: { terminate(): void }): void => {
+    if (socketReleased) return;
+    socketReleased = true;
+    socket.terminate();
+  };
+
   const abortSocket = (socket: { terminate(): void }, error: Error): void => {
     failure ??= error;
     // Bun's terminate() is the forceful full close; end() only closes writes.
-    socket.terminate();
+    releaseSocket(socket);
     rejectPending(failure);
-    settleClosed();
+    settleResponse();
   };
 
   /** False only when the block carried a payload that could not be parsed. */
   const consumeEvent = (block: string): boolean => {
-    const payload = block.split("\n").filter((l) => l.startsWith("data:")).map((l) => l.slice(5).trim()).join("");
+    const payload = block.split(/\r\n|\r|\n/).filter((l) => l.startsWith("data:")).map((l) => l.slice(5).trim()).join("");
     if (!payload || payload === "[DONE]") return true;
     let event: { type?: string; delta?: string; text?: string; error?: { message?: string } };
     try { event = JSON.parse(payload); } catch { return false; }
@@ -404,15 +413,17 @@ export async function transcribeLive(
       failure ??= new Error(sanitizeLabel(event.error.message ?? "stream error", MAX_REMOTE_ERROR_CHARS));
       return true;
     }
-    const at = now() - t0;
+    const at = now();
     if (event.type === "transcript.text.delta") {
       deltas++;
       joined += event.delta ?? "";
-      firstDeltaMs ??= at;
-      lastDeltaMs = at;
-      if (at < audioMs) deltasDuringAudio++;
+      firstDeltaAt ??= at;
+      lastDeltaAt = at;
+      deltaTimes.push(at);
     } else if (event.type === "transcript.text.done") {
-      doneMs ??= at;
+      // The last terminal event wins because its text is the transcript scored;
+      // replacing both fields keeps that transcript paired with its own timing.
+      doneAt = at;
       finalText = event.text ?? "";
     }
     return true;
@@ -458,21 +469,54 @@ export async function transcribeLive(
     sseBytes = 0;
   };
 
+  let pendingCr = false;
+  let pendingCrBelongsToEvent = false;
+  let lineHasContent = false;
+
   const consumeEvents = (text: string): void => {
     let offset = 0;
-    if (sse.endsWith("\n") && text.startsWith("\n")) {
-      takeEvent(sse.slice(0, -1));
-      offset = 1;
-    }
-    for (;;) {
-      const end = text.indexOf("\n\n", offset);
-      if (end < 0) {
-        appendEventFragment(text.slice(offset));
-        return;
+    if (pendingCr) {
+      if (text.charCodeAt(0) === LF) {
+        if (pendingCrBelongsToEvent) appendEventFragment("\n");
+        offset = 1;
       }
-      appendEventFragment(text.slice(offset, end));
-      takeEvent(sse);
-      offset = end + 2;
+      pendingCr = false;
+      pendingCrBelongsToEvent = false;
+    }
+
+    while (offset < text.length) {
+      let end = offset;
+      while (end < text.length) {
+        const code = text.charCodeAt(end);
+        if (code === CR || code === LF) break;
+        end++;
+      }
+      if (end > offset) {
+        appendEventFragment(text.slice(offset, end));
+        lineHasContent = true;
+      }
+      if (end === text.length) return;
+
+      const code = text.charCodeAt(end);
+      if (lineHasContent) {
+        appendEventFragment(code === CR ? "\r" : "\n");
+        lineHasContent = false;
+        if (code === CR) pendingCrBelongsToEvent = true;
+      } else {
+        takeEvent(sse);
+        pendingCrBelongsToEvent = false;
+      }
+      pendingCr = code === CR;
+      offset = end + 1;
+
+      if (pendingCr && offset < text.length) {
+        if (text.charCodeAt(offset) === LF) {
+          if (pendingCrBelongsToEvent) appendEventFragment("\n");
+          offset++;
+        }
+        pendingCr = false;
+        pendingCrBelongsToEvent = false;
+      }
     }
   };
 
@@ -514,7 +558,7 @@ export async function transcribeLive(
     } else {
       failure ??= error;
       rejectPending(failure);
-      settleClosed();
+      settleResponse();
     }
     rejectDeadline(failure ?? error);
   }, timeoutMs);
@@ -527,6 +571,13 @@ export async function transcribeLive(
         data: (s, chunk) => {
           try {
             consumeEvents(reader.push(chunk));
+            if (reader.complete) {
+              // HTTP/1.1 persistence leaves the socket open after the zero
+              // chunk and trailer terminator, so framing completion owns this
+              // signal rather than the transport's eventual close callback.
+              flushPendingEvent();
+              settleResponse();
+            }
             if (failure) abortSocket(s, failure);
           } catch (err: unknown) {
             abortSocket(s, err instanceof Error ? err : new Error(String(err)));
@@ -538,13 +589,14 @@ export async function transcribeLive(
           waiter?.resolve();
         },
         close: () => {
+          socketReleased = true;
           if (!requestBodyDone) {
             failure ??= new Error("connection closed before request body completed");
           } else if (!reader.complete) {
             failure ??= new Error("connection closed before response completed");
           }
           if (failure) rejectPending(failure);
-          settleClosed();
+          settleResponse();
         },
         error: (s, err) => {
           abortSocket(s, err instanceof Error ? err : new Error(String(err)));
@@ -564,30 +616,32 @@ export async function transcribeLive(
       `Transfer-Encoding: chunked\r\nContent-Type: application/octet-stream\r\nAccept: text/event-stream\r\n\r\n`,
     );
 
-    t0 = now();
+    paceStartedAt = now();
     for (let off = 0; off < pcm.length && !failure; off += chunkBytes) {
       const slice = pcm.subarray(off, Math.min(off + chunkBytes, pcm.length));
       if (c.pace !== "fast") {
         // Wait until this chunk's final sample would have been captured before
         // sending it, so no sample arrives earlier than a live microphone could provide it.
         const playedMs = ((off + slice.length) / 2 / sampleRate) * 1000;
-        const wait = t0 + playedMs - now();
+        const wait = paceStartedAt + playedMs - now();
         if (wait > 0) await waitForPace(wait);
       }
       await writeAll(`${slice.length.toString(16)}\r\n`);
+      if (off === 0) firstPcmWrittenAt = now();
       await writeAll(slice);
+      if (off + slice.length === pcm.length) lastPcmWrittenAt = now();
       await writeAll("\r\n");
     }
     await writeAll("0\r\n\r\n");
     requestBodyDone = true;
-    await closed;
+    await responseComplete;
     flushPendingEvent();
   } finally {
     clearTimeout(timeout);
     const cleanupError = failure ?? new Error("live transcription request ended");
     rejectPending(cleanupError);
-    settleClosed();
-    socket?.terminate();
+    settleResponse();
+    if (socket) releaseSocket(socket);
   }
 
   if (failure) throw failure;
@@ -603,12 +657,12 @@ export async function transcribeLive(
   return {
     text: text.trim(),
     audioMs,
-    firstDeltaMs,
-    deltasDuringAudio,
+    firstDeltaMs: firstDeltaAt === null ? null : firstDeltaAt - firstPcmWrittenAt,
+    deltasDuringAudio: deltaTimes.filter((at) => at < lastPcmWrittenAt).length,
     deltas,
     // Without a terminal event, the last delta is the best available finish
     // estimate. A negative value is still meaningful when that final available
     // delta genuinely arrived before the audio itself finished.
-    finalAfterAudioMs: (doneMs ?? lastDeltaMs ?? audioMs) - audioMs,
+    finalAfterAudioMs: (doneAt ?? lastDeltaAt ?? lastPcmWrittenAt) - lastPcmWrittenAt,
   };
 }

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -84,7 +84,9 @@ function toS16le(samples: Float32Array): Uint8Array {
  * split on event boundaries.
  */
 class ChunkedResponseReader {
-  private state: "headers" | "size" | "size-lf" | "data" | "data-cr" | "data-lf" | "done" = "headers";
+  private state:
+    | "headers" | "size" | "size-lf" | "data" | "data-cr" | "data-lf"
+    | "trailer" | "trailer-lf" | "done" = "headers";
   private header = new Uint8Array(1024);
   private headerLength = 0;
   private headerEndMatched = 0;
@@ -92,6 +94,8 @@ class ChunkedResponseReader {
   private sizeLineLength = 0;
   private chunkRemaining = 0;
   private bodyBytes = 0;
+  private trailerBytes = 0;
+  private trailerLineLength = 0;
   private readonly decoder = new TextDecoder();
   status = 0;
 
@@ -140,6 +144,33 @@ class ChunkedResponseReader {
       if (this.state === "data-cr") {
         if (byte !== CR) throw new Error("response chunk is missing its trailing CRLF");
         this.state = "data-lf";
+        offset++;
+        continue;
+      }
+      if (this.state === "trailer") {
+        if (byte === CR) {
+          this.state = "trailer-lf";
+        } else {
+          this.trailerLineLength++;
+          this.trailerBytes++;
+          if (this.trailerBytes > this.limits.maxHeaderBytes) {
+            throw new RangeError(
+              `response trailer section exceeds ${this.limits.maxHeaderBytes}-byte limit`,
+            );
+          }
+        }
+        offset++;
+        continue;
+      }
+      if (this.state === "trailer-lf") {
+        if (byte !== LF) throw new Error("malformed trailer section in response");
+        if (this.trailerLineLength === 0) {
+          this.state = "done";
+          text.push(this.decoder.decode());
+        } else {
+          this.trailerLineLength = 0;
+          this.state = "trailer";
+        }
         offset++;
         continue;
       }
@@ -227,8 +258,14 @@ class ChunkedResponseReader {
     }
     this.sizeLineLength = 0;
     if (size === 0) {
-      this.state = "done";
-      return this.decoder.decode();
+      // RFC 9112 7.1: the zero chunk is followed by an optional trailer section
+      // and a final empty line. The response is NOT complete until that line
+      // arrives, and treating it as complete lets a peer that sends `0\r\n` and
+      // then FIN be recorded as a successful measurement.
+      this.trailerBytes = 0;
+      this.trailerLineLength = 0;
+      this.state = "trailer";
+      return "";
     }
     this.chunkRemaining = size;
     this.state = "data";

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -18,7 +18,7 @@ import { sanitizeLabel } from "../../src/text-utils";
 import type { StreamCandidate } from "./types";
 
 export interface LiveStreamResult {
-  /** Final transcript from `transcript.text.done` (falls back to joined deltas). */
+  /** Final transcript from `transcript.text.done`. */
   text: string;
   /** Clip length in ms — the wall-clock budget a real-time feed spends uploading. */
   audioMs: number;
@@ -341,7 +341,6 @@ export async function transcribeLive(
   let sse = "";
   let sseBytes = 0;
   let firstDeltaAt: number | null = null;
-  let lastDeltaAt: number | null = null;
   const deltaTimes: number[] = [];
   let deltas = 0;
   let doneAt: number | null = null;
@@ -350,7 +349,6 @@ export async function transcribeLive(
   // empty final fall back to the partials, which records a stale mid-stream
   // guess as the model's answer.
   let finalText: string | null = null;
-  let joined = "";
   let paceStartedAt = 0;
   let firstPcmWrittenAt = 0;
   let lastPcmWrittenAt = 0;
@@ -416,9 +414,7 @@ export async function transcribeLive(
     const at = now();
     if (event.type === "transcript.text.delta") {
       deltas++;
-      joined += event.delta ?? "";
       firstDeltaAt ??= at;
-      lastDeltaAt = at;
       deltaTimes.push(at);
     } else if (event.type === "transcript.text.done") {
       // The last terminal event wins because its text is the transcript scored;
@@ -645,13 +641,19 @@ export async function transcribeLive(
   }
 
   if (failure) throw failure;
+  // Clean HTTP framing is not a complete transcription: a server that never
+  // sends the terminal event has no finish instant to measure, and scoring its
+  // last partial instead would time the finish earlier than a conforming
+  // server's terminal event, ranking the incomplete implementation ahead of
+  // the correct one. A run that cannot be measured is an error, not a number.
+  if (finalText === null || doneAt === null) {
+    throw new Error("stream ended without a transcript.text.done terminal event");
+  }
   // A terminal event wins even when it is empty: the model said it heard
   // nothing, and the partials it has already retracted are not a substitute.
-  const text = finalText ?? joined;
+  const text = finalText;
   if (!text.trim()) {
-    throw new Error(finalText === null
-      ? "stream closed without a transcript"
-      : "stream ended with an empty final transcript");
+    throw new Error("stream ended with an empty final transcript");
   }
 
   return {
@@ -660,9 +662,6 @@ export async function transcribeLive(
     firstDeltaMs: firstDeltaAt === null ? null : firstDeltaAt - firstPcmWrittenAt,
     deltasDuringAudio: deltaTimes.filter((at) => at < lastPcmWrittenAt).length,
     deltas,
-    // Without a terminal event, the last delta is the best available finish
-    // estimate. A negative value is still meaningful when that final available
-    // delta genuinely arrived before the audio itself finished.
-    finalAfterAudioMs: (doneAt ?? lastDeltaAt ?? lastPcmWrittenAt) - lastPcmWrittenAt,
+    finalAfterAudioMs: doneAt - lastPcmWrittenAt,
   };
 }

--- a/bench/stt/live-stream.ts
+++ b/bench/stt/live-stream.ts
@@ -21,7 +21,7 @@ export interface LiveStreamResult {
   text: string;
   /** Clip length in ms — the wall-clock budget a real-time feed spends uploading. */
   audioMs: number;
-  /** First `transcript.text.delta`, ms after the first PCM byte. null if none. */
+  /** First `transcript.text.delta`, ms after real-time capture begins. null if none. */
   firstDeltaMs: number | null;
   /** Deltas that landed before the clip's audio would have finished playing. */
   deltasDuringAudio: number;
@@ -46,7 +46,13 @@ export interface LiveStreamOptions {
   limits?: Partial<LiveStreamResponseLimits>;
   /** Injectable monotonic clock for deterministic timing regressions. */
   now?: () => number;
+  /** Injectable connector for deterministic connection-deadline regressions. */
+  connect?: LiveStreamConnect;
 }
+
+export type LiveStreamConnect = (
+  options: Bun.TCPSocketConnectOptions<undefined>,
+) => Promise<Bun.Socket<undefined>>;
 
 const DEFAULT_CHUNK_MS = 100;
 const DEFAULT_TIMEOUT_MS = 180_000;
@@ -90,6 +96,10 @@ class ChunkedResponseReader {
   status = 0;
 
   constructor(private readonly limits: LiveStreamResponseLimits) {}
+
+  get complete(): boolean {
+    return this.state === "done";
+  }
 
   /** Returns any newly decoded body text. Throws on a malformed response. */
   push(chunk: Uint8Array): string {
@@ -258,6 +268,8 @@ export async function transcribeLive(
   }
   const limits = responseLimits(options.limits);
   const now = options.now ?? (() => performance.now());
+  const connect: LiveStreamConnect =
+    options.connect ?? ((connectOptions) => Bun.connect(connectOptions));
   const { samples, sampleRate } = decodeWav(await Bun.file(audioPath).arrayBuffer());
   const pcm = toS16le(samples);
   const audioMs = (samples.length / sampleRate) * 1000;
@@ -285,7 +297,7 @@ export async function transcribeLive(
   let doneMs: number | null = null;
   let finalText = "";
   let joined = "";
-  let t0 = 0; // set when the first PCM byte goes out
+  let t0 = 0; // set when real-time capture begins
   let failure: Error | null = null;
   let resolveClosed!: () => void;
   let closedSettled = false;
@@ -381,42 +393,14 @@ export async function transcribeLive(
     }
   };
 
-  const socket = await Bun.connect({
-    hostname: host,
-    port: c.port,
-    socket: {
-      data: (s, chunk) => {
-        try {
-          consumeEvents(reader.push(chunk));
-          if (failure) abortSocket(s, failure);
-        } catch (err: unknown) {
-          abortSocket(s, err instanceof Error ? err : new Error(String(err)));
-        }
-      },
-      drain: () => {
-        const waiter = drainWaiter;
-        drainWaiter = null;
-        waiter?.resolve();
-      },
-      close: () => {
-        if (!requestBodyDone) {
-          failure ??= new Error("connection closed before request body completed");
-          rejectPending(failure);
-        }
-        settleClosed();
-      },
-      error: (s, err) => {
-        abortSocket(s, err instanceof Error ? err : new Error(String(err)));
-      },
-    },
-  });
+  let socket: Bun.Socket<undefined> | null = null;
 
   /** Bun's `write` does not buffer the remainder, so a short write must be re-driven. */
   const writeAll = async (data: Uint8Array | string): Promise<void> => {
     let payload = typeof data === "string" ? new TextEncoder().encode(data) : data;
     while (payload.length) {
       if (failure) throw failure;
-      const n = socket.write(payload);
+      const n = socket!.write(payload);
       if (n >= payload.length) return;
       payload = payload.subarray(Math.max(n, 0));
       await new Promise<void>((resolve, reject) => {
@@ -436,11 +420,62 @@ export async function transcribeLive(
     });
   };
 
+  let releaseLateSocket = false;
+  let rejectDeadline!: (error: Error) => void;
+  const deadline = new Promise<never>((_, reject) => { rejectDeadline = reject; });
   const timeout = setTimeout(() => {
-    abortSocket(socket, new Error(`no response within ${timeoutMs} ms`));
+    releaseLateSocket = true;
+    const error = new Error(`no response within ${timeoutMs} ms`);
+    if (socket) {
+      abortSocket(socket, error);
+    } else {
+      failure ??= error;
+      rejectPending(failure);
+      settleClosed();
+    }
+    rejectDeadline(failure ?? error);
   }, timeoutMs);
 
   try {
+    const connecting = connect({
+      hostname: host,
+      port: c.port,
+      socket: {
+        data: (s, chunk) => {
+          try {
+            consumeEvents(reader.push(chunk));
+            if (failure) abortSocket(s, failure);
+          } catch (err: unknown) {
+            abortSocket(s, err instanceof Error ? err : new Error(String(err)));
+          }
+        },
+        drain: () => {
+          const waiter = drainWaiter;
+          drainWaiter = null;
+          waiter?.resolve();
+        },
+        close: () => {
+          if (!requestBodyDone) {
+            failure ??= new Error("connection closed before request body completed");
+          } else if (!reader.complete) {
+            failure ??= new Error("connection closed before response completed");
+          }
+          if (failure) rejectPending(failure);
+          settleClosed();
+        },
+        error: (s, err) => {
+          abortSocket(s, err instanceof Error ? err : new Error(String(err)));
+        },
+      },
+    });
+    void connecting.then(
+      (connected) => {
+        if (releaseLateSocket) connected.terminate();
+      },
+      () => {},
+    );
+    socket = await Promise.race([connecting, deadline]);
+
     await writeAll(
       `POST ${path} HTTP/1.1\r\nHost: ${host}:${c.port}\r\n` +
       `Transfer-Encoding: chunked\r\nContent-Type: application/octet-stream\r\nAccept: text/event-stream\r\n\r\n`,
@@ -449,16 +484,16 @@ export async function transcribeLive(
     t0 = now();
     for (let off = 0; off < pcm.length && !failure; off += chunkBytes) {
       const slice = pcm.subarray(off, Math.min(off + chunkBytes, pcm.length));
-      await writeAll(`${slice.length.toString(16)}\r\n`);
-      await writeAll(slice);
-      await writeAll("\r\n");
       if (c.pace !== "fast") {
-        // Sleep until this chunk's audio would have finished playing, so the
-        // server never sees samples earlier than a live microphone would deliver.
+        // Wait until this chunk's final sample would have been captured before
+        // sending it, so no sample arrives earlier than a live microphone could provide it.
         const playedMs = ((off + slice.length) / 2 / sampleRate) * 1000;
         const wait = t0 + playedMs - now();
         if (wait > 0) await waitForPace(wait);
       }
+      await writeAll(`${slice.length.toString(16)}\r\n`);
+      await writeAll(slice);
+      await writeAll("\r\n");
     }
     await writeAll("0\r\n\r\n");
     requestBodyDone = true;
@@ -468,7 +503,7 @@ export async function transcribeLive(
     const cleanupError = failure ?? new Error("live transcription request ended");
     rejectPending(cleanupError);
     settleClosed();
-    socket.terminate();
+    socket?.terminate();
   }
 
   if (failure) throw failure;

--- a/bench/stt/types.ts
+++ b/bench/stt/types.ts
@@ -1,5 +1,5 @@
 /** A thing the bench can compare: anything that turns a WAV into text. */
-export type Candidate = ProviderCandidate | CommandCandidate;
+export type Candidate = ProviderCandidate | CommandCandidate | StreamCandidate;
 
 /** An integrated Cicero STT backend, exercised through its real provider. */
 export interface ProviderCandidate {
@@ -20,6 +20,27 @@ export interface CommandCandidate {
   name: string;
   kind: "command";
   command: string; // e.g. "parakeet-mlx transcribe {audio}"
+}
+
+/**
+ * An audio.cpp model driven over `POST /v1/audio/transcriptions/live` — PCM fed
+ * at real-time pace up a chunked request body, SSE deltas timed as they come
+ * back. This is the only candidate kind that measures streaming time-to-final;
+ * the other two are whole-clip transcribes. The model must be `mode: "streaming"`
+ * server-side, and each run costs at least the clip's own duration in wall-clock.
+ */
+export interface StreamCandidate {
+  name: string;
+  kind: "stream";
+  model: string; // audio.cpp model id, e.g. "voxtral-realtime"
+  port: number;
+  host?: string; // default 127.0.0.1
+  path?: string; // default /v1/audio/transcriptions/live
+  language?: string;
+  chunkMs?: number; // PCM sent per write; default 100
+  /** "fast" uploads as quickly as the socket takes it — useful to check a model
+   *  responds at all, but the resulting timings are NOT streaming latencies. */
+  pace?: "realtime" | "fast";
 }
 
 /** One clip to transcribe, paired with its ground-truth transcript. */

--- a/src/backends/stt/tap.ts
+++ b/src/backends/stt/tap.ts
@@ -2,6 +2,7 @@ import { chmod, lstat, mkdir, open, readdir, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { log } from "../../logger";
 import { PRIVATE_DIRECTORY_MODE, PRIVATE_FILE_MODE } from "../../platform/secure-storage";
+import { sanitizeLabel } from "../../text-utils";
 import type { STTProvider, STTTranscriptionResult } from "./provider";
 
 /**
@@ -81,19 +82,6 @@ const MAX_ENGINE_CHARS = 128; // provider name is untrusted; cap it in logs + si
 
 /** Matches only files this tap wrote: an ISO-ish stamp plus a 3-digit counter. */
 const TAP_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2}T[0-9-]+Z-\d{3})\.(wav|json)$/;
-
-/**
- * Make a value safe to interpolate into a log line: strip C0/C7F control
- * characters (so a newline or terminal escape in an env path / provider name
- * can't forge log entries or emit control sequences) and length-cap it.
- */
-function sanitizeLabel(value: string, max: number): string {
-  const cleaned = Array.from(value, (ch) => {
-    const c = ch.codePointAt(0)!;
-    return c < 0x20 || c === 0x7f ? "\uFFFD" : ch; // strip C0/DEL controls
-  });
-  return cleaned.length > max ? cleaned.slice(0, max).join("") + "\u2026" : cleaned.join("");
-}
 
 /** One utterance, fully read from the source and ready to persist off the hot path. */
 interface Capture {

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -1,4 +1,17 @@
 /**
+ * Make a value safe to interpolate into a log line: strip C0/C7F control
+ * characters (so a newline or terminal escape in an untrusted value can't
+ * forge log entries or emit control sequences) and length-cap it.
+ */
+export function sanitizeLabel(value: string, max: number): string {
+  const cleaned = Array.from(value, (ch) => {
+    const c = ch.codePointAt(0)!;
+    return c < 0x20 || c === 0x7f ? "\uFFFD" : ch; // strip C0/DEL controls
+  });
+  return cleaned.length > max ? cleaned.slice(0, max).join("") + "\u2026" : cleaned.join("");
+}
+
+/**
  * Strip leading filler words and trailing punctuation from voice input.
  * Used as a preprocessing step before intent classification.
  *

--- a/tests/bench/live-stream.test.ts
+++ b/tests/bench/live-stream.test.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { createServer, type Socket as NodeSocket } from "node:net";
+import { transcribeLive } from "../../bench/stt/live-stream";
+import type { StreamCandidate } from "../../bench/stt/types";
+import { writeWavFixture } from "../helpers/wav";
+
+const encoder = new TextEncoder();
+
+function candidate(port: number): StreamCandidate {
+  return {
+    name: "local test stream",
+    kind: "stream",
+    model: "test-model",
+    host: "127.0.0.1",
+    port,
+    pace: "fast",
+  };
+}
+
+function listenAfterCompleteRequest(
+  respond: (socket: Bun.Socket) => void,
+): Bun.TCPSocketListener<undefined> {
+  let request = "";
+  let responded = false;
+  return Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, data) {
+        request += data.toString("latin1");
+        if (!responded && request.includes("0\r\n\r\n")) {
+          responded = true;
+          respond(socket);
+        }
+      },
+    },
+  });
+}
+
+async function withGuard<T>(promise: Promise<T>, ms = 500): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`test guard expired after ${ms} ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function writeChunk(socket: Bun.Socket, text: string): void {
+  const bytes = encoder.encode(text);
+  socket.write(`${bytes.byteLength.toString(16)}\r\n`);
+  socket.write(bytes);
+  socket.write("\r\n");
+}
+
+/**
+ * A peer that consumes the whole request and then neither answers nor closes —
+ * and, crucially, tolerates the client's half-close. This has to be `node:net`
+ * with `allowHalfOpen`: a `Bun.listen` server closes the connection as soon as
+ * it sees the client's FIN, which resolves the client's `closed` promise for it
+ * and makes a write-side-only `end()` look like a working deadline. Keeping the
+ * response side open is what a real streaming HTTP server does while the
+ * request body is already finished, and it is the case the deadline must
+ * survive without hanging.
+ */
+async function listenIgnoringHalfClose(): Promise<{
+  port: number;
+  sawCompleteRequest: () => boolean;
+  stop: () => Promise<void>;
+}> {
+  const sockets = new Set<NodeSocket>();
+  let request = "";
+  let complete = false;
+  const server = createServer({ allowHalfOpen: true }, (socket) => {
+    sockets.add(socket);
+    socket.on("data", (data: Buffer) => {
+      request += data.toString("latin1");
+      if (request.includes("0\r\n\r\n")) complete = true;
+    });
+    // Deliberately no `socket.end()` here: the client's FIN must not be echoed.
+    socket.on("end", () => {});
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test peer did not report a numeric port");
+  }
+  return {
+    port: address.port,
+    sawCompleteRequest: () => complete,
+    stop: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => { server.close(() => resolve()); });
+    },
+  };
+}
+
+/*
+ * This test is a behavioural guard, NOT a pre-fix reproducer, and the
+ * distinction is worth recording because the original review claimed otherwise.
+ * The claim was that the old write-side-only `socket.end()` left `closed`
+ * pending until the peer closed, so a silent peer hung the request forever.
+ * That is Node's half-close behaviour, not Bun's: measured on Bun 1.3.14, a
+ * client `end()` fires the client's own `close` handler immediately even when
+ * the peer holds its side open (`allowHalfOpen`), so `closed` resolved and the
+ * old code raised this same error. The write path does not hang either — Bun
+ * fires `drain` after a close, so a parked `writeAll` is released.
+ *
+ * The deadline rework is therefore hardening rather than a bug fix: it stops
+ * depending on Bun choosing to fire `drain` on a closing socket, which is not
+ * documented behaviour. What this test locks in is the error text and that the
+ * request terminates; no mutation of the release path makes it fail.
+ */
+test("live stream deadline releases a peer that never responds or closes", async () => {
+  const server = await listenIgnoringHalfClose();
+  const wav = writeWavFixture(0.01);
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 50 }),
+    )).rejects.toThrow("no response within 50 ms");
+    expect(server.sawCompleteRequest()).toBe(true);
+  } finally {
+    await server.stop();
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("live stream rejects a response chunk above the configured limit", async () => {
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "9\r\n",
+    );
+  });
+  const wav = writeWavFixture(0.01);
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), {
+        timeoutMs: 250,
+        limits: { maxChunkBytes: 8 },
+      }),
+    )).rejects.toThrow("response chunk exceeds 8-byte limit");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("live stream without a terminal event uses the last delta for time-to-final", async () => {
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello "}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"world"}\n\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(10);
+  const clock = [0, 1_000, 10_500];
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), {
+        timeoutMs: 250,
+        now: () => clock.shift() ?? 10_500,
+      }),
+    );
+    expect(result.audioMs).toBeCloseTo(10_000, 5);
+    expect(result.firstDeltaMs).toBeCloseTo(1_000, 5);
+    expect(result.finalAfterAudioMs).toBeCloseTo(500, 5);
+    expect(result.finalAfterAudioMs).not.toBeCloseTo(-9_000, 5);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);

--- a/tests/bench/live-stream.test.ts
+++ b/tests/bench/live-stream.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
 import { rmSync } from "node:fs";
 import { createServer, type Socket as NodeSocket } from "node:net";
-import { transcribeLive } from "../../bench/stt/live-stream";
+import { liveStreamTimeoutMs, transcribeLive } from "../../bench/stt/live-stream";
+import { MAX_DECODED_WAV_DURATION_MS } from "../../src/platform/wav";
 import { portOpen } from "../../bench/stt-bench";
 import type { StreamCandidate } from "../../bench/stt/types";
 import { writeWavFixture } from "../helpers/wav";
@@ -307,6 +308,120 @@ test("live stream without a terminal event uses the last delta for time-to-final
     expect(result.firstDeltaMs).toBeCloseTo(1_000, 5);
     expect(result.finalAfterAudioMs).toBeCloseTo(500, 5);
     expect(result.finalAfterAudioMs).not.toBeCloseTo(-9_000, 5);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("an empty terminal transcript is not backfilled from the partials", async () => {
+  // audio.cpp emits partials and the terminal `text_output` independently, so a
+  // clip the model ultimately heard nothing in arrives as deltas followed by an
+  // empty `transcript.text.done`. Scoring the retracted partial as the answer
+  // would silently credit a model for words it withdrew.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"stale partial"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":""}\n\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.08, 8_000);
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    )).rejects.toThrow("empty final transcript");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("a non-empty terminal transcript still wins over the partials", async () => {
+  // The other side of that boundary: the terminal event replaces the deltas, it
+  // does not merely get preferred when non-empty by accident of `||`.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"stale partial"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"corrected final"}\n\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.08, 8_000);
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    );
+    expect(result.text).toBe("corrected final");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("the default deadline outlasts the longest clip decodeWav will accept", () => {
+  // The feed is paced in real time, so a run cannot finish sooner than the clip
+  // itself. A fixed 180s deadline failed every legal clip over three minutes
+  // however healthy the server was — decodeWav accepts up to five.
+  expect(liveStreamTimeoutMs(MAX_DECODED_WAV_DURATION_MS)).toBeGreaterThan(MAX_DECODED_WAV_DURATION_MS);
+  expect(liveStreamTimeoutMs(10_000)).toBeGreaterThan(10_000);
+  // Still bounded: the grace is a constant, not a multiple.
+  expect(liveStreamTimeoutMs(10_000)).toBeLessThan(10_000 + 5 * 60_000);
+});
+
+test("a final SSE event missing its blank line is still consumed", async () => {
+  // The HTTP body can frame correctly while the last event lacks its "\n\n".
+  // Dropping that residual silently rewrote the answer to the previous delta.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello world"}\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.08, 8_000);
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    );
+    expect(result.text).toBe("hello world");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("a response cut off inside its final SSE event fails the run", async () => {
+  // The other side of that boundary: a residual that is not a whole event means
+  // the stream was truncated, and the earlier delta is not the model's answer.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello wor');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.08, 8_000);
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    )).rejects.toThrow("response ended mid-event");
   } finally {
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });

--- a/tests/bench/live-stream.test.ts
+++ b/tests/bench/live-stream.test.ts
@@ -403,6 +403,62 @@ test("a final SSE event missing its blank line is still consumed", async () => {
   }
 }, 1_000);
 
+test("a malformed but properly delimited SSE event fails the run", async () => {
+  // The residual path is not the only way an unparseable event arrives. A
+  // server can emit a whole "\n\n"-terminated event whose payload is not JSON;
+  // discarding it left the run scored on the previous delta with that delta's
+  // timing recorded as the final.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello wor\n\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.08, 8_000);
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    )).rejects.toThrow("malformed SSE event");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("non-JSON bookkeeping lines are not mistaken for malformed events", async () => {
+  // The other side of that boundary: SSE comments, an unrelated event type and
+  // the conventional [DONE] sentinel carry no JSON payload and must not fail a
+  // run that otherwise completed.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, ": keep-alive\n\n");
+    writeChunk(socket, "event: ping\n\n");
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello world"}\n\n');
+    writeChunk(socket, "data: [DONE]\n\n");
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.08, 8_000);
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    );
+    expect(result.text).toBe("hello world");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
 test("a response cut off inside its final SSE event fails the run", async () => {
   // The other side of that boundary: a residual that is not a whole event means
   // the stream was truncated, and the earlier delta is not the model's answer.

--- a/tests/bench/live-stream.test.ts
+++ b/tests/bench/live-stream.test.ts
@@ -97,6 +97,7 @@ test("live stream realtime pacing waits for each chunk's final sample", async ()
               "Transfer-Encoding: chunked\r\n\r\n",
             );
             writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"ok"}\n\n');
+            writeChunk(socket, 'data: {"type":"transcript.text.done","text":"ok"}\n\n');
             socket.write("0\r\n\r\n");
             socket.end();
           }
@@ -151,6 +152,7 @@ test("first-delta latency starts when the first PCM bytes are written", async ()
       "Transfer-Encoding: chunked\r\n\r\n",
     );
     writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"ok"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"ok"}\n\n');
     socket.write("0\r\n\r\n");
     socket.end();
   });
@@ -357,7 +359,10 @@ test("live stream completes and releases a persistent HTTP connection", async ()
   }
 }, 1_000);
 
-test("live stream without a terminal event uses the last delta for time-to-final", async () => {
+test("live stream rejects a cleanly framed response without a terminal event", async () => {
+  // A delta-only response has no time-to-final measurement: using its last
+  // partial would timestamp it earlier than a conforming server's terminal
+  // event and silently reward an incomplete application-level sequence.
   const server = listenAfterCompleteRequest((socket) => {
     socket.write(
       "HTTP/1.1 200 OK\r\n" +
@@ -370,20 +375,56 @@ test("live stream without a terminal event uses the last delta for time-to-final
     socket.end();
   });
   const wav = writeWavFixture(10);
-  const clock = [0, 0, 0, 1_000, 10_500];
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    )).rejects.toThrow("stream ended without a transcript.text.done terminal event");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("a terminal event remains the source of time-to-final", async () => {
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello"}\n\n');
+    writeChunk(socket, "data: [DONE]\n\n");
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello world"}\n\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const incompleteServer = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, "data: [DONE]\n\n");
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.01);
+  const clock = [0, 0, 0, 100, 800];
   try {
     const result = await withGuard(
       transcribeLive(wav.path, candidate(server.port), {
         timeoutMs: 250,
-        now: () => clock.shift() ?? 10_500,
+        now: () => clock.shift() ?? 800,
       }),
     );
-    expect(result.audioMs).toBeCloseTo(10_000, 5);
-    expect(result.firstDeltaMs).toBeCloseTo(1_000, 5);
-    expect(result.finalAfterAudioMs).toBeCloseTo(10_500, 5);
-    expect(result.finalAfterAudioMs).not.toBeCloseTo(1_000, 5);
+    expect(result.text).toBe("hello world");
+    expect(result.finalAfterAudioMs).toBeCloseTo(800, 5);
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(incompleteServer.port), { timeoutMs: 250 }),
+    )).rejects.toThrow("stream ended without a transcript.text.done terminal event");
   } finally {
     server.stop(true);
+    incompleteServer.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });
   }
 }, 1_000);

--- a/tests/bench/live-stream.test.ts
+++ b/tests/bench/live-stream.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { rmSync } from "node:fs";
 import { createServer, type Socket as NodeSocket } from "node:net";
 import { transcribeLive } from "../../bench/stt/live-stream";
+import { portOpen } from "../../bench/stt-bench";
 import type { StreamCandidate } from "../../bench/stt/types";
 import { writeWavFixture } from "../helpers/wav";
 
@@ -58,6 +59,88 @@ function writeChunk(socket: Bun.Socket, text: string): void {
   socket.write(bytes);
   socket.write("\r\n");
 }
+
+test("live stream realtime pacing waits for each chunk's final sample", async () => {
+  const arrivals: number[] = [];
+  let buffered = Buffer.alloc(0);
+  let headersRead = false;
+  let responded = false;
+  const server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, data) {
+        buffered = Buffer.concat([buffered, data]);
+        if (!headersRead) {
+          const headerEnd = buffered.indexOf("\r\n\r\n");
+          if (headerEnd < 0) return;
+          headersRead = true;
+          buffered = buffered.subarray(headerEnd + 4);
+        }
+        for (;;) {
+          const lineEnd = buffered.indexOf("\r\n");
+          if (lineEnd < 0) return;
+          const size = Number.parseInt(buffered.subarray(0, lineEnd).toString("ascii"), 16);
+          const frameEnd = lineEnd + 2 + size + 2;
+          if (buffered.length < frameEnd) return;
+          buffered = buffered.subarray(frameEnd);
+          if (size > 0) {
+            arrivals.push(performance.now());
+            continue;
+          }
+          if (!responded) {
+            responded = true;
+            socket.write(
+              "HTTP/1.1 200 OK\r\n" +
+              "Content-Type: text/event-stream\r\n" +
+              "Transfer-Encoding: chunked\r\n\r\n",
+            );
+            writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"ok"}\n\n');
+            socket.write("0\r\n\r\n");
+            socket.end();
+          }
+          return;
+        }
+      },
+    },
+  });
+  const chunkMs = 40;
+  // 8 kHz is the lowest rate decodeWav accepts, and 80 ms of it is two 40 ms
+  // chunks — enough to check pacing without the test itself taking real time.
+  const wav = writeWavFixture(0.08, 8_000);
+  const realtimeCandidate: StreamCandidate = {
+    name: "local realtime test stream",
+    kind: "stream",
+    model: "test-model",
+    host: "127.0.0.1",
+    port: server.port,
+    chunkMs,
+  };
+  let captureStartedAt: number | undefined;
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, realtimeCandidate, {
+        timeoutMs: 250,
+        now: () => {
+          const at = performance.now();
+          captureStartedAt ??= at;
+          return at;
+        },
+      }),
+    );
+    expect(result.text).toBe("ok");
+    expect(arrivals).toHaveLength(2);
+    if (captureStartedAt === undefined) throw new Error("capture clock was not read");
+    for (const [index, arrival] of arrivals.entries()) {
+      expect(arrival - captureStartedAt).toBeGreaterThanOrEqual(
+        (index + 1) * chunkMs - 3,
+      );
+    }
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
 
 /**
  * A peer that consumes the whole request and then neither answers nor closes —
@@ -133,6 +216,28 @@ test("live stream deadline releases a peer that never responds or closes", async
   }
 }, 1_000);
 
+test("live stream deadline includes connection establishment", async () => {
+  const wav = writeWavFixture(0.01);
+  let connectCalls = 0;
+  const startedAt = performance.now();
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(0), {
+        timeoutMs: 30,
+        connect: () => {
+          connectCalls++;
+          return new Promise<Bun.Socket<undefined>>(() => {});
+        },
+      }),
+      250,
+    )).rejects.toThrow("no response within 30 ms");
+    expect(connectCalls).toBe(1);
+    expect(performance.now() - startedAt).toBeLessThan(200);
+  } finally {
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
 test("live stream rejects a response chunk above the configured limit", async () => {
   const server = listenAfterCompleteRequest((socket) => {
     socket.write(
@@ -150,6 +255,27 @@ test("live stream rejects a response chunk above the configured limit", async ()
         limits: { maxChunkBytes: 8 },
       }),
     )).rejects.toThrow("response chunk exceeds 8-byte limit");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("live stream rejects a response truncated before its zero chunk", async () => {
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"partial"}\n\n');
+    socket.end();
+  });
+  const wav = writeWavFixture(0.01);
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    )).rejects.toThrow("connection closed before response completed");
   } finally {
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });
@@ -185,4 +311,26 @@ test("live stream without a terminal event uses the last delta for time-to-final
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });
   }
+}, 1_000);
+
+test("the bench liveness probe gives up on a host that never connects", async () => {
+  // The probe runs before transcribeLive, so an unbounded connect here would
+  // hold the whole bench for the OS TCP timeout on a host that drops SYNs.
+  // Injected rather than pointed at a blackhole address, which is not portable.
+  let released = false;
+  const started = performance.now();
+  const open = await portOpen("192.0.2.1", 9, {
+    timeoutMs: 30,
+    connect: () => new Promise<Bun.Socket<undefined>>((resolve) => {
+      setTimeout(() => {
+        released = true;
+        resolve({ terminate: () => {}, end: () => {} } as unknown as Bun.Socket<undefined>);
+      }, 120);
+    }),
+  });
+  expect(open).toBe(false);
+  expect(performance.now() - started).toBeLessThan(100);
+  // The late socket must still be released rather than leaked.
+  await new Promise<void>((resolve) => { setTimeout(resolve, 150); });
+  expect(released).toBe(true);
 }, 1_000);

--- a/tests/bench/live-stream.test.ts
+++ b/tests/bench/live-stream.test.ts
@@ -334,3 +334,54 @@ test("the bench liveness probe gives up on a host that never connects", async ()
   await new Promise<void>((resolve) => { setTimeout(resolve, 150); });
   expect(released).toBe(true);
 }, 1_000);
+
+test("live stream rejects a response cut off inside the trailer section", async () => {
+  // RFC 9112 §7.1: a chunked body ends with the zero chunk, optional trailer
+  // fields, and a final empty line. A peer that sends `0\r\n` and then FIN has
+  // NOT finished, and treating it as finished silently records a truncated
+  // stream as a successful measurement.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"partial accepted"}\n\n');
+    socket.write("0\r\n");   // zero chunk, but no terminating CRLF
+    socket.end();
+  });
+  const wav = writeWavFixture(0.01);
+  try {
+    await expect(withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    )).rejects.toThrow("connection closed before response completed");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("live stream accepts a response whose zero chunk carries trailer fields", async () => {
+  // The converse of the truncation case: trailers are legal, so consuming the
+  // trailer section must not turn a well-formed response into a failure.
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"all done"}\n\n');
+    socket.write("0\r\nX-Bench-Trailer: ok\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.01);
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    );
+    expect(result.text).toBe("all done");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);

--- a/tests/bench/live-stream.test.ts
+++ b/tests/bench/live-stream.test.ts
@@ -143,6 +143,33 @@ test("live stream realtime pacing waits for each chunk's final sample", async ()
   }
 }, 1_000);
 
+test("first-delta latency starts when the first PCM bytes are written", async () => {
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"ok"}\n\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.01);
+  const clock = [0, 100, 105, 105];
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), {
+        timeoutMs: 250,
+        now: () => clock.shift() ?? 105,
+      }),
+    );
+    expect(result.firstDeltaMs).toBe(5);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
 /**
  * A peer that consumes the whole request and then neither answers nor closes —
  * and, crucially, tolerates the client's half-close. This has to be `node:net`
@@ -283,6 +310,53 @@ test("live stream rejects a response truncated before its zero chunk", async () 
   }
 }, 1_000);
 
+test("live stream completes and releases a persistent HTTP connection", async () => {
+  const sockets = new Set<NodeSocket>();
+  let resolveReleased!: () => void;
+  const released = new Promise<void>((resolve) => { resolveReleased = resolve; });
+  const server = createServer({ allowHalfOpen: true }, (socket) => {
+    sockets.add(socket);
+    let request = "";
+    socket.on("data", (data: Buffer) => {
+      request += data.toString("latin1");
+      if (!request.includes("0\r\n\r\n")) return;
+      socket.write(
+        "HTTP/1.1 200 OK\r\n" +
+        "Content-Type: text/event-stream\r\n" +
+        "Transfer-Encoding: chunked\r\n\r\n",
+      );
+      const event = 'data: {"type":"transcript.text.done","text":"kept alive"}\n\n';
+      socket.write(`${Buffer.byteLength(event).toString(16)}\r\n${event}\r\n0\r\n\r\n`);
+      request = "";
+    });
+    // A conformant persistent server leaves its write side open after the
+    // message terminator; the client must finish from framing and release it.
+    socket.on("end", () => {});
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      sockets.delete(socket);
+      resolveReleased();
+    });
+  });
+  await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test peer did not report a numeric port");
+  }
+  const wav = writeWavFixture(0.01);
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(address.port), { timeoutMs: 250 }),
+    );
+    expect(result.text).toBe("kept alive");
+    await withGuard(released, 250);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => { server.close(() => resolve()); });
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
 test("live stream without a terminal event uses the last delta for time-to-final", async () => {
   const server = listenAfterCompleteRequest((socket) => {
     socket.write(
@@ -296,7 +370,7 @@ test("live stream without a terminal event uses the last delta for time-to-final
     socket.end();
   });
   const wav = writeWavFixture(10);
-  const clock = [0, 1_000, 10_500];
+  const clock = [0, 0, 0, 1_000, 10_500];
   try {
     const result = await withGuard(
       transcribeLive(wav.path, candidate(server.port), {
@@ -306,8 +380,8 @@ test("live stream without a terminal event uses the last delta for time-to-final
     );
     expect(result.audioMs).toBeCloseTo(10_000, 5);
     expect(result.firstDeltaMs).toBeCloseTo(1_000, 5);
-    expect(result.finalAfterAudioMs).toBeCloseTo(500, 5);
-    expect(result.finalAfterAudioMs).not.toBeCloseTo(-9_000, 5);
+    expect(result.finalAfterAudioMs).toBeCloseTo(10_500, 5);
+    expect(result.finalAfterAudioMs).not.toBeCloseTo(1_000, 5);
   } finally {
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });
@@ -367,6 +441,35 @@ test("a non-empty terminal transcript still wins over the partials", async () =>
   }
 }, 1_000);
 
+test("the last terminal transcript keeps the last terminal timestamp", async () => {
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"draft"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"corrected"}\n\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.01);
+  const clock = [0, 0, 0, 100, 800];
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), {
+        timeoutMs: 250,
+        now: () => clock.shift() ?? 800,
+      }),
+    );
+    expect(result.text).toBe("corrected");
+    expect(result.finalAfterAudioMs).toBeCloseTo(800, 5);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
 test("the default deadline outlasts the longest clip decodeWav will accept", () => {
   // The feed is paced in real time, so a run cannot finish sooner than the clip
   // itself. A fixed 180s deadline failed every legal clip over three minutes
@@ -397,6 +500,31 @@ test("a final SSE event missing its blank line is still consumed", async () => {
       transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
     );
     expect(result.text).toBe("hello world");
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 1_000);
+
+test("CRLF-framed SSE events are parsed separately", async () => {
+  const server = listenAfterCompleteRequest((socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello "}\r\n\r\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello world"}\r\n\r\n');
+    socket.write("0\r\n\r\n");
+    socket.end();
+  });
+  const wav = writeWavFixture(0.01);
+  try {
+    const result = await withGuard(
+      transcribeLive(wav.path, candidate(server.port), { timeoutMs: 250 }),
+    );
+    expect(result.text).toBe("hello world");
+    expect(result.deltas).toBe(1);
   } finally {
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });
@@ -494,8 +622,10 @@ test("the bench liveness probe gives up on a host that never connects", async ()
     timeoutMs: 30,
     connect: () => new Promise<Bun.Socket<undefined>>((resolve) => {
       setTimeout(() => {
-        released = true;
-        resolve({ terminate: () => {}, end: () => {} } as unknown as Bun.Socket<undefined>);
+        resolve({
+          terminate: () => { released = true; },
+          end: () => {},
+        } as unknown as Bun.Socket<undefined>);
       }, 120);
     }),
   });

--- a/tests/bench/stt-bench-report.test.ts
+++ b/tests/bench/stt-bench-report.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { median, renderTable, renderStreamingTable } from "../../bench/stt-bench";
+
+const streamStats = { firstDeltaMs: 120, finalAfterAudioMs: 300, deltasDuringAudio: 4, deltas: 6 };
+
+test("median reports no samples as n/a rather than zero", () => {
+  // Every caller feeds this into a latency column. Returning 0 for "we never
+  // measured anything" is indistinguishable from an instantaneous response.
+  expect(median([])).toBeNaN();
+  expect(median([5])).toBe(5);
+  expect(median([1, 3])).toBe(2);
+});
+
+test("a candidate whose every clip failed is reported, not ranked first", () => {
+  // The failing candidate is listed first and carries WER 0 under the old
+  // aggregation, so an ascending sort by WER crowned the one that produced
+  // nothing. errors/clips columns alone did not stop it being read as the
+  // winner of the table.
+  const table = renderTable([
+    { name: "broken", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 3, clips: 0 },
+    { name: "working", available: true, meanWerPct: 12.5, warmMs: 400, coldMs: 900, rtf: 0.4, errors: 0, clips: 3 },
+    { name: "missing", available: false, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 },
+  ]);
+  const lines = table.split("\n");
+  const rows = lines.filter((l) => l.startsWith("| ") && !l.startsWith("| Candidate"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toContain("working");
+  expect(table).not.toMatch(/\| broken \|/);
+  expect(table).toContain("**Failed:**");
+  expect(table).toContain("- broken (reachable, but every clip failed — 3 errors; no metrics)");
+  expect(table).toContain("**Skipped:**");
+  expect(table).toContain("- missing (unavailable");
+});
+
+test("a streaming candidate whose every clip failed is reported, not ranked first", () => {
+  const table = renderStreamingTable([
+    {
+      name: "broken-stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
+      errors: 2, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0 },
+    },
+    {
+      name: "working-stream", available: true, meanWerPct: 8, warmMs: 5_000, coldMs: 5_000, rtf: 1,
+      errors: 0, clips: 3, streaming: streamStats,
+    },
+  ]);
+  const rows = table.split("\n").filter((l) => l.startsWith("| ") && !l.startsWith("| Candidate"));
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toContain("working-stream");
+  expect(table).toContain("- broken-stream (reachable, but every clip failed — 2 errors; no metrics)");
+});
+
+test("an all-failed streaming candidate is still reported when nothing succeeded", () => {
+  // With no ranked rows at all the table used to render as the empty string,
+  // so a total streaming failure disappeared from the report entirely.
+  const table = renderStreamingTable([
+    {
+      name: "broken-stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
+      errors: 1, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0 },
+    },
+  ]);
+  expect(table).toContain("broken-stream");
+  expect(table).toContain("1 error;");
+});
+
+test("batch and streaming candidates stay in their own tables", () => {
+  const rows = [
+    { name: "batch", available: true, meanWerPct: 10, warmMs: 300, coldMs: 800, rtf: 0.3, errors: 0, clips: 2 },
+    {
+      name: "stream", available: true, meanWerPct: 9, warmMs: 4_000, coldMs: 4_000, rtf: 1,
+      errors: 0, clips: 2, streaming: streamStats,
+    },
+  ];
+  expect(renderTable(rows)).toContain("| batch |");
+  expect(renderTable(rows)).not.toContain("| stream |");
+  expect(renderStreamingTable(rows)).toContain("| stream |");
+  expect(renderStreamingTable(rows)).not.toContain("| batch |");
+});

--- a/tests/bench/stt-bench-report.test.ts
+++ b/tests/bench/stt-bench-report.test.ts
@@ -20,9 +20,9 @@ test("a candidate whose every clip failed is reported, not ranked first", () => 
   // nothing. errors/clips columns alone did not stop it being read as the
   // winner of the table.
   const table = renderTable([
-    { name: "broken", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 3, clips: 0 },
-    { name: "working", available: true, meanWerPct: 12.5, warmMs: 400, coldMs: 900, rtf: 0.4, errors: 0, clips: 3 },
-    { name: "missing", available: false, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 },
+    { name: "broken", kind: "batch", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 3, clips: 0 },
+    { name: "working", kind: "batch", available: true, meanWerPct: 12.5, warmMs: 400, coldMs: 900, rtf: 0.4, errors: 0, clips: 3 },
+    { name: "missing", kind: "batch", available: false, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 },
   ]);
   const lines = table.split("\n");
   const rows = lines.filter((l) => l.startsWith("| ") && !l.startsWith("| Candidate"));
@@ -38,11 +38,11 @@ test("a candidate whose every clip failed is reported, not ranked first", () => 
 test("a streaming candidate whose every clip failed is reported, not ranked first", () => {
   const table = renderStreamingTable([
     {
-      name: "broken-stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
+      name: "broken-stream", kind: "stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
       errors: 2, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0, paced: true },
     },
     {
-      name: "working-stream", available: true, meanWerPct: 8, warmMs: 5_000, coldMs: 5_000, rtf: 1,
+      name: "working-stream", kind: "stream", available: true, meanWerPct: 8, warmMs: 5_000, coldMs: 5_000, rtf: 1,
       errors: 0, clips: 3, streaming: streamStats,
     },
   ]);
@@ -57,7 +57,7 @@ test("an all-failed streaming candidate is still reported when nothing succeeded
   // so a total streaming failure disappeared from the report entirely.
   const table = renderStreamingTable([
     {
-      name: "broken-stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
+      name: "broken-stream", kind: "stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
       errors: 1, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0, paced: true },
     },
   ]);
@@ -67,9 +67,9 @@ test("an all-failed streaming candidate is still reported when nothing succeeded
 
 test("batch and streaming candidates stay in their own tables", () => {
   const rows = [
-    { name: "batch", available: true, meanWerPct: 10, warmMs: 300, coldMs: 800, rtf: 0.3, errors: 0, clips: 2 },
+    { name: "batch", kind: "batch", available: true, meanWerPct: 10, warmMs: 300, coldMs: 800, rtf: 0.3, errors: 0, clips: 2 },
     {
-      name: "stream", available: true, meanWerPct: 9, warmMs: 4_000, coldMs: 4_000, rtf: 1,
+      name: "stream", kind: "stream", available: true, meanWerPct: 9, warmMs: 4_000, coldMs: 4_000, rtf: 1,
       errors: 0, clips: 2, streaming: streamStats,
     },
   ];
@@ -104,12 +104,12 @@ test("a fast probe is ranked on accuracy but never reports a latency", () => {
   // table headed "Streaming (real-time feed)" with nothing marking them.
   const table = renderStreamingTable([
     {
-      name: "probe", available: true, meanWerPct: 5, warmMs: 900, coldMs: 900, rtf: 0.1,
+      name: "probe", kind: "stream", available: true, meanWerPct: 5, warmMs: 900, coldMs: 900, rtf: 0.1,
       errors: 0, clips: 2,
       streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: NaN, deltas: 3, paced: false },
     },
     {
-      name: "real", available: true, meanWerPct: 9, warmMs: 5_000, coldMs: 5_000, rtf: 1,
+      name: "real", kind: "stream", available: true, meanWerPct: 9, warmMs: 5_000, coldMs: 5_000, rtf: 1,
       errors: 0, clips: 2, streaming: streamStats,
     },
   ]);
@@ -125,4 +125,24 @@ test("a fast probe is ranked on accuracy but never reports a latency", () => {
   // The genuinely paced row still reports its numbers.
   expect(rows[1]).toContain("120");
   expect(rows[1]).toContain("4 / 6");
+});
+
+test("an unreachable streaming server is skipped under Streaming, not Batch", () => {
+  // A candidate that never started has no metrics, so a renderer that decides
+  // where a row belongs by looking for streaming stats put an unreachable
+  // audio.cpp under "Batch (whole-clip transcribe)" — the one heading it can
+  // never belong to.
+  const rows = [
+    { name: "closed stream", kind: "stream" as const, available: false, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 },
+    { name: "missing binary", kind: "batch" as const, available: false, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN, errors: 0, clips: 0 },
+  ];
+  const batch = renderTable(rows);
+  expect(batch).toContain("- missing binary (unavailable");
+  expect(batch).not.toContain("closed stream");
+
+  const streaming = renderStreamingTable(rows);
+  expect(streaming).toContain("- closed stream (unavailable");
+  expect(streaming).not.toContain("missing binary");
+  // The streaming table has to appear at all for that line to be readable.
+  expect(streaming).toContain("Streaming (real-time feed");
 });

--- a/tests/bench/stt-bench-report.test.ts
+++ b/tests/bench/stt-bench-report.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { median, renderTable, renderStreamingTable } from "../../bench/stt-bench";
 
 const streamStats = { firstDeltaMs: 120, finalAfterAudioMs: 300, deltasDuringAudio: 4, deltas: 6 };
@@ -74,4 +77,21 @@ test("batch and streaming candidates stay in their own tables", () => {
   expect(renderTable(rows)).not.toContain("| stream |");
   expect(renderStreamingTable(rows)).toContain("| stream |");
   expect(renderStreamingTable(rows)).not.toContain("| batch |");
+});
+
+test("writing a report creates the archive directory it needs", async () => {
+  // A RUNTIME-ASSUMPTION guard, not a bug fix. `bench/stt/results/` is
+  // gitignored and absent from a fresh checkout, and main() archives there
+  // without an explicit mkdir because Bun.write creates missing parents
+  // (verified on the pinned Bun 1.3.14 by running the real entry point in a
+  // fresh clone). If that ever changes, this fails here instead of the first
+  // time somebody benchmarks a new checkout.
+  const root = mkdtempSync(join(tmpdir(), "cicero-bench-report-"));
+  try {
+    const archivePath = join(root, "bench", "stt", "results", "2026-01-01T00-00-00-000Z.md");
+    await Bun.write(archivePath, "report");
+    expect(Bun.file(archivePath).size).toBeGreaterThan(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/tests/bench/stt-bench-report.test.ts
+++ b/tests/bench/stt-bench-report.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { median, renderTable, renderStreamingTable } from "../../bench/stt-bench";
 
-const streamStats = { firstDeltaMs: 120, finalAfterAudioMs: 300, deltasDuringAudio: 4, deltas: 6 };
+const streamStats = { firstDeltaMs: 120, finalAfterAudioMs: 300, deltasDuringAudio: 4, deltas: 6, paced: true };
 
 test("median reports no samples as n/a rather than zero", () => {
   // Every caller feeds this into a latency column. Returning 0 for "we never
@@ -39,7 +39,7 @@ test("a streaming candidate whose every clip failed is reported, not ranked firs
   const table = renderStreamingTable([
     {
       name: "broken-stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
-      errors: 2, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0 },
+      errors: 2, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0, paced: true },
     },
     {
       name: "working-stream", available: true, meanWerPct: 8, warmMs: 5_000, coldMs: 5_000, rtf: 1,
@@ -58,7 +58,7 @@ test("an all-failed streaming candidate is still reported when nothing succeeded
   const table = renderStreamingTable([
     {
       name: "broken-stream", available: true, meanWerPct: NaN, warmMs: NaN, coldMs: NaN, rtf: NaN,
-      errors: 1, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0 },
+      errors: 1, clips: 0, streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: 0, deltas: 0, paced: true },
     },
   ]);
   expect(table).toContain("broken-stream");
@@ -94,4 +94,35 @@ test("writing a report creates the archive directory it needs", async () => {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("a fast probe is ranked on accuracy but never reports a latency", () => {
+  // pace:"fast" uploads the whole clip as quickly as the socket takes it, so
+  // "before the audio ended" is measured against an instant that never
+  // happened — a 10s clip answered at 100ms records -9,900ms time-to-final and
+  // counts every delta as arriving during audio. Those numbers went into a
+  // table headed "Streaming (real-time feed)" with nothing marking them.
+  const table = renderStreamingTable([
+    {
+      name: "probe", available: true, meanWerPct: 5, warmMs: 900, coldMs: 900, rtf: 0.1,
+      errors: 0, clips: 2,
+      streaming: { firstDeltaMs: NaN, finalAfterAudioMs: NaN, deltasDuringAudio: NaN, deltas: 3, paced: false },
+    },
+    {
+      name: "real", available: true, meanWerPct: 9, warmMs: 5_000, coldMs: 5_000, rtf: 1,
+      errors: 0, clips: 2, streaming: streamStats,
+    },
+  ]);
+  const rows = table.split("\n").filter((l) => l.startsWith("| ") && !l.startsWith("| Candidate"));
+  expect(rows).toHaveLength(2);
+  // Ranked on WER like any other row — accuracy does not depend on pacing.
+  expect(rows[0]).toContain("probe (fast probe)");
+  expect(rows[1]).toContain("real");
+  // ...but every latency column on that row is withheld, not printed.
+  expect(rows[0]).not.toContain("-9900");
+  expect(rows[0]!.match(/n\/a/g) ?? []).toHaveLength(3);
+  expect(table).toContain("Re-run it without");
+  // The genuinely paced row still reports its numbers.
+  expect(rows[1]).toContain("120");
+  expect(rows[1]).toContain("4 / 6");
 });

--- a/tests/bench/stt-bench-runs.test.ts
+++ b/tests/bench/stt-bench-runs.test.ts
@@ -104,3 +104,36 @@ test("a clip whose every run succeeds is scored", async () => {
     rmSync(wav.dir, { recursive: true, force: true });
   }
 }, 15_000);
+
+test("a fast probe reports no streaming latency at all", async () => {
+  const wav = writeWavFixture(0.08, 8_000);
+  const server = listenPerConnection([goodResponse]);
+  const clip: Clip = { name: "clip1", path: wav.path, reference: "hello world", durationSec: 0.08 };
+  try {
+    const row = await benchStreamCandidate({ ...candidate(server.port), pace: "fast" }, [clip], 1);
+    expect(row.clips).toBe(1);
+    expect(row.meanWerPct).toBe(0); // accuracy is still a real measurement
+    expect(row.streaming?.paced).toBe(false);
+    expect(row.streaming?.firstDeltaMs).toBeNaN();
+    expect(row.streaming?.finalAfterAudioMs).toBeNaN();
+    expect(row.streaming?.deltasDuringAudio).toBeNaN();
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("a real-time candidate still reports its streaming latency", async () => {
+  // The other side: withholding must be tied to pace, not applied everywhere.
+  const wav = writeWavFixture(0.08, 8_000);
+  const server = listenPerConnection([goodResponse]);
+  const clip: Clip = { name: "clip1", path: wav.path, reference: "hello world", durationSec: 0.08 };
+  try {
+    const row = await benchStreamCandidate(candidate(server.port), [clip], 1);
+    expect(row.streaming?.paced).toBe(true);
+    expect(Number.isNaN(row.streaming!.finalAfterAudioMs)).toBe(false);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);

--- a/tests/bench/stt-bench-runs.test.ts
+++ b/tests/bench/stt-bench-runs.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { benchStreamCandidate } from "../../bench/stt-bench";
+import type { Clip, StreamCandidate } from "../../bench/stt/types";
+import { writeWavFixture } from "../helpers/wav";
+
+const encoder = new TextEncoder();
+
+function writeChunk(socket: Bun.Socket, text: string): void {
+  const bytes = encoder.encode(text);
+  socket.write(`${bytes.byteLength.toString(16)}\r\n`);
+  socket.write(bytes);
+  socket.write("\r\n");
+}
+
+/**
+ * A listener that answers each connection differently, so a candidate can be
+ * driven through a run that succeeds and a run that does not.
+ */
+function listenPerConnection(
+  responders: Array<(socket: Bun.Socket) => void>,
+): Bun.TCPSocketListener<{ request: string; done: boolean }> {
+  // Indexed by completed REQUEST, not by connection: benchStreamCandidate opens
+  // and drops a liveness-probe connection first, which would otherwise shift
+  // every responder by one and silently test a different scenario.
+  let requests = 0;
+  return Bun.listen<{ request: string; done: boolean }>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.data = { request: "", done: false };
+      },
+      data(socket, data) {
+        socket.data.request += data.toString("latin1");
+        if (socket.data.done || !socket.data.request.includes("0\r\n\r\n")) return;
+        socket.data.done = true;
+        const responder = responders[Math.min(requests++, responders.length - 1)];
+        responder?.(socket);
+      },
+    },
+  });
+}
+
+function goodResponse(socket: Bun.Socket): void {
+  socket.write(
+    "HTTP/1.1 200 OK\r\n" +
+    "Content-Type: text/event-stream\r\n" +
+    "Transfer-Encoding: chunked\r\n\r\n",
+  );
+  writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello world"}\n\n');
+  socket.write("0\r\n\r\n");
+  socket.end();
+}
+
+function truncatedResponse(socket: Bun.Socket): void {
+  socket.write(
+    "HTTP/1.1 200 OK\r\n" +
+    "Content-Type: text/event-stream\r\n" +
+    "Transfer-Encoding: chunked\r\n\r\n",
+  );
+  socket.terminate();
+}
+
+function candidate(port: number): StreamCandidate {
+  return { name: "flaky", kind: "stream", model: "test-model", port, host: "127.0.0.1", chunkMs: 50 };
+}
+
+test("a clip whose later run fails is an error, not a one-sample measurement", async () => {
+  // The first run populated `transcript`, so a clip that then failed run 2 was
+  // scored anyway: WER from one run, latency medians over one sample, and
+  // errors=0 for a clip that demonstrably errored. The bench is a measurement
+  // tool — a partially measured clip must not be reported as a clean one.
+  const wav = writeWavFixture(0.08, 8_000);
+  const server = listenPerConnection([goodResponse, truncatedResponse]);
+  const clip: Clip = { name: "clip1", path: wav.path, reference: "hello world", durationSec: 0.08 };
+  try {
+    const row = await benchStreamCandidate(candidate(server.port), [clip], 2);
+    expect(row.available).toBe(true);
+    expect(row.clips).toBe(0);
+    expect(row.errors).toBe(1);
+    // No fabricated metrics for a clip that never completed.
+    expect(row.meanWerPct).toBeNaN();
+    expect(row.streaming?.finalAfterAudioMs).toBeNaN();
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("a clip whose every run succeeds is scored", async () => {
+  // The positive side of that boundary: the strict rule must not reject a clip
+  // that actually completed all of its runs.
+  const wav = writeWavFixture(0.08, 8_000);
+  const server = listenPerConnection([goodResponse]);
+  const clip: Clip = { name: "clip1", path: wav.path, reference: "hello world", durationSec: 0.08 };
+  try {
+    const row = await benchStreamCandidate(candidate(server.port), [clip], 2);
+    expect(row.clips).toBe(1);
+    expect(row.errors).toBe(0);
+    expect(row.meanWerPct).toBe(0);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);

--- a/tests/bench/stt-bench-runs.test.ts
+++ b/tests/bench/stt-bench-runs.test.ts
@@ -103,6 +103,22 @@ function deltaResponse(socket: Bun.Socket): void {
   }, 10);
 }
 
+function finalOnlyResponse(socket: Bun.Socket): void {
+  // Answers on the same schedule as deltaResponse but sends no partials, and
+  // leaves the socket to the harness so the client can finish uploading. A
+  // responder that hangs up as soon as it has answered fails the run instead
+  // of measuring it, which is a different scenario entirely.
+  setTimeout(() => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello brave world"}\n\n');
+    socket.write("0\r\n\r\n");
+  }, 10);
+}
+
 function candidate(port: number): StreamCandidate {
   return { name: "flaky", kind: "stream", model: "test-model", port, host: "127.0.0.1", chunkMs: 50 };
 }
@@ -165,6 +181,27 @@ test("a fully measured clip reports its first run delta counts", async () => {
     expect(row.errors).toBe(0);
     expect(row.streaming?.deltas).toBe(3);
     expect(row.streaming?.deltasDuringAudio).toBe(3);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("first-delta latency is withheld when any repetition has no partial", async () => {
+  const wav = writeWavFixture(0.2, 8_000);
+  const server = listenPerConnection([deltaResponse, finalOnlyResponse], true);
+  const clip: Clip = {
+    name: "clip1",
+    path: wav.path,
+    reference: "hello brave world",
+    durationSec: 0.2,
+  };
+  try {
+    // Both runs succeed — this is about a measured absence, not a failure.
+    const row = await benchStreamCandidate(candidate(server.port), [clip], 2);
+    expect(row.clips).toBe(1);
+    expect(row.errors).toBe(0);
+    expect(row.streaming?.firstDeltaMs).toBeNaN();
   } finally {
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });

--- a/tests/bench/stt-bench-runs.test.ts
+++ b/tests/bench/stt-bench-runs.test.ts
@@ -19,10 +19,11 @@ function writeChunk(socket: Bun.Socket, text: string): void {
  */
 function listenPerConnection(
   responders: Array<(socket: Bun.Socket) => void>,
+  respondAfterHeaders = false,
 ): Bun.TCPSocketListener<{ request: string; done: boolean }> {
-  // Indexed by completed REQUEST, not by connection: benchStreamCandidate opens
-  // and drops a liveness-probe connection first, which would otherwise shift
-  // every responder by one and silently test a different scenario.
+  // Indexed by HTTP requests, not connections: benchStreamCandidate opens and
+  // drops a liveness-probe connection first, which would otherwise shift every
+  // responder by one and silently test a different scenario.
   let requests = 0;
   return Bun.listen<{ request: string; done: boolean }>({
     hostname: "127.0.0.1",
@@ -33,10 +34,19 @@ function listenPerConnection(
       },
       data(socket, data) {
         socket.data.request += data.toString("latin1");
-        if (socket.data.done || !socket.data.request.includes("0\r\n\r\n")) return;
+        const requestComplete = socket.data.request.includes("0\r\n\r\n");
+        if (socket.data.done) {
+          if (respondAfterHeaders && requestComplete) socket.end();
+          return;
+        }
+        const responseReady = respondAfterHeaders
+          ? socket.data.request.includes("\r\n\r\n")
+          : requestComplete;
+        if (!responseReady) return;
         socket.data.done = true;
         const responder = responders[Math.min(requests++, responders.length - 1)];
         responder?.(socket);
+        if (respondAfterHeaders && requestComplete) socket.end();
       },
     },
   });
@@ -62,6 +72,24 @@ function truncatedResponse(socket: Bun.Socket): void {
   socket.terminate();
 }
 
+function deltaResponse(socket: Bun.Socket): void {
+  // Sending partials while the paced request is still uploading makes the
+  // during-audio counter non-zero, so the rejection regression covers both
+  // candidate-wide delta totals rather than only the total event count.
+  setTimeout(() => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello "}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"brave "}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"world"}\n\n');
+    writeChunk(socket, 'data: {"type":"transcript.text.done","text":"hello brave world"}\n\n');
+    socket.write("0\r\n\r\n");
+  }, 10);
+}
+
 function candidate(port: number): StreamCandidate {
   return { name: "flaky", kind: "stream", model: "test-model", port, host: "127.0.0.1", chunkMs: 50 };
 }
@@ -82,6 +110,48 @@ test("a clip whose later run fails is an error, not a one-sample measurement", a
     // No fabricated metrics for a clip that never completed.
     expect(row.meanWerPct).toBeNaN();
     expect(row.streaming?.finalAfterAudioMs).toBeNaN();
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("a rejected clip does not leak its first run delta counts", async () => {
+  const wav = writeWavFixture(0.2, 8_000);
+  const server = listenPerConnection([deltaResponse, truncatedResponse], true);
+  const clip: Clip = {
+    name: "clip1",
+    path: wav.path,
+    reference: "hello brave world",
+    durationSec: 0.2,
+  };
+  try {
+    const row = await benchStreamCandidate(candidate(server.port), [clip], 2);
+    expect(row.clips).toBe(0);
+    expect(row.errors).toBe(1);
+    expect(row.streaming?.deltas).toBe(0);
+    expect(row.streaming?.deltasDuringAudio).toBe(0);
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("a fully measured clip reports its first run delta counts", async () => {
+  const wav = writeWavFixture(0.2, 8_000);
+  const server = listenPerConnection([deltaResponse], true);
+  const clip: Clip = {
+    name: "clip1",
+    path: wav.path,
+    reference: "hello brave world",
+    durationSec: 0.2,
+  };
+  try {
+    const row = await benchStreamCandidate(candidate(server.port), [clip], 2);
+    expect(row.clips).toBe(1);
+    expect(row.errors).toBe(0);
+    expect(row.streaming?.deltas).toBe(3);
+    expect(row.streaming?.deltasDuringAudio).toBe(3);
   } finally {
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });

--- a/tests/bench/stt-bench-runs.test.ts
+++ b/tests/bench/stt-bench-runs.test.ts
@@ -137,3 +137,16 @@ test("a real-time candidate still reports its streaming latency", async () => {
     rmSync(wav.dir, { recursive: true, force: true });
   }
 }, 15_000);
+
+test("an unreachable streaming candidate is still identified as streaming", async () => {
+  // Straight through the real aggregation path: the probe fails, and the row it
+  // returns must still know which table it belongs in.
+  const clip: Clip = { name: "clip1", path: "/nonexistent.wav", reference: "hello", durationSec: 1 };
+  const row = await benchStreamCandidate(
+    { name: "closed stream", kind: "stream", model: "test-model", host: "127.0.0.1", port: 1 },
+    [clip],
+    1,
+  );
+  expect(row.available).toBe(false);
+  expect(row.kind).toBe("stream");
+}, 15_000);

--- a/tests/bench/stt-bench-runs.test.ts
+++ b/tests/bench/stt-bench-runs.test.ts
@@ -72,6 +72,17 @@ function truncatedResponse(socket: Bun.Socket): void {
   socket.terminate();
 }
 
+function deltaOnlyResponse(socket: Bun.Socket): void {
+  socket.write(
+    "HTTP/1.1 200 OK\r\n" +
+    "Content-Type: text/event-stream\r\n" +
+    "Transfer-Encoding: chunked\r\n\r\n",
+  );
+  writeChunk(socket, 'data: {"type":"transcript.text.delta","delta":"hello world"}\n\n');
+  socket.write("0\r\n\r\n");
+  socket.end();
+}
+
 function errorResponse(message: string): (socket: Bun.Socket) => void {
   return (socket) => {
     socket.write(
@@ -137,6 +148,26 @@ test("a clip whose later run fails is an error, not a one-sample measurement", a
     expect(row.clips).toBe(0);
     expect(row.errors).toBe(1);
     // No fabricated metrics for a clip that never completed.
+    expect(row.meanWerPct).toBeNaN();
+    expect(row.streaming?.finalAfterAudioMs).toBeNaN();
+  } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("a clip whose run omits the terminal event is an error and is not scored", async () => {
+  // Clean HTTP framing does not complete the documented event sequence. If the
+  // last delta were scored, the non-conforming server would be ranked using a
+  // finish timestamp necessarily earlier than the terminal event it omitted.
+  const wav = writeWavFixture(0.08, 8_000);
+  const server = listenPerConnection([deltaOnlyResponse]);
+  const clip: Clip = { name: "clip1", path: wav.path, reference: "hello world", durationSec: 0.08 };
+  try {
+    const row = await benchStreamCandidate(candidate(server.port), [clip], 1);
+    expect(row.available).toBe(true);
+    expect(row.clips).toBe(0);
+    expect(row.errors).toBe(1);
     expect(row.meanWerPct).toBeNaN();
     expect(row.streaming?.finalAfterAudioMs).toBeNaN();
   } finally {

--- a/tests/bench/stt-bench-runs.test.ts
+++ b/tests/bench/stt-bench-runs.test.ts
@@ -72,6 +72,19 @@ function truncatedResponse(socket: Bun.Socket): void {
   socket.terminate();
 }
 
+function errorResponse(message: string): (socket: Bun.Socket) => void {
+  return (socket) => {
+    socket.write(
+      "HTTP/1.1 200 OK\r\n" +
+      "Content-Type: text/event-stream\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n",
+    );
+    writeChunk(socket, `data: ${JSON.stringify({ error: { message } })}\n\n`);
+    socket.write("0\r\n\r\n");
+    socket.end();
+  };
+}
+
 function deltaResponse(socket: Bun.Socket): void {
   // Sending partials while the paced request is still uploading makes the
   // during-audio counter non-zero, so the rejection regression covers both
@@ -203,6 +216,41 @@ test("a real-time candidate still reports its streaming latency", async () => {
     expect(row.streaming?.paced).toBe(true);
     expect(Number.isNaN(row.streaming!.finalAfterAudioMs)).toBe(false);
   } finally {
+    server.stop(true);
+    rmSync(wav.dir, { recursive: true, force: true });
+  }
+}, 15_000);
+
+test("remote SSE errors are terminal-safe without mangling ordinary messages", async () => {
+  // The transcription server is untrusted input (AGENTS.md), and its error text
+  // went straight into console.warn: an escaped ESC ]52 sequence in error.message
+  // survived JSON.parse as a real OSC 52 clipboard write on the operator's
+  // terminal, and an escaped newline let the server forge benchmark output
+  // lines. The ordinary message here is the other half — a sanitizer that
+  // mangles readable text would make the bench worse, not safer.
+  const wav = writeWavFixture(0.08, 8_000);
+  const malicious = `remote \u001b]52;c;Y2xpcGJvYXJk\u0007 forged\nline`;
+  const ordinary = "model rejected the requested language";
+  const server = listenPerConnection([errorResponse(malicious), errorResponse(ordinary)]);
+  const clips: Clip[] = [
+    { name: "hostile", path: wav.path, reference: "hello", durationSec: 0.08 },
+    { name: "ordinary", path: wav.path, reference: "hello", durationSec: 0.08 },
+  ];
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+  try {
+    const row = await benchStreamCandidate(candidate(server.port), clips, 1);
+    expect(row.errors).toBe(2);
+    expect(warnings).toHaveLength(2);
+
+    const hostileCodes = Array.from(warnings[0]!, (ch) => ch.codePointAt(0)!);
+    expect(hostileCodes).not.toContain(0x1b);
+    expect(hostileCodes).not.toContain(0x07);
+    expect(hostileCodes).not.toContain(0x0a);
+    expect(warnings[1]).toBe(`  ⚠️  flaky / ordinary: ${ordinary}`);
+  } finally {
+    console.warn = warn;
     server.stop(true);
     rmSync(wav.dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Why

`bench/stt/README.md` has carried this line since the harness was written:

> ❌ **Streaming time-to-final** — this is a *batch* bench (whole-clip transcribe).

It was true because there was no way to feed audio.cpp incrementally over HTTP — the CLI could (`audiocpp_cli --audio -`), the server could not. [audio.cpp PR #144](https://github.com/audio-cpp/audio.cpp/pull/144) adds `POST /v1/audio/transcriptions/live`, so the axis is now measurable.

## What

A third candidate kind, `stream`:

```json
{ "name": "audiocpp nemotron (streaming)", "kind": "stream", "model": "nemotron", "port": 8093 }
```

PCM is fed up a chunked request body at the clip's own real-time pace while SSE deltas are timed coming back. It reports time to first partial, **how many partials landed while the audio was still uploading**, and time-to-final relative to the end of the audio.

Real-time pacing is the point: a model can't be credited with a partial it only produced because the whole file arrived at once.

`bench/stt/live-stream.ts` uses a raw socket rather than `fetch` deliberately. This is a full-duplex exchange, and `fetch` request streaming is half-duplex *by specification* — the response is withheld until the request body ends, which would collapse the exact measurement. It de-frames the chunked SSE response itself.

## Results (13 clips, nemotron, isolated GPU seat, 1 run)

| Candidate | WER % | first delta ms | deltas during audio | final after audio ms |
|---|---:|---:|---:|---:|
| audiocpp nemotron (batch) | 3.8 | — | — | — |
| audiocpp nemotron (streaming) | 3.8 | 6245 | **0 / 506** | 267 |

- **Identical WER on both paths** — the streaming transport does not change the transcript, and 3.8% reproduces the 2026-07-21 sweep exactly, which is a decent check on the whole rig.
- **Zero of 506 deltas arrived during capture.** Median first delta (6.2 s) is past the median clip length. Nemotron buffers internally, so over this endpoint streaming buys the ~267 ms emission tail, not live partials.

That last point is a property of the **model**, not the endpoint — voxtral on the same endpoint emits 63/63 deltas during audio. The table prints `n/a` for first delta when a model emitted nothing, rather than a `0` that would read as "instant" in a latency column.

Streaming rows get their own table. A real-time feed spends at least the clip duration by construction, so putting its wall-clock next to a batch latency would invite a comparison that means nothing.

## Two fixes carried along

- **`candidates.example.json` was not valid JSON.** The template entries were object members (`"_kyutai": { ... }`) sitting inside an array, so following the README's "copy it to `candidates.json` and edit" crashed the bench on `JSON.parse` before it did anything. Templates moved under a `_templates` object; only `candidates` is read.
- **Every run now also writes a stamped copy to `bench/stt/results/`** (git-ignored). `last-results.md` is overwritten on every run, so a one-candidate re-run erased a full sweep — which is exactly what happened while developing this.

## Cost

A real-time `stream` run takes at least the total clip duration per run: 75 s of clips × 3 runs ≈ 4 minutes per candidate before the model does any work. `"pace": "fast"` skips the throttle for a does-it-respond check, and the README says plainly that those timings are not streaming latencies.

## Testing

- `bun x tsc --noEmit` clean.
- Full sweep run end to end against an isolated audio.cpp server on :8093 (never the live :8092 seat), batch and streaming candidates side by side — that's the table above.
- `bun test`: 2044 pass / 3 fail, and the 3 failures reproduce identically with these changes stashed (`tests/terminal-send-errors.test.ts` and friends — environmental, nothing here is imported by `src/`).