### PR TITLE
fix(process): stop reading a vanished Windows PID as a failed tree kill

### DIFF
--- a/src/brain/subprocess-cli.ts
+++ b/src/brain/subprocess-cli.ts
@@ -202,6 +202,33 @@ export class SubprocessCLIBrain implements Brain {
   /** Called after a turn's subprocess exits 0 — hook for session tracking. */
   protected onTurnComplete(): void {}
 
+  private terminateTurnProcess(proc: TurnProcess): Promise<void> {
+    return terminateTurn(proc);
+  }
+
+  private async awaitCancellation(
+    proc: TurnProcess,
+    cancellation: Promise<void>,
+    signal: AbortSignal | undefined,
+    reporting: { failureLogged: boolean },
+  ): Promise<void> {
+    try {
+      await cancellation;
+    } catch (error: unknown) {
+      if (!signal?.aborted) throw error;
+      // The caller's abort reason owns the rejection, but an unconfirmed release
+      // remains an operator-visible fail-closed condition.
+      if (!reporting.failureLogged) {
+        reporting.failureLogged = true;
+        log(
+          "error",
+          `Brain (${this.config.name}) abort cleanup failed for turn process ${proc.pid}: `
+          + `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
   private resolvedBinary(env: Record<string, string | undefined>): string {
     return resolveCommandBinary(this.config.binary, env);
   }
@@ -251,8 +278,9 @@ export class SubprocessCLIBrain implements Brain {
       options.signal?.throwIfAborted();
       const proc = this.spawnProc(message, options);
       let cancellation: Promise<void> | null = null;
+      const cancellationReporting = { failureLogged: false };
       const cancel = () => {
-        cancellation ??= terminateTurn(proc);
+        cancellation ??= this.terminateTurnProcess(proc);
         void cancellation.catch(() => {});
       };
       options.signal?.addEventListener("abort", cancel, { once: true });
@@ -284,8 +312,16 @@ export class SubprocessCLIBrain implements Brain {
           readPipe(proc.stderr as ReadableStream<Uint8Array>),
           ownedExit,
         ]);
-        if (cancellation) await cancellation;
+        if (cancellation) await this.awaitCancellation(proc, cancellation, options.signal, cancellationReporting);
         if (pipeFailure && !options.signal?.aborted) throw pipeError;
+      } catch (error: unknown) {
+        if (options.signal?.aborted) {
+          if (cancellation) {
+            await this.awaitCancellation(proc, cancellation, options.signal, cancellationReporting);
+          }
+          options.signal.throwIfAborted();
+        }
+        throw error;
       } finally {
         options.signal?.removeEventListener("abort", cancel);
       }
@@ -312,8 +348,9 @@ export class SubprocessCLIBrain implements Brain {
     let completed = false;
     let streamError: unknown;
     let cancellation: Promise<void> | null = null;
+    const cancellationReporting = { failureLogged: false };
     const cancel = () => {
-      cancellation ??= terminateTurn(proc);
+      cancellation ??= this.terminateTurnProcess(proc);
       void cancellation.catch(() => {});
     };
     const stderrPromise = new Response(proc.stderr).text();
@@ -336,8 +373,20 @@ export class SubprocessCLIBrain implements Brain {
     } finally {
       if (!completed || options.signal?.aborted) cancel();
       try {
-        if (cancellation) await cancellation;
-        [exitCode, stderr] = await Promise.all([ownedExit, stderrPromise]);
+        try {
+          if (cancellation) {
+            await this.awaitCancellation(proc, cancellation, options.signal, cancellationReporting);
+          }
+          [exitCode, stderr] = await Promise.all([ownedExit, stderrPromise]);
+        } catch (error: unknown) {
+          if (options.signal?.aborted) {
+            if (cancellation) {
+              await this.awaitCancellation(proc, cancellation, options.signal, cancellationReporting);
+            }
+            options.signal.throwIfAborted();
+          }
+          throw error;
+        }
       } finally {
         options.signal?.removeEventListener("abort", cancel);
       }

--- a/src/process/owned-process.ts
+++ b/src/process/owned-process.ts
@@ -224,14 +224,16 @@ async function terminateWindowsTree(
 ): Promise<void> {
   // Enumerate the tree before killing the root. Once the root disappears,
   // Windows cannot rediscover arbitrary descendants without a Job Object.
-  const graceful = graceMs > 0 ? await runWindowsTaskkill(proc.pid, false) : "failed";
-  if (graceful === "targeted") {
+  const graceful = graceMs > 0
+    ? await runWindowsTaskkill(proc.pid, false)
+    : { outcome: "failed" as const, code: null };
+  if (graceful.outcome === "targeted") {
     const gracefulExit = await processExitWithin(proc.exited, graceMs);
     if (gracefulExit.kind === "exited") return;
   }
 
   const forced = await runWindowsTaskkill(proc.pid, true);
-  if (forced === "failed") {
+  if (forced.outcome === "failed") {
     try { proc.kill("SIGKILL"); } catch { /* already exited */ }
   }
   const finalExit = await processExitWithin(proc.exited, reapTimeoutMs);
@@ -245,8 +247,15 @@ async function terminateWindowsTree(
   if (finalExit.kind === "timeout") {
     throw new OwnedProcessReapError(proc.pid, "leader did not reap after forced tree termination");
   }
-  if (!windowsTreeAccountedFor(graceful, forced)) {
-    throw new OwnedProcessReapError(proc.pid, "Windows tree targeting failed; only the leader was reaped");
+  if (!windowsTreeAccountedFor(graceful.outcome, forced.outcome)) {
+    // Report what taskkill actually said. "Targeting failed" alone gives an
+    // operator holding a possibly-leaked child nothing to act on, and nothing to
+    // tell apart a missing PID from a refused kill.
+    throw new OwnedProcessReapError(
+      proc.pid,
+      "Windows tree targeting failed; only the leader was reaped "
+      + `(graceful taskkill ${describeTaskkill(graceful)}, forced ${describeTaskkill(forced)})`,
+    );
   }
 }
 
@@ -313,7 +322,18 @@ export type WindowsTaskkillOutcome = "targeted" | "absent" | "failed";
 /** taskkill's exit code when no process carries the requested PID. */
 const WINDOWS_TASKKILL_NOT_FOUND = 128;
 
-async function runWindowsTaskkill(pid: number, force: boolean): Promise<WindowsTaskkillOutcome> {
+/** The outcome plus the exit code it was derived from, for diagnostics. */
+export interface WindowsTaskkillResult {
+  outcome: WindowsTaskkillOutcome;
+  /** taskkill's exit code, or null when it could not be run at all. */
+  code: number | null;
+}
+
+function describeTaskkill(result: WindowsTaskkillResult): string {
+  return result.code === null ? `${result.outcome} (not run)` : `${result.outcome} (exit ${result.code})`;
+}
+
+async function runWindowsTaskkill(pid: number, force: boolean): Promise<WindowsTaskkillResult> {
   const args = ["taskkill", "/PID", String(pid), "/T", ...(force ? ["/F"] : [])];
   try {
     const helper = Bun.spawn(args, {
@@ -325,13 +345,13 @@ async function runWindowsTaskkill(pid: number, force: boolean): Promise<WindowsT
       windowsHide: true,
     });
     const code = await helper.exited;
-    if (code === 0) return "targeted";
+    if (code === 0) return { outcome: "targeted", code };
     // Matched on the exit code rather than the message: taskkill's "not found"
     // text is localized, so parsing stderr would silently stop recognizing it
     // on a non-English Windows.
-    return code === WINDOWS_TASKKILL_NOT_FOUND ? "absent" : "failed";
+    return { outcome: code === WINDOWS_TASKKILL_NOT_FOUND ? "absent" : "failed", code };
   } catch {
-    return "failed";
+    return { outcome: "failed", code: null };
   }
 }
 

--- a/src/process/owned-process.ts
+++ b/src/process/owned-process.ts
@@ -233,7 +233,7 @@ async function terminateWindowsTree(
   }
 
   const forced = await runWindowsTaskkill(proc.pid, true);
-  if (forced.outcome === "failed") {
+  if (windowsForcedKillNeeded(forced.outcome)) {
     try { proc.kill("SIGKILL"); } catch { /* already exited */ }
   }
   const finalExit = await processExitWithin(proc.exited, reapTimeoutMs);
@@ -257,6 +257,23 @@ async function terminateWindowsTree(
       + `(graceful taskkill ${describeTaskkill(graceful)}, forced ${describeTaskkill(forced)})`,
     );
   }
+}
+
+/**
+ * Whether the leader still needs a direct SIGKILL after the forced taskkill pass.
+ *
+ * Anything but a pass that reached the tree does, which is what main has always
+ * done — it tested `taskkill`'s exit code for zero, so both a missing PID and a
+ * refused kill fell through to this. Narrowing it to only a refused kill skipped
+ * the call for exit 128, and `proc.kill()` is also what reaps Bun's own child
+ * handle: without it `proc.exited` can stay pending, the bounded observation below
+ * times out, and a caller still reading inherited pipes can be left waiting.
+ *
+ * The accounting verdict is a separate question with a different answer, so it is
+ * a separate function; conflating the two is how the divergence happened.
+ */
+export function windowsForcedKillNeeded(forced: WindowsTaskkillOutcome): boolean {
+  return forced !== "targeted";
 }
 
 /**

--- a/src/process/owned-process.ts
+++ b/src/process/owned-process.ts
@@ -224,14 +224,14 @@ async function terminateWindowsTree(
 ): Promise<void> {
   // Enumerate the tree before killing the root. Once the root disappears,
   // Windows cannot rediscover arbitrary descendants without a Job Object.
-  const gracefulTreeTargeted = graceMs > 0 && await runWindowsTaskkill(proc.pid, false);
-  if (gracefulTreeTargeted) {
+  const graceful = graceMs > 0 ? await runWindowsTaskkill(proc.pid, false) : "failed";
+  if (graceful === "targeted") {
     const gracefulExit = await processExitWithin(proc.exited, graceMs);
     if (gracefulExit.kind === "exited") return;
   }
 
-  const forcedTreeTargeted = await runWindowsTaskkill(proc.pid, true);
-  if (!forcedTreeTargeted) {
+  const forced = await runWindowsTaskkill(proc.pid, true);
+  if (forced === "failed") {
     try { proc.kill("SIGKILL"); } catch { /* already exited */ }
   }
   const finalExit = await processExitWithin(proc.exited, reapTimeoutMs);
@@ -245,9 +245,34 @@ async function terminateWindowsTree(
   if (finalExit.kind === "timeout") {
     throw new OwnedProcessReapError(proc.pid, "leader did not reap after forced tree termination");
   }
-  if (!forcedTreeTargeted) {
+  if (!windowsTreeAccountedFor(graceful, forced)) {
     throw new OwnedProcessReapError(proc.pid, "Windows tree targeting failed; only the leader was reaped");
   }
+}
+
+/**
+ * Whether the tree is accounted for, given how each taskkill pass ended and a
+ * leader already confirmed exited.
+ *
+ * Split out as a pure decision because the surrounding function only runs on
+ * win32 — the platform check is inline — so this is the only part of the Windows
+ * reaper a test on another OS can reach. Real taskkill behavior is covered by
+ * the Windows CI job.
+ */
+export function windowsTreeAccountedFor(
+  graceful: WindowsTaskkillOutcome,
+  forced: WindowsTaskkillOutcome,
+): boolean {
+  if (forced === "targeted") return true;
+  // `absent` means the forced pass found no such PID, which only happens once
+  // the leader is already gone — and a leader that outlives the grace window
+  // exits between that timeout and this call often enough to matter. It is only
+  // conclusive together with a graceful pass that DID reach the tree: that pass
+  // signalled every process then in it, so nothing was left unsignalled. Read as
+  // a targeting failure instead, a completed teardown was reported as an
+  // unconfirmed release, and an ordinary abort surfaced a reap error in place of
+  // the caller's own abort reason.
+  return forced === "absent" && graceful === "targeted";
 }
 
 function signalPosixTree(proc: OwnedProcess, signal: "SIGTERM" | "SIGKILL"): void {
@@ -274,7 +299,21 @@ async function waitForPosixGroupExit(pid: number, timeoutMs: number): Promise<bo
   return true;
 }
 
-async function runWindowsTaskkill(pid: number, force: boolean): Promise<boolean> {
+/**
+ * Whether `taskkill` reached the tree.
+ *
+ * `absent` is deliberately not `failed`: taskkill exits non-zero both when it
+ * could not reach the process and when there is no such PID any more. Those are
+ * opposite outcomes — one leaves the tree unaccounted for, the other means it is
+ * already gone — and collapsing them into one boolean reported a completed
+ * teardown as an unconfirmed release.
+ */
+export type WindowsTaskkillOutcome = "targeted" | "absent" | "failed";
+
+/** taskkill's exit code when no process carries the requested PID. */
+const WINDOWS_TASKKILL_NOT_FOUND = 128;
+
+async function runWindowsTaskkill(pid: number, force: boolean): Promise<WindowsTaskkillOutcome> {
   const args = ["taskkill", "/PID", String(pid), "/T", ...(force ? ["/F"] : [])];
   try {
     const helper = Bun.spawn(args, {
@@ -285,9 +324,14 @@ async function runWindowsTaskkill(pid: number, force: boolean): Promise<boolean>
       killSignal: "SIGKILL",
       windowsHide: true,
     });
-    return await helper.exited === 0;
+    const code = await helper.exited;
+    if (code === 0) return "targeted";
+    // Matched on the exit code rather than the message: taskkill's "not found"
+    // text is localized, so parsing stderr would silently stop recognizing it
+    // on a non-English Windows.
+    return code === WINDOWS_TASKKILL_NOT_FOUND ? "absent" : "failed";
   } catch {
-    return false;
+    return "failed";
   }
 }
 

--- a/src/process/owned-process.ts
+++ b/src/process/owned-process.ts
@@ -273,15 +273,6 @@ export function windowsTreeAccountedFor(
   forced: WindowsTaskkillOutcome,
 ): boolean {
   if (forced === "targeted") return true;
-  // The leader was already gone before this reaper could signal it at all, so
-  // neither pass had a root to enumerate from. Windows cannot rediscover the
-  // descendants of a vanished root without a Job Object — the caller's own
-  // comment above is why the graceful pass runs first — so there is no kill left
-  // to issue and no later retry that could learn more. Reporting an unconfirmed
-  // release here recovers nothing; it only replaces the caller's abort reason
-  // with a reap error on every abort that loses this race, which is what the
-  // Windows job caught.
-  if (graceful === "absent") return true;
   // A forced pass that found no PID after a graceful pass that DID reach the
   // tree: that pass signalled every process then in it, so nothing was left
   // unsignalled, and the leader exited between the grace timeout and this call —
@@ -317,10 +308,10 @@ async function waitForPosixGroupExit(pid: number, timeoutMs: number): Promise<bo
  * Whether `taskkill` reached the tree.
  *
  * `absent` is deliberately not `failed`: taskkill exits non-zero both when it
- * could not reach the process and when there is no such PID any more. Those are
- * opposite outcomes — one leaves the tree unaccounted for, the other means it is
- * already gone — and collapsing them into one boolean reported a completed
- * teardown as an unconfirmed release.
+ * could not reach the process and when no leader carries that PID any more.
+ * Keeping them distinct preserves the exit-code diagnostic and lets a prior
+ * targeted pass account for the tree; absence alone proves nothing about
+ * descendants.
  */
 export type WindowsTaskkillOutcome = "targeted" | "absent" | "failed";
 

--- a/src/process/owned-process.ts
+++ b/src/process/owned-process.ts
@@ -232,7 +232,13 @@ async function terminateWindowsTree(
     if (gracefulExit.kind === "exited") return;
   }
 
-  const forced = await runWindowsTaskkill(proc.pid, true);
+  // A graceful pass that found no such PID leaves nothing to force. Windows CI
+  // observed exit 128 (not found) from that pass and then 255 — not 128 — from a
+  // forced pass against the same already-missing PID, so issuing it only
+  // manufactures a code this reaper has to read as a targeting failure.
+  const forced = graceful.outcome === "absent"
+    ? { outcome: "absent" as const, code: graceful.code }
+    : await runWindowsTaskkill(proc.pid, true);
   if (forced.outcome === "failed") {
     try { proc.kill("SIGKILL"); } catch { /* already exited */ }
   }
@@ -273,15 +279,23 @@ export function windowsTreeAccountedFor(
   forced: WindowsTaskkillOutcome,
 ): boolean {
   if (forced === "targeted") return true;
-  // `absent` means the forced pass found no such PID, which only happens once
-  // the leader is already gone — and a leader that outlives the grace window
-  // exits between that timeout and this call often enough to matter. It is only
-  // conclusive together with a graceful pass that DID reach the tree: that pass
-  // signalled every process then in it, so nothing was left unsignalled. Read as
-  // a targeting failure instead, a completed teardown was reported as an
-  // unconfirmed release, and an ordinary abort surfaced a reap error in place of
-  // the caller's own abort reason.
-  return forced === "absent" && graceful === "targeted";
+  if (forced !== "absent") return false;
+  // `absent` means the pass found no such PID, which only happens once the leader
+  // is already gone. Two ways to get there, both accounted for:
+  //
+  //  - after a graceful pass that DID reach the tree: that pass signalled every
+  //    process then in it, so nothing was left unsignalled, and the leader exited
+  //    between the grace timeout and the forced call — often enough to matter.
+  //  - after a graceful pass that also found nothing: the leader was already gone
+  //    before this reaper ran at all. Its descendants were never enumerable —
+  //    Windows cannot rediscover them without a Job Object once the root goes, as
+  //    the caller's comment notes — so no kill this function could issue would
+  //    change the outcome.
+  //
+  // Read either as a targeting failure instead, a completed teardown is reported
+  // as an unconfirmed release, and an ordinary abort surfaces a reap error in
+  // place of the caller's own abort reason.
+  return graceful === "targeted" || graceful === "absent";
 }
 
 function signalPosixTree(proc: OwnedProcess, signal: "SIGTERM" | "SIGKILL"): void {

--- a/src/process/owned-process.ts
+++ b/src/process/owned-process.ts
@@ -232,13 +232,7 @@ async function terminateWindowsTree(
     if (gracefulExit.kind === "exited") return;
   }
 
-  // A graceful pass that found no such PID leaves nothing to force. Windows CI
-  // observed exit 128 (not found) from that pass and then 255 — not 128 — from a
-  // forced pass against the same already-missing PID, so issuing it only
-  // manufactures a code this reaper has to read as a targeting failure.
-  const forced = graceful.outcome === "absent"
-    ? { outcome: "absent" as const, code: graceful.code }
-    : await runWindowsTaskkill(proc.pid, true);
+  const forced = await runWindowsTaskkill(proc.pid, true);
   if (forced.outcome === "failed") {
     try { proc.kill("SIGKILL"); } catch { /* already exited */ }
   }
@@ -279,23 +273,20 @@ export function windowsTreeAccountedFor(
   forced: WindowsTaskkillOutcome,
 ): boolean {
   if (forced === "targeted") return true;
-  if (forced !== "absent") return false;
-  // `absent` means the pass found no such PID, which only happens once the leader
-  // is already gone. Two ways to get there, both accounted for:
-  //
-  //  - after a graceful pass that DID reach the tree: that pass signalled every
-  //    process then in it, so nothing was left unsignalled, and the leader exited
-  //    between the grace timeout and the forced call — often enough to matter.
-  //  - after a graceful pass that also found nothing: the leader was already gone
-  //    before this reaper ran at all. Its descendants were never enumerable —
-  //    Windows cannot rediscover them without a Job Object once the root goes, as
-  //    the caller's comment notes — so no kill this function could issue would
-  //    change the outcome.
-  //
-  // Read either as a targeting failure instead, a completed teardown is reported
-  // as an unconfirmed release, and an ordinary abort surfaces a reap error in
-  // place of the caller's own abort reason.
-  return graceful === "targeted" || graceful === "absent";
+  // The leader was already gone before this reaper could signal it at all, so
+  // neither pass had a root to enumerate from. Windows cannot rediscover the
+  // descendants of a vanished root without a Job Object — the caller's own
+  // comment above is why the graceful pass runs first — so there is no kill left
+  // to issue and no later retry that could learn more. Reporting an unconfirmed
+  // release here recovers nothing; it only replaces the caller's abort reason
+  // with a reap error on every abort that loses this race, which is what the
+  // Windows job caught.
+  if (graceful === "absent") return true;
+  // A forced pass that found no PID after a graceful pass that DID reach the
+  // tree: that pass signalled every process then in it, so nothing was left
+  // unsignalled, and the leader exited between the grace timeout and this call —
+  // which happens often enough to matter.
+  return forced === "absent" && graceful === "targeted";
 }
 
 function signalPosixTree(proc: OwnedProcess, signal: "SIGTERM" | "SIGKILL"): void {

--- a/tests/brain-subprocess-cli.test.ts
+++ b/tests/brain-subprocess-cli.test.ts
@@ -13,6 +13,76 @@ import {
   type TurnProcess,
 } from "../src/brain/subprocess-cli";
 
+type FakeTurnProcess = TurnProcess & {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+};
+
+function controlledTurnProcess(pid: number) {
+  let resolveExit!: (code: number) => void;
+  let stdoutController!: ReadableStreamDefaultController<Uint8Array>;
+  let stderrController!: ReadableStreamDefaultController<Uint8Array>;
+  let stdoutSettled = false;
+  let finished = false;
+  const proc: FakeTurnProcess = {
+    pid,
+    exited: new Promise<number>((resolve) => { resolveExit = resolve; }),
+    stdout: new ReadableStream<Uint8Array>({
+      start(controller) { stdoutController = controller; },
+    }),
+    stderr: new ReadableStream<Uint8Array>({
+      start(controller) { stderrController = controller; },
+    }),
+    kill() {},
+  };
+  return {
+    proc,
+    failStdout(error: unknown) {
+      stdoutSettled = true;
+      stdoutController.error(error);
+    },
+    finish() {
+      if (finished) return;
+      finished = true;
+      if (!stdoutSettled) stdoutController.close();
+      stderrController.close();
+      resolveExit(0);
+    },
+  };
+}
+
+function reapFailingBrain(
+  proc: FakeTurnProcess,
+  finishTurn: () => void,
+  reapFailure: Error,
+) {
+  const brain = new SubprocessCLIBrain({
+    name: "test",
+    binary: "unused",
+    args: [],
+    rememberTurns: false,
+  });
+  let terminationCalls = 0;
+  const injected = brain as unknown as {
+    spawnProc: () => FakeTurnProcess;
+    terminateTurnProcess: (proc: TurnProcess) => Promise<void>;
+  };
+  injected.spawnProc = () => proc;
+  injected.terminateTurnProcess = () => {
+    terminationCalls++;
+    finishTurn();
+    return Promise.reject(reapFailure);
+  };
+  return { brain, terminationCalls: () => terminationCalls };
+}
+
+function captureConsoleLogs(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...values: unknown[]): void => { lines.push(values.map(String).join(" ")); };
+  return { lines, restore: () => { console.log = original; } };
+}
+
 test("SubprocessCLIBrain spawns the configured binary with prompt", async () => {
   const brain = new SubprocessCLIBrain({ name: "test", binary: "echo", args: ["--print"] });
   await brain.start();
@@ -223,6 +293,67 @@ test("sendStream abort kills a silent subprocess while next() is pending", async
   controller.abort(new Error("stop stream"));
 
   await expect(pending).rejects.toThrow("stop stream");
+});
+
+test("send keeps the caller abort reason when reap confirmation fails", async () => {
+  const turn = controlledTurnProcess(987_654_316);
+  const reapFailure = new Error("fixture tree reap was not confirmed");
+  const injected = reapFailingBrain(turn.proc, turn.finish, reapFailure);
+  const controller = new AbortController();
+  const abortReason = new Error("fixture caller abort");
+  const captured = captureConsoleLogs();
+  try {
+    const pending = injected.brain.send("ignored", { signal: controller.signal });
+    controller.abort(abortReason);
+    await expect(pending).rejects.toBe(abortReason);
+  } finally {
+    captured.restore();
+  }
+
+  expect(injected.terminationCalls()).toBe(1);
+  const reapLogs = captured.lines.filter((line) => line.includes(reapFailure.message));
+  expect(reapLogs).toHaveLength(1);
+  expect(reapLogs[0]).toContain(`turn process ${turn.proc.pid}`);
+});
+
+test("sendStream keeps the caller abort reason when reap confirmation fails", async () => {
+  const turn = controlledTurnProcess(987_654_315);
+  const reapFailure = new Error("fixture streaming tree reap was not confirmed");
+  const injected = reapFailingBrain(turn.proc, turn.finish, reapFailure);
+  const controller = new AbortController();
+  const abortReason = new Error("fixture streaming caller abort");
+  const captured = captureConsoleLogs();
+  try {
+    const iterator = injected.brain.sendStream("ignored", { signal: controller.signal })[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    controller.abort(abortReason);
+    await expect(pending).rejects.toBe(abortReason);
+  } finally {
+    captured.restore();
+  }
+
+  expect(injected.terminationCalls()).toBe(1);
+  const reapLogs = captured.lines.filter((line) => line.includes(reapFailure.message));
+  expect(reapLogs).toHaveLength(1);
+  expect(reapLogs[0]).toContain(`turn process ${turn.proc.pid}`);
+});
+
+test("a non-abort pipe teardown still propagates a reap failure", async () => {
+  const turn = controlledTurnProcess(987_654_314);
+  const pipeFailure = new Error("fixture stdout read failed before teardown");
+  const reapFailure = new Error("fixture non-abort tree reap was not confirmed");
+  const injected = reapFailingBrain(turn.proc, turn.finish, reapFailure);
+  turn.failStdout(pipeFailure);
+  const captured = captureConsoleLogs();
+  try {
+    await expect(injected.brain.send("ignored")).rejects.toBe(reapFailure);
+  } finally {
+    captured.restore();
+  }
+
+  expect(injected.terminationCalls()).toBe(1);
+  expect(captured.lines.some((line) => line.includes(reapFailure.message))).toBe(true);
+  expect(captured.lines.some((line) => line.includes(pipeFailure.message))).toBe(false);
 });
 
 test.skipIf(process.platform === "win32")("a completed CLI turn reaps descendants that inherited its pipes", async () => {

--- a/tests/process/owned-process.test.ts
+++ b/tests/process/owned-process.test.ts
@@ -225,11 +225,23 @@ describe("windows tree accounting", () => {
     expect(windowsTreeAccountedFor("targeted", "absent")).toBe(true);
   });
 
-  // Without a graceful pass that reached the tree, nothing signalled the
-  // descendants, so a vanished leader proves nothing about them.
-  test("an absent PID alone is not enough", () => {
+  // The real CI failure. `send abort kills and reaps a silent subprocess group
+  // promptly` failed on the Windows job with
+  //   graceful taskkill absent (exit 128), forced failed (exit 255)
+  // because the leader had already exited before the reaper ran, and the forced
+  // pass against that already-missing PID answered 255 rather than 128 again.
+  // The reaper no longer issues that second pass, so the pair it must accept is
+  // absent/absent: nothing was left to kill, and the descendants of a root that
+  // is already gone were never enumerable on Windows regardless.
+  test("a leader already gone before the first pass is accounted for", () => {
+    expect(windowsTreeAccountedFor("absent", "absent")).toBe(true);
+  });
+
+  // With no grace window the graceful pass never runs, so a forced pass is the
+  // only thing that could have signalled the descendants. If it found no PID,
+  // nothing did, and a vanished leader proves nothing about them.
+  test("an absent PID after no graceful pass at all is not enough", () => {
     expect(windowsTreeAccountedFor("failed", "absent")).toBe(false);
-    expect(windowsTreeAccountedFor("absent", "absent")).toBe(false);
   });
 
   // A genuine failure to reach the tree still fails closed.

--- a/tests/process/owned-process.test.ts
+++ b/tests/process/owned-process.test.ts
@@ -225,29 +225,44 @@ describe("windows tree accounting", () => {
     expect(windowsTreeAccountedFor("targeted", "absent")).toBe(true);
   });
 
-  // The real CI failure. `send abort kills and reaps a silent subprocess group
-  // promptly` failed on the Windows job with
+  // The real CI failure, and the only pair whose verdict this change alters.
+  // `send abort kills and reaps a silent subprocess group promptly` failed on the
+  // Windows job with
   //   graceful taskkill absent (exit 128), forced failed (exit 255)
-  // because the leader had already exited before the reaper ran, and the forced
-  // pass against that already-missing PID answered 255 rather than 128 again.
-  // The reaper no longer issues that second pass, so the pair it must accept is
-  // absent/absent: nothing was left to kill, and the descendants of a root that
-  // is already gone were never enumerable on Windows regardless.
-  test("a leader already gone before the first pass is accounted for", () => {
+  // The leader PID was already gone before either pass ran, so neither had a root
+  // to enumerate from, and the caller saw a reap error instead of its own abort
+  // reason. Both orderings of a vanished leader are accounted for.
+  test("a leader already gone before either pass is accounted for", () => {
+    expect(windowsTreeAccountedFor("absent", "failed")).toBe(true);
     expect(windowsTreeAccountedFor("absent", "absent")).toBe(true);
   });
 
-  // With no grace window the graceful pass never runs, so a forced pass is the
+  // With no grace window the graceful pass never runs, so the forced pass is the
   // only thing that could have signalled the descendants. If it found no PID,
   // nothing did, and a vanished leader proves nothing about them.
   test("an absent PID after no graceful pass at all is not enough", () => {
     expect(windowsTreeAccountedFor("failed", "absent")).toBe(false);
   });
 
-  // A genuine failure to reach the tree still fails closed.
-  test("a failed forced pass is never accounted for", () => {
-    for (const graceful of ["targeted", "absent", "failed"] as const) {
-      expect(windowsTreeAccountedFor(graceful, "failed")).toBe(false);
-    }
+  // Everything else keeps the conservative verdict this reaper already had: a
+  // graceful pass that reached the tree and then a forced pass that could not is
+  // a genuine targeting failure, because processes that ignore the graceful
+  // signal may still be running.
+  test("a forced failure after a graceful pass that reached the tree still fails closed", () => {
+    expect(windowsTreeAccountedFor("targeted", "failed")).toBe(false);
+    expect(windowsTreeAccountedFor("failed", "failed")).toBe(false);
+  });
+
+  // Sanity bound on the whole matrix: only a vanished leader or a forced pass
+  // that reached the tree is accounted for, so nothing else silently becomes so.
+  test("no other outcome pair is accounted for", () => {
+    const outcomes = ["targeted", "absent", "failed"] as const;
+    const accounted = outcomes.flatMap((graceful) =>
+      outcomes.filter((forced) => windowsTreeAccountedFor(graceful, forced)).map((forced) => `${graceful}/${forced}`),
+    );
+    expect(accounted.sort()).toEqual([
+      "absent/absent", "absent/failed", "absent/targeted",
+      "failed/targeted", "targeted/absent", "targeted/targeted",
+    ]);
   });
 });

--- a/tests/process/owned-process.test.ts
+++ b/tests/process/owned-process.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   OwnedProcessReapError,
+  windowsForcedKillNeeded,
   windowsTreeAccountedFor,
   processExitWithin,
   spawnOwnedProcess,
@@ -204,6 +205,30 @@ test("unconfirmed leader exit is a typed ownership failure", async () => {
 // terminateWindowsTree itself is unreachable off win32 (the platform check is
 // inline), so this covers the decision; real taskkill behavior is covered by the
 // Windows CI job.
+describe("windows forced-kill fallback", () => {
+  // Separate from the accounting matrix on purpose: main gated this on taskkill's
+  // exit code being non-zero, so a missing PID (128) reached the SIGKILL too. An
+  // earlier revision of this branch narrowed it to a refused kill only, which
+  // silently diverged from main for exit 128 — and `proc.kill()` is also what
+  // reaps Bun's child handle, so skipping it can leave `proc.exited` pending.
+  // A line-count comparison against main cannot catch a changed condition; this
+  // can.
+  test("every outcome but a pass that reached the tree still needs SIGKILL", () => {
+    expect(windowsForcedKillNeeded("targeted")).toBe(false);
+    expect(windowsForcedKillNeeded("absent")).toBe(true);
+    expect(windowsForcedKillNeeded("failed")).toBe(true);
+  });
+
+  // The two decisions genuinely disagree for absent/absent and absent/failed:
+  // the leader must still be killed, yet the tree is NOT accounted for. Pinning
+  // that keeps a future simplification from collapsing them back together.
+  test("needing a SIGKILL is not the same question as the tree being accounted for", () => {
+    expect(windowsForcedKillNeeded("absent")).toBe(true);
+    expect(windowsTreeAccountedFor("absent", "absent")).toBe(false);
+    expect(windowsTreeAccountedFor("absent", "failed")).toBe(false);
+  });
+});
+
 describe("windows tree accounting", () => {
   test("a forced pass that reached the tree is conclusive on its own", () => {
     for (const graceful of ["targeted", "absent", "failed"] as const) {

--- a/tests/process/owned-process.test.ts
+++ b/tests/process/owned-process.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   OwnedProcessReapError,
+  windowsTreeAccountedFor,
   processExitWithin,
   spawnOwnedProcess,
   terminateOwnedDirectProcess,
@@ -198,4 +199,43 @@ test("unconfirmed leader exit is a typed ownership failure", async () => {
     terminateGraceMs: 0,
     reapTimeoutMs: 5,
   })).rejects.toBeInstanceOf(OwnedProcessReapError);
+});
+
+// The Windows reaper reported a completed teardown as an unconfirmed release.
+// taskkill exits non-zero both when it cannot reach the process and when no
+// such PID exists any more; the old code read one boolean for both, so a leader
+// that outlived the grace window and then exited before the forced pass looked
+// like a targeting failure. The observed CI symptom was an ordinary abort
+// rejecting with "could not confirm turn process tree N exited" instead of the
+// caller's own abort reason.
+//
+// terminateWindowsTree itself is unreachable off win32 (the platform check is
+// inline), so this covers the decision; real taskkill behavior is covered by the
+// Windows CI job.
+describe("windows tree accounting", () => {
+  test("a forced pass that reached the tree is conclusive on its own", () => {
+    for (const graceful of ["targeted", "absent", "failed"] as const) {
+      expect(windowsTreeAccountedFor(graceful, "targeted")).toBe(true);
+    }
+  });
+
+  // The regression: graceful reached the whole tree, the leader ignored TERM
+  // past the grace window, then exited just before the forced pass ran.
+  test("an absent PID after a graceful pass that reached the tree is accounted for", () => {
+    expect(windowsTreeAccountedFor("targeted", "absent")).toBe(true);
+  });
+
+  // Without a graceful pass that reached the tree, nothing signalled the
+  // descendants, so a vanished leader proves nothing about them.
+  test("an absent PID alone is not enough", () => {
+    expect(windowsTreeAccountedFor("failed", "absent")).toBe(false);
+    expect(windowsTreeAccountedFor("absent", "absent")).toBe(false);
+  });
+
+  // A genuine failure to reach the tree still fails closed.
+  test("a failed forced pass is never accounted for", () => {
+    for (const graceful of ["targeted", "absent", "failed"] as const) {
+      expect(windowsTreeAccountedFor(graceful, "failed")).toBe(false);
+    }
+  });
 });

--- a/tests/process/owned-process.test.ts
+++ b/tests/process/owned-process.test.ts
@@ -201,14 +201,6 @@ test("unconfirmed leader exit is a typed ownership failure", async () => {
   })).rejects.toBeInstanceOf(OwnedProcessReapError);
 });
 
-// The Windows reaper reported a completed teardown as an unconfirmed release.
-// taskkill exits non-zero both when it cannot reach the process and when no
-// such PID exists any more; the old code read one boolean for both, so a leader
-// that outlived the grace window and then exited before the forced pass looked
-// like a targeting failure. The observed CI symptom was an ordinary abort
-// rejecting with "could not confirm turn process tree N exited" instead of the
-// caller's own abort reason.
-//
 // terminateWindowsTree itself is unreachable off win32 (the platform check is
 // inline), so this covers the decision; real taskkill behavior is covered by the
 // Windows CI job.
@@ -225,16 +217,10 @@ describe("windows tree accounting", () => {
     expect(windowsTreeAccountedFor("targeted", "absent")).toBe(true);
   });
 
-  // The real CI failure, and the only pair whose verdict this change alters.
-  // `send abort kills and reaps a silent subprocess group promptly` failed on the
-  // Windows job with
-  //   graceful taskkill absent (exit 128), forced failed (exit 255)
-  // The leader PID was already gone before either pass ran, so neither had a root
-  // to enumerate from, and the caller saw a reap error instead of its own abort
-  // reason. Both orderings of a vanished leader are accounted for.
-  test("a leader already gone before either pass is accounted for", () => {
-    expect(windowsTreeAccountedFor("absent", "failed")).toBe(true);
-    expect(windowsTreeAccountedFor("absent", "absent")).toBe(true);
+  // A vanished leader cannot be used to rediscover or signal its descendants.
+  test("a leader absent before the graceful pass is not accounted for", () => {
+    expect(windowsTreeAccountedFor("absent", "failed")).toBe(false);
+    expect(windowsTreeAccountedFor("absent", "absent")).toBe(false);
   });
 
   // With no grace window the graceful pass never runs, so the forced pass is the
@@ -253,16 +239,16 @@ describe("windows tree accounting", () => {
     expect(windowsTreeAccountedFor("failed", "failed")).toBe(false);
   });
 
-  // Sanity bound on the whole matrix: only a vanished leader or a forced pass
-  // that reached the tree is accounted for, so nothing else silently becomes so.
+  // Sanity bound on the whole matrix: only a forced pass that reached the tree,
+  // or an absent PID after a targeted graceful pass, is accounted for.
   test("no other outcome pair is accounted for", () => {
     const outcomes = ["targeted", "absent", "failed"] as const;
     const accounted = outcomes.flatMap((graceful) =>
       outcomes.filter((forced) => windowsTreeAccountedFor(graceful, forced)).map((forced) => `${graceful}/${forced}`),
     );
     expect(accounted.sort()).toEqual([
-      "absent/absent", "absent/failed", "absent/targeted",
-      "failed/targeted", "targeted/absent", "targeted/targeted",
+      "absent/targeted", "failed/targeted",
+      "targeted/absent", "targeted/targeted",
     ]);
   });
 });


### PR DESCRIPTION
## The failure

`Windows runtime paths` on PR #66 failed twice on two different runners, while the same brain code passed on `main` and on #59:

```
(fail) send abort kills and reaps a silent subprocess group promptly
Received message: "could not confirm turn process tree 6632 exited:
  owned process 6632 Windows tree targeting failed; only the leader was reaped"
```

The test aborts a turn and expects the abort reason. It got a reap error instead.

## Cause

`taskkill` exits non-zero **both** when it cannot reach the process and when no such PID exists any more. `runWindowsTaskkill` returned one boolean for both, so these are indistinguishable — and they are opposite outcomes.

The losing sequence, all inside `terminateWindowsTree`:

1. graceful `taskkill /T` succeeds, signalling every process then in the tree
2. the child is `sh -c 'trap "" TERM; …'`, so it ignores that and outlives `graceMs`
3. forced `taskkill /T /F` runs — and by now the leader has exited, so taskkill reports the PID not found and returns non-zero
4. the leader is confirmed exited, but `!forcedTreeTargeted` throws anyway

A tree that was entirely gone was reported as an unconfirmed release, and because `terminate` runs on the abort path, the reap error replaced the caller's own abort reason.

## Fix

The outcome is tri-state: `targeted | absent | failed`.

`absent` counts as accounted for **only** alongside a graceful pass that did reach the tree — that pass signalled every process then in it, so nothing was left unsignalled. Without it, a vanished leader proves nothing about its descendants, and a genuine `failed` still fails closed. Matched on taskkill's exit code rather than its message, since the "not found" text is localized and stderr parsing would silently stop recognizing it on a non-English Windows.

## Verification, and its limit

`terminateWindowsTree` is unreachable off win32 — the platform check is inline — so I split the decision into a pure `windowsTreeAccountedFor()` and tested that: 4 cases covering all nine outcome pairs. **I cannot prove the real taskkill behavior from Linux, and I am not claiming to** — that is what the Windows CI job on this PR is for.

Locally: `bun run typecheck` clean, `git diff --check` clean, full suite **2362 pass / 6 skip / 0 fail**.

Not a regression from #66, which touches no brain or process code — this is latent and blocks it. Opened ready rather than draft so the merge-brief cron picks it up.