### PR TITLE
fix(switchboard): a dial-back no longer supersedes its own turn

### DIFF
--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { BackgroundTurnOptions, Brain, BrainTurnOptions, PendingConfirmation } from "../types";
 import { dialBackMemo, matchCallMe, SpeculativeSideEffectError } from "../call-intent";
 import { log } from "../logger";
@@ -340,6 +341,11 @@ export class SwitchboardBrain implements Brain {
   private readonly standupLaneTimeoutMs: number;
   private acceptedTurnSequence = 0;
   private acceptedTurn: AcceptedTurn | null = null;
+  /** Carries the delegating turn to nested public calls made on the delegate's
+   * own async context — see delegateWithinTurn(). Deliberately NOT a plain
+   * field: a concurrent barge-in runs on a different context and must still be
+   * admitted as a newer turn that supersedes this one. */
+  private readonly delegation = new AsyncLocalStorage<AcceptedTurn>();
   private stopping = false;
   private lifecycleSequence = 0;
   private lifecycleBarrier: Promise<void> = Promise.resolve();
@@ -558,6 +564,36 @@ export class SwitchboardBrain implements Brain {
     return turn;
   }
 
+  /**
+   * A control action can only reach some behavior through another PUBLIC entry
+   * point: the daemon's dial-back handler calls transferTo() back into this
+   * switchboard to decide who picks up. That nested call used to be admitted as
+   * a brand-new turn, so it superseded the very turn that invoked it — the
+   * phone rang, the lane was pinned, and then the caller was handed
+   * "superseded by a newer accepted turn" instead of the ack (live incident
+   * 2026-07-30: "have him call me" answered with an unreachable error).
+   *
+   * Delegation therefore runs ON the caller's turn. The parent keeps sole
+   * ownership of the lease: the nested call neither settles nor aborts it, and
+   * a nested failure propagates so the parent's own handler decides.
+   */
+  private delegateWithinTurn<T>(turn: AcceptedTurn, body: () => Promise<T>): Promise<T> {
+    this.assertAcceptedTurn(turn);
+    return this.delegation.run(turn, body);
+  }
+
+  /**
+   * The turn a nested public call should adopt, or null for normal admission.
+   * Only the live lease is adoptable — once the parent is settled, aborted, or
+   * displaced by a genuinely newer turn, a nested call must take its chances
+   * with beginAcceptedTurn like any other caller.
+   */
+  private adoptableTurn(): AcceptedTurn | null {
+    const turn = this.delegation.getStore();
+    if (!turn || turn.settled || turn.signal.aborted) return null;
+    return this.acceptedTurn === turn ? turn : null;
+  }
+
   private assertAcceptedTurn(turn: AcceptedTurn): void {
     turn.signal.throwIfAborted();
     if (turn.settled || this.acceptedTurn?.sequence !== turn.sequence || this.acceptedTurn !== turn) {
@@ -643,6 +679,15 @@ export class SwitchboardBrain implements Brain {
     options: BrainTurnOptions | undefined,
     body: (turn: AcceptedTurn, options: BrainTurnOptions) => Promise<T>,
   ): Promise<T> {
+    // Nested delegation from a control action rides the caller's turn instead
+    // of superseding it. The parent owns begin/finish/abort, so this path only
+    // runs the body; a caller signal is still honored up front, but the turn's
+    // own signal governs the work (the delegate is part of that turn).
+    const adopted = this.adoptableTurn();
+    if (adopted) {
+      options?.signal?.throwIfAborted();
+      return body(adopted, this.optionsForTurn(adopted, options));
+    }
     const turn = this.beginAcceptedTurn(options);
     const turnOptions = this.optionsForTurn(turn, options);
     try {
@@ -970,7 +1015,8 @@ export class SwitchboardBrain implements Brain {
     if (RELEASE_RE.test(m)) return this.doRelease(turn);
     // Spoken dial-back ("call me", "have ada call me") — must beat PIN_RE:
     // "have ada call me" would otherwise read as a transfer to "ada call".
-    if (this.callMe) {
+    const dial = this.callMe;
+    if (dial) {
       const call = matchCallMe(m);
       if (call) {
         // Refuse below the selection, exactly like DialBackBrain: the lane
@@ -979,13 +1025,13 @@ export class SwitchboardBrain implements Brain {
         // callback is not retractable by the final utterance.
         if (options.speculative) throw new SpeculativeSideEffectError();
         log("info", `switchboard: dial-back requested${call.who ? ` — ${call.who}` : ""}`);
-        // Handler args deliberately unchanged by this PR: only `{ signal }`, as
-        // before. `options` is needed for the refusal above, NOT by the handler
-        // — forwarding it there regressed named dial-backs, and the underlying
-        // re-entrancy defect (the handler pins the lane by calling transferTo()
-        // back into this switchboard, whose admission supersedes the turn it was
-        // called from) is pre-existing and tracked separately.
-        const reply = await this.callMe(call.who, { signal: turn.signal });
+        // Handler args stay `{ signal }` only: `options` is needed for the
+        // refusal above, NOT by the handler — forwarding it there regressed
+        // named dial-backs. The handler pins the lane by calling transferTo()
+        // back into this switchboard, so it runs inside the delegation window
+        // that keeps that nested turn from superseding this one.
+        const reply = await this.delegateWithinTurn(turn, () =>
+          dial(call.who, { signal: turn.signal }));
         // Memo even if this turn was superseded meanwhile: the call was placed.
         this.leaveMemo(dialBackMemo(call.who));
         return reply;
@@ -1086,8 +1132,9 @@ export class SwitchboardBrain implements Brain {
     if (label === "callme" || label.startsWith("callme:")) {
       // Same hallucinated-label defense as the group actions: dialing the
       // user's phone demands call vocabulary in the actual utterance.
-      if (!this.callMe || !/\b(?:call|ring|phone|dial)\b/i.test(utterance)) {
-        if (this.callMe) log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" mentions no call — ignoring`);
+      const dial = this.callMe;
+      if (!dial || !/\b(?:call|ring|phone|dial)\b/i.test(utterance)) {
+        if (dial) log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" mentions no call — ignoring`);
         return null;
       }
       const who = label.startsWith("callme:") ? label.slice("callme:".length).trim() : "";
@@ -1095,8 +1142,12 @@ export class SwitchboardBrain implements Brain {
       // patterns miss ("phone me now"), so no phrase list can cover this.
       if (options.speculative) throw new SpeculativeSideEffectError();
       log("info", `switchboard: dial-back requested (classifier)${who ? ` — ${who}` : ""}`);
-      // Handler args unchanged by this PR — see the note on the lexical path.
-      const reply = await this.callMe(who || undefined);
+      // Handler args match the lexical path — see the note there. The turn
+      // signal was previously withheld here, so an aborted turn's dial-back
+      // kept doing board work; the delegation window is what stops the
+      // handler's transferTo() from superseding this turn.
+      const reply = await this.delegateWithinTurn(turn, () =>
+        dial(who || undefined, { signal: turn.signal }));
       // Memo before the turn assert: a superseding turn still needs to know.
       this.leaveMemo(dialBackMemo(who || undefined));
       this.assertAcceptedTurn(turn);

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1866,6 +1866,87 @@ test("classifier callme:<employee> routes the named pickup", async () => {
   expect(rang).toEqual(["coder"]);
 });
 
+test("a classifier dial-back survives its own handler pinning the lane", async () => {
+  // Live incident 2026-07-30: "I can't talk to Rick have him call mw" routed to
+  // callme:think, the phone rang and the lane was pinned — then the user got
+  // "(Cicero unreachable: switchboard turn superseded by a newer accepted
+  // turn)" instead of the ack. The real daemon handler calls transferTo() to
+  // decide who picks up, and that is itself a public turn, so it superseded
+  // the very turn that invoked it. Every other dial-back test uses an inert
+  // handler, which is why nothing caught it. A control action delegating to
+  // another public entry point must not cancel its own caller.
+  const calls: string[] = [];
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    think: { brain: fakeBrain("think", calls) },
+  }, async () => "callme:think");
+  sb.setCallMeHandler(async (who) => {
+    const name = await sb.transferTo(who ?? "think");
+    return `Ringing you now — ${name} will pick up.`;
+  });
+  try {
+    await sb.start();
+    expect(await sb.send("I can't talk to Rick have him call me")).toBe(
+      "Ringing you now — Think will pick up.",
+    );
+    expect(sb.activeLane()).toBe("think");
+  } finally {
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("a spoken dial-back survives its own handler pinning the lane", async () => {
+  // Same defect on the lexical path: it reaches the daemon handler too, and
+  // the outer runAcceptedTurn asserts the turn before it returns. Telegram's
+  // typed "call me" masks this by intercepting before the brain, so voice is
+  // where it bites.
+  const calls: string[] = [];
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    think: { brain: fakeBrain("think", calls) },
+  });
+  sb.setCallMeHandler(async (who) => {
+    const name = await sb.transferTo(who ?? "think");
+    return `Ringing you now — ${name} will pick up.`;
+  });
+  try {
+    await sb.start();
+    expect(await sb.send("have think call me")).toBe(
+      "Ringing you now — Think will pick up.",
+    );
+  } finally {
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("a barge-in during a dial-back still supersedes the dialing turn", async () => {
+  // The delegation window must be scoped to the handler's OWN async context.
+  // A concurrent public turn is not delegation — it is the user interrupting,
+  // and it has to take the lease. If it were allowed to adopt the dialing turn
+  // instead, two utterances would share one lease and the barge-in would never
+  // cancel the dial.
+  const calls: string[] = [];
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    think: { brain: fakeBrain("think", calls) },
+  });
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => { release = resolve; });
+  sb.setCallMeHandler(async () => {
+    await held;
+    return "Ringing you now.";
+  });
+  try {
+    await sb.start();
+    const dialing = sb.send("call me");
+    await Bun.sleep(5); // let the turn reach the held handler
+    const bargeIn = sb.send("actually never mind");
+    expect(await settlesWithin(bargeIn, "barge-in")).toBe("front reply");
+    release();
+    await expect(dialing).rejects.toThrow("superseded by a newer accepted turn");
+  } finally {
+    release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
 test("hallucinated callme labels are ignored without call vocabulary", async () => {
   // Mirror of the group-word guard: the classifier alone must never be able
   // to dial the user's phone from an utterance that mentions no call.
@@ -1969,14 +2050,15 @@ test("the speculative refusal reaches sendStream, the speculator's own entry poi
   expect(rang).toEqual([]);
 });
 
-test("the dial sites pass the handler exactly what they always did", async () => {
+test("both dial sites hand the handler the turn signal and nothing more", async () => {
   // Guards against re-introducing the regression this PR briefly shipped:
   // forwarding the whole turn options to the handler. The refusal above the
-  // dial needs `options`; the HANDLER must keep its original arguments, because
-  // it pins the named lane by calling transferTo() back into this switchboard
-  // and that admission supersedes the turn it was called from. (That
-  // re-entrancy defect is pre-existing and tracked separately — this test only
-  // pins the argument contract.)
+  // dial needs `options`; the handler gets ONLY `{ signal }` so a cancelled
+  // turn stops the dial-back's own work without leaking `speculative` (which
+  // would make the handler refuse a dial the site already approved).
+  // Both sites now match: the classifier path used to withhold the signal
+  // because the handler's transferTo() re-entry superseded the turn — the
+  // delegation window fixes that cause, so it no longer has to.
   const seen: Array<{ who?: string; keys: string[] }> = [];
   const lexical = board([]);
   lexical.setCallMeHandler(async (who, options) => {
@@ -1998,7 +2080,7 @@ test("the dial sites pass the handler exactly what they always did", async () =>
 
   expect(seen).toEqual([
     { who: undefined, keys: ["signal"] }, // lexical: the turn signal, nothing else
-    { who: "coder", keys: [] },           // classifier: no options at all
+    { who: "coder", keys: ["signal"] },   // classifier: the same, no more
   ]);
 });
 


### PR DESCRIPTION
## The live failure

Over Telegram, 2026-07-30 03:06 UTC:

> **Tym:** I can't talk to Rick have him call mw
> **cicero-voice:** (Cicero unreachable: switchboard turn superseded by a newer accepted turn)

The daemon log shows the action actually *succeeded* before the error:

```
switchboard: classifier routed "I can't talk to Rick have him call mw" → callme:think
switchboard: dial-back requested (classifier) — think
switchboard: briefed think on the Cicero exchange
switchboard: pinned to think
telegram notify sent: "(Cicero unreachable: switchboard turn superseded by a newer "
```

## Cause

The daemon's dial-back handler decides who picks up by calling `transferTo()`
back into the switchboard. `transferTo` is a public entry point, so it ran
`beginAcceptedTurn`, which unconditionally aborts the current lease — the very
turn that invoked the handler. `actOnIntent` then asserts that turn and throws.

The defect was already documented in `switchboard.ts` as "pre-existing and
tracked separately"; this is that fix.

**It was a class, not a one-off.** The lexical path (`have <employee> call me`)
re-enters the same handler and the outer `runAcceptedTurn` asserts before it
returns, so it fails too. Typed `call me` masked it because `telegram.ts`
intercepts `matchCallMe` before the brain ever sees it — so **voice** is where
it bit. Both paths are fixed and pinned.

## Fix

A control action that can only reach behavior through another public entry point
now delegates inside a window that makes the nested call ride the caller's turn.
The parent keeps sole ownership of the lease: the nested call neither settles nor
aborts it, and a nested failure propagates so the parent's handler decides.

The window is an `AsyncLocalStorage` store, **not a field**, so it is scoped to
the delegate's own async context. A concurrent barge-in runs on a different
context and must still be admitted as a newer turn that supersedes the dial — a
field-based window would have let a barge-in silently share the dialing turn's
lease instead of cancelling it. That hazard is pinned by its own regression.

The classifier site also forwards the turn signal now, matching the lexical site.
It was withheld only because of this re-entrancy, so an aborted turn's dial-back
kept doing board-CLI work.

## Regressions

Three new tests in `tests/brain/switchboard.test.ts`. Every pre-existing
`setCallMeHandler` test uses an inert handler that never re-enters the
switchboard — which is exactly why nothing caught this. The new ones use a
handler that calls `transferTo()`, like the real daemon's.

- `a classifier dial-back survives its own handler pinning the lane`
- `a spoken dial-back survives its own handler pinning the lane`
- `a barge-in during a dial-back still supersedes the dialing turn`

`the dial sites pass the handler exactly what they always did` is renamed and
updated: it pinned the classifier site as passing *no options*, and its stated
reason was this re-entrancy defect. With the cause fixed, both sites pass
`{ signal }` and nothing more.

## Verification

- `bun run typecheck` — clean
- `bun test tests/brain/switchboard.test.ts` — 112 pass, 0 fail
- Full `bun test` — 2416 pass / 6 skip / 2 fail / 1 error, vs **2413 / 6 / 2 / 1
  on the untouched baseline**: exactly +3 (the new regressions), identical
  failure count. The 2 failures are pre-existing and environmental — the
  `terminal-send-errors` case asserts stderr text that Bun colorizes with ANSI
  codes under this job's TTY; it fails the same way on a clean tree.
- `git diff --check` — clean

**Mutation proofs** (each mechanism neutered alone, then restored):

| Mutation | Result |
|---|---|
| `adoptableTurn()` returns `null` (never adopt) | the 2 dial-back regressions fail — 110 pass / 2 fail |
| window made context-blind (plain field instead of `AsyncLocalStorage`) | `a barge-in during a dial-back still supersedes the dialing turn` fails — 111 pass / 1 fail |

Not verified by CI: no hardware or real Telegram/tgcall hop was driven. The
sidecar side of that evening's dial-back is visible in `tgcall.log`
(`[call] placing callback to the configured owner`) but is not exercised here.
