### PR TITLE
Bound flaky test waits by wall clock instead of by luck

### DIFF
--- a/tests/backends/tts/audiocpp.test.ts
+++ b/tests/backends/tts/audiocpp.test.ts
@@ -477,4 +477,7 @@ test("keeps the exact voice_ref leased until audio.cpp finishes the request", as
     finishRequest();
   }
   await generation;
-});
+  // The 65 eviction-pressure cycles above are real write + hash + copy work, which
+  // outruns Bun's 5s default on a loaded CI runner. Explicit budget so a true hang
+  // still fails rather than hanging.
+}, 30_000);

--- a/tests/notify/briefing-scheduler.test.ts
+++ b/tests/notify/briefing-scheduler.test.ts
@@ -23,12 +23,16 @@ function local(hours: number, minutes: number, day = 15): Date {
   return new Date(2026, 6, day, hours, minutes, 5);
 }
 
-async function waitFor(condition: () => boolean): Promise<void> {
-  for (let i = 0; i < 100; i++) {
-    if (condition()) return;
-    await Bun.sleep(1);
+// Bounded by wall-clock, not by iteration count: 100 rounds of Bun.sleep(1) is a
+// ~100ms budget, which a loaded CI runner exhausts while the awaited work is still
+// making progress. Same shape as kanban-watch.test.ts. A satisfied condition still
+// returns immediately, so the longer ceiling only costs time on a real failure.
+async function waitFor(condition: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) throw new Error("condition was not reached before timeout");
+    await Bun.sleep(5);
   }
-  throw new Error("condition was not reached");
 }
 
 function scheduler(options: {

--- a/tests/notify/telegram.test.ts
+++ b/tests/notify/telegram.test.ts
@@ -42,12 +42,15 @@ function shellQuote(value: string): string {
 type JsonObject = Record<string, unknown>;
 type CapturedCall = { path: string; body: JsonObject };
 
-async function waitFor(condition: () => boolean): Promise<void> {
-  for (let i = 0; i < 100; i++) {
-    if (condition()) return;
-    await Bun.sleep(1);
+// Wall-clock bound rather than 100 iterations of Bun.sleep(1): that is only a
+// ~100ms budget, and a contended CI runner blows through it while the awaited work
+// is still progressing. Matches kanban-watch.test.ts.
+async function waitFor(condition: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) throw new Error("condition was not reached before timeout");
+    await Bun.sleep(5);
   }
-  throw new Error("condition was not reached");
 }
 
 function jsonObject(value: unknown): JsonObject {

--- a/tests/voice-audio-reference.test.ts
+++ b/tests/voice-audio-reference.test.ts
@@ -330,4 +330,7 @@ test("the process-owned lease cache evicts beyond its exact count bound", async 
   expect(processLeaseDirectories).toHaveLength(1);
   expect(readdirSync(join(root, "leases", processLeaseDirectories[0]!)))
     .toHaveLength(64);
-});
+  // Crossing the count bound costs 65 write + hash + copy cycles, which is real
+  // disk work: fast locally, but past Bun's 5s default on a contended CI runner.
+  // The budget is explicit so a genuine hang still fails instead of hanging.
+}, 30_000);


### PR DESCRIPTION
## What

Four tests fail intermittently in CI while passing locally. Between them they have already turned `main` red, failed an unrelated PR's checks, and blocked a docs-only PR from being reviewed at all — so this is merge-gate noise, not tidying.

No production code changes. No assertion changes. Only how long each test is willing to wait.

## Two causes, both readable straight off the failure timings

**1. Iteration-count polls (`tests/notify/briefing-scheduler.test.ts`, `tests/notify/telegram.test.ts`).**

```ts
for (let i = 0; i < 100; i++) { if (condition()) return; await Bun.sleep(1); }
```

That is a ~100ms total budget. The observed failure — `shutdown abort prevents late completion and drains the owned run` — took **108.72ms**, i.e. the budget plus overhead: the awaited work was still making progress when the poll gave up. Both now bound by an absolute deadline, which is the shape `tests/notify/kanban-watch.test.ts` already uses in this same directory. A satisfied condition still returns immediately, so the wider ceiling only costs time on a real failure.

**2. Bun's 5s per-test default on genuinely disk-bound tests** (`tests/voice-audio-reference.test.ts`, `tests/backends/tts/audiocpp.test.ts`).

Both cross a 64-entry lease bound by running 65 write + hash + copy cycles. They died at **5001.83ms** and **5052.43ms** — the 5s default, to the millisecond. Both get an explicit `30_000` budget, the convention `tests/voice-cli.test.ts:93` already uses, so a real hang still fails rather than hanging forever.

## Evidence this is flakiness and not a regression

| test | evidence |
|---|---|
| `shutdown abort prevents late completion…` | failed CI on #60, a **markdown-only** PR; passes locally |
| `multiple ticks while a delivery is in flight…`, `restart with today's persisted claim…` | failed CI on #57, whose diff is a shell script + a doc + one test |
| `keeps the exact voice_ref leased…`, `…lease cache evicts beyond its exact count bound` | same #57 run; **re-running the identical tree passed** |

## Verification

`bun run typecheck` and `git diff --check` clean. `bun test` 2050 pass / 2 fail, both failures (`tests/terminal-send-errors.test.ts`, `tests/cli/status.test.ts`) reproducing identically on unmodified `origin/main` and unrelated to this diff. The four touched files pass together (91 tests), including under 8-way CPU contention.

**Stated honestly: I could not reproduce the flake locally.** Synthetic CPU load on this machine was not enough to blow the old 100ms budget, so the diagnosis rests on the timing signatures above and the code shape, not on a local red-to-green demonstration. The change is safe regardless of whether that reading is exactly right: widening a wait cannot make a passing test fail, and the assertions are untouched.
