### PR TITLE
fix(test): stop a status test from reading the operator's real pairing file

### DIFF
--- a/tests/cli/status.test.ts
+++ b/tests/cli/status.test.ts
@@ -157,6 +157,11 @@ describe("configured CLI status", () => {
     const lines = await collectStatus(config, {
       platform: "darwin",
       inspectDaemon: () => Promise.resolve({ kind: "absent" }),
+      // Every other test in this file stubs this. Left out, the default reads
+      // the real ~/.cicero/web-voice/pairing.json, so this test passes on a
+      // clean checkout and fails on any machine that actually runs Cicero --
+      // an extra "Phone pairing" line the expectation below does not list.
+      readPairingState: () => null,
       probe: (request) => {
         requests.push(request);
         return Promise.resolve(true);


### PR DESCRIPTION
`collectStatus` defaults `pairingStateFile` to `~/.cicero/web-voice/pairing.json`. Every other test in `tests/cli/status.test.ts` stubs `readPairingState`; this one did not.

So on a machine that actually runs Cicero, the collected status gained a "Phone pairing" line the expectation does not list, and the test failed:

```
- Expected  - 0
+ Received  + 1
    "Daemon",
+   "Phone pairing",
    "STT",
```

It passes on a clean checkout and on CI — which is exactly why it survived. It fails only for someone running the daemon on the same box they run the suite on, i.e. the developer most likely to be running it.

One line, using the seam the surrounding tests already use.

**Verification:** `bun run typecheck` clean, `git diff --check` clean, and the full suite is **2358 pass / 6 skip / 0 fail** on a box with a live Cicero install — previously 1 fail. On a clean checkout the behavior is unchanged.

Opened ready rather than draft so the merge-brief cron can pick it up; drafts are invisible to it.