### PR TITLE
fix(switchboard): a transfer talked over during a cold start is not dropped

### DIFF
--- a/docs/office.md
+++ b/docs/office.md
@@ -28,7 +28,7 @@ brain:
       voice: af_sky
 ```
 
-- **Transfers are sticky** — a phone transfer, not a per-question relay. "Talk to / switch me to / pass me to / patch me through to X" pins; "back to you / that's all / hang up" releases.
+- **Transfers are sticky** — a phone transfer, not a per-question relay. "Talk to / switch me to / pass me to / patch me through to X" pins; "back to you / that's all / hang up" releases. If a cold transfer connects but the conversation ends before that colleague answers an ordinary turn, Cicero discards the unused pin; after the colleague answers, it is as sticky as a warm transfer.
 - **Nobody plays dumb about what just happened** — a transferred-to colleague is briefed on what you were discussing, and on release the front desk gets a recap of the last few exchanges it missed. Control-plane actions leave the same trail: after "call me" rings your phone, asking "did you call me?" gets a straight yes instead of a denial from a persona that never saw the dial happen.
 - **The first alias is the working name** — the one Cicero says when reciting the roster or running a roll call.
 - **Lanes start lazily** on their first pin, so a big roster costs nothing at boot.

--- a/docs/web-voice.md
+++ b/docs/web-voice.md
@@ -96,6 +96,16 @@ handler cannot be mistaken for the current reply. Turn queues, abort state,
 speculation, and replay detection are scoped to one WebSocket; one browser
 cannot abort or drain another browser's transport queue.
 
+Stopping the conversation sends a `{"type":"bye"}` control frame before closing.
+A closed socket alone cannot say whether the operator stopped or the network
+dropped, and the page reconnects by itself (1s → 2s → 5s) in the second case, so
+the server ends the conversation immediately after a goodbye and otherwise waits
+out a grace period that a returning client cancels. That matters to a brain
+holding deferred work — a cold transfer still connecting — which would otherwise
+be called off by an ordinary blip. The frame carries no authority and is
+accepted regardless of session id: refusing it would silently downgrade a Stop
+into a dropped connection.
+
 Protocol-v2 binary frames are `CVP2`, two little-endian ID lengths, the UTF-8
 session and turn IDs, then the existing WAV or `PRB2` payload. Clients that do
 not request `protocol=2` remain on the original raw-binary/untagged-JSON format

--- a/src/brain/dial-back.ts
+++ b/src/brain/dial-back.ts
@@ -99,6 +99,7 @@ export class DialBackBrain implements Brain {
 
   get sendToTab(): Brain["sendToTab"] { return bindBrainCapability(this.inner, "sendToTab"); }
   get switchTab(): Brain["switchTab"] { return bindBrainCapability(this.inner, "switchTab"); }
+  get dropDeferredWork(): Brain["dropDeferredWork"] { return bindBrainCapability(this.inner, "dropDeferredWork"); }
   get getTargetTab(): Brain["getTargetTab"] { return bindBrainCapability(this.inner, "getTargetTab"); }
   get activeLane(): Brain["activeLane"] { return bindBrainCapability(this.inner, "activeLane"); }
   get transferTo(): Brain["transferTo"] { return bindBrainCapability(this.inner, "transferTo"); }

--- a/src/brain/fallback.ts
+++ b/src/brain/fallback.ts
@@ -95,6 +95,7 @@ export class FallbackBrain implements Brain {
 
   get sendToTab(): Brain["sendToTab"] { return bindBrainCapability(this.current(), "sendToTab"); }
   get switchTab(): Brain["switchTab"] { return bindBrainCapability(this.current(), "switchTab"); }
+  get dropDeferredWork(): Brain["dropDeferredWork"] { return bindBrainCapability(this.current(), "dropDeferredWork"); }
   get getTargetTab(): Brain["getTargetTab"] { return bindBrainCapability(this.current(), "getTargetTab"); }
   get activeLane(): Brain["activeLane"] { return bindBrainCapability(this.current(), "activeLane"); }
   get transferTo(): Brain["transferTo"] { return bindBrainCapability(this.current(), "transferTo"); }

--- a/src/brain/quick-intents.ts
+++ b/src/brain/quick-intents.ts
@@ -102,6 +102,7 @@ export class QuickIntentsBrain implements Brain {
   }
   get sendToTab(): Brain["sendToTab"] { return bindBrainCapability(this.inner, "sendToTab"); }
   get switchTab(): Brain["switchTab"] { return bindBrainCapability(this.inner, "switchTab"); }
+  get dropDeferredWork(): Brain["dropDeferredWork"] { return bindBrainCapability(this.inner, "dropDeferredWork"); }
   get getTargetTab(): Brain["getTargetTab"] { return bindBrainCapability(this.inner, "getTargetTab"); }
   get activeLane(): Brain["activeLane"] { return bindBrainCapability(this.inner, "activeLane"); }
   get transferTo(): Brain["transferTo"] { return bindBrainCapability(this.inner, "transferTo"); }

--- a/src/brain/routing.ts
+++ b/src/brain/routing.ts
@@ -100,6 +100,7 @@ export class RoutingBrain implements Brain {
 
   get sendToTab(): Brain["sendToTab"] { return bindBrainCapability(this.current, "sendToTab"); }
   get switchTab(): Brain["switchTab"] { return bindBrainCapability(this.current, "switchTab"); }
+  get dropDeferredWork(): Brain["dropDeferredWork"] { return bindBrainCapability(this.current, "dropDeferredWork"); }
   get getTargetTab(): Brain["getTargetTab"] { return bindBrainCapability(this.current, "getTargetTab"); }
   get activeLane(): Brain["activeLane"] { return bindBrainCapability(this.current, "activeLane"); }
   get transferTo(): Brain["transferTo"] { return bindBrainCapability(this.current, "transferTo"); }

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -1,5 +1,4 @@
 import type { BackgroundTurnOptions, Brain, BrainTurnOptions, PendingConfirmation } from "../types";
-import { turnCancellationContinuesConversation } from "../types";
 import { dialBackMemo, matchCallMe, SpeculativeSideEffectError } from "../call-intent";
 import { log } from "../logger";
 import { BrainTurnContext } from "./turn-context";
@@ -204,7 +203,7 @@ const STRICT_VERB = "let me (?:talk|speak) (?:to|with)|switch(?: me)?(?: over)? 
 // fall through to the classifier instead of dead-ending at the roster.
 const LOOSE_VERB = "(?:talk|speak) (?:to|with)|put|get me|give me|pass me (?:over |through )?to|hand me (?:over )?to|patch me (?:through |over )?to";
 const PIN_RE = new RegExp(`^${LEAD_IN}${ASK_WRAP}(?:(${STRICT_VERB})|(?:${LOOSE_VERB}))\\s+(?:the\\s+)?(?!me\\b|you\\b|us\\b)(.{1,60}?)(?:\\s+on(?: the line)?)?(?:\\s+please)?$`, "i");
-const RELEASE_RE = new RegExp(`^${LEAD_IN}(?:thanks\\s+|thank you\\s+)?(?:(?:go |switch )?back to (?:you|cicero|jarvis)|(?:cicero|jarvis) come back|switch back|that(?:'s| is) all(?: for now)?|hang up|end (?:the )?(?:call|transfer))(?:\\s+please)?$`, "i");
+const RELEASE_RE = new RegExp(`^${LEAD_IN}(?:thanks\\s+|thank you\\s+)?(?:(?:go |switch )?back to (?:you|cicero|jarvis)|(?:cicero|jarvis) come back|switch back|that(?:'s| is) all(?: for now)?|hang up|end (?:the )?(?:call|transfer)|never\\s?mind(?: (?:about )?(?:that|it))?|forget (?:it|that))(?:\\s+please)?$`, "i");
 // Roll call: every employee checks in, each sentence rendered in that lane's
 // own voice (the voice queue below feeds activeLaneVoice per sentence).
 // "Group call" style requests land here too — there's no conference mode, so
@@ -605,16 +604,11 @@ export class SwitchboardBrain implements Brain {
   }
 
   /**
-   * True when this turn was cancelled but the conversation carries on, so a
-   * pending cold transfer should wait for the successor turn instead of being
-   * dropped. Both signals are consulted: a switchboard-internal supersession
-   * aborts `signal`, while a transport barge-in aborts `callerSignal`.
+   * The conversation ended, or the operator called the work off. A transfer
+   * that is still starting must not steer whatever is said next.
    */
-  private isContinuingCancellation(turn: AcceptedTurn): boolean {
-    if (turn.signal.reason instanceof SwitchboardTurnSupersededError) return true;
-    if (turnCancellationContinuesConversation(turn.signal.reason)) return true;
-    return turn.callerSignal?.aborted === true
-      && turnCancellationContinuesConversation(turn.callerSignal.reason);
+  dropDeferredWork(): void {
+    this.clearPendingTransfer();
   }
 
   private clearPendingTransfer(expected?: PendingTransfer): void {
@@ -628,14 +622,14 @@ export class SwitchboardBrain implements Brain {
     pending.detachAbort();
     pending.owner = turn;
     pending.disposition = "owned";
+    // Any cancellation of the owning turn parks the transfer for the next turn
+    // to adopt. Whether the conversation is actually over is not knowable from
+    // the abort reason — see Brain.dropDeferredWork, which is how a transport
+    // says so.
     const onAbort = (): void => {
       if (this.pendingTransfer !== pending || pending.owner !== turn) return;
-      if (this.isContinuingCancellation(turn)) {
-        pending.disposition = "awaiting-successor";
-        pending.detachAbort();
-      } else {
-        this.clearPendingTransfer(pending);
-      }
+      pending.disposition = "awaiting-successor";
+      pending.detachAbort();
     };
     turn.signal.addEventListener("abort", onAbort, { once: true });
     turn.callerSignal?.addEventListener("abort", onAbort, { once: true });

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -1,4 +1,5 @@
 import type { BackgroundTurnOptions, Brain, BrainTurnOptions, PendingConfirmation } from "../types";
+import { TURN_SUPERSEDED_BY_NEWER } from "../types";
 import { dialBackMemo, matchCallMe, SpeculativeSideEffectError } from "../call-intent";
 import { log } from "../logger";
 import { BrainTurnContext } from "./turn-context";
@@ -81,6 +82,16 @@ interface AcceptedTurn {
   settled: boolean;
   detachAbort: () => void;
   detachCaller: () => void;
+}
+
+interface PendingTransfer {
+  readonly lane: string;
+  /** The accepted turn whose cancellation disposition controls this ask. */
+  owner: AcceptedTurn;
+  /** Retained only while waiting for the continuing conversation's next turn. */
+  disposition: "owned" | "awaiting-successor";
+  /** Cancellation listeners belong to this record and leave with it. */
+  detachAbort: () => void;
 }
 
 interface LaneStartLifecycle {
@@ -175,6 +186,7 @@ class LaneStartRetiredError extends Error {
     this.name = "LaneStartRetiredError";
   }
 }
+
 
 // Matched against a normalized utterance (commas stripped, whitespace collapsed,
 // trailing punctuation removed) so STT decoration ("I said, let me talk to the
@@ -324,7 +336,7 @@ export class SwitchboardBrain implements Brain {
    * asked, so the front desk stops answering as though they never did: a later
    * turn reports the wait, or completes the pin itself once the lane is up.
    */
-  private pendingTransfer: string | null = null;
+  private pendingTransfer: PendingTransfer | null = null;
   /** Cold starts outlive initiating turns and are shared by concurrent callers. */
   private laneStarts = new Map<string, LaneStartLifecycle>();
   /** Cleanup calls coalesce when a failing start races global shutdown. */
@@ -592,6 +604,60 @@ export class SwitchboardBrain implements Brain {
     if (this.acceptedTurn === turn) this.acceptedTurn = null;
   }
 
+  private isContinuingSupersession(turn: AcceptedTurn): boolean {
+    if (turn.signal.reason instanceof SwitchboardTurnSupersededError) return true;
+    return turn.callerSignal?.aborted === true
+      && turn.callerSignal.reason instanceof Error
+      && turn.callerSignal.reason.message === TURN_SUPERSEDED_BY_NEWER;
+  }
+
+  private clearPendingTransfer(expected?: PendingTransfer): void {
+    const pending = this.pendingTransfer;
+    if (pending === null || (expected !== undefined && pending !== expected)) return;
+    pending.detachAbort();
+    this.pendingTransfer = null;
+  }
+
+  private ownPendingTransfer(pending: PendingTransfer, turn: AcceptedTurn): void {
+    pending.detachAbort();
+    pending.owner = turn;
+    pending.disposition = "owned";
+    const onAbort = (): void => {
+      if (this.pendingTransfer !== pending || pending.owner !== turn) return;
+      if (this.isContinuingSupersession(turn)) {
+        pending.disposition = "awaiting-successor";
+        pending.detachAbort();
+      } else {
+        this.clearPendingTransfer(pending);
+      }
+    };
+    turn.signal.addEventListener("abort", onAbort, { once: true });
+    turn.callerSignal?.addEventListener("abort", onAbort, { once: true });
+    pending.detachAbort = () => {
+      turn.signal.removeEventListener("abort", onAbort);
+      turn.callerSignal?.removeEventListener("abort", onAbort);
+    };
+    if (turn.signal.aborted || turn.callerSignal?.aborted) onAbort();
+  }
+
+  private setPendingTransfer(lane: string, turn: AcceptedTurn): void {
+    this.clearPendingTransfer();
+    const pending: PendingTransfer = {
+      lane,
+      owner: turn,
+      disposition: "owned",
+      detachAbort: () => {},
+    };
+    this.pendingTransfer = pending;
+    this.ownPendingTransfer(pending, turn);
+  }
+
+  private adoptPendingTransfer(turn: AcceptedTurn): void {
+    const pending = this.pendingTransfer;
+    if (pending === null || pending.owner === turn) return;
+    this.ownPendingTransfer(pending, turn);
+  }
+
   private abortAcceptedTurn(turn: AcceptedTurn, reason: unknown): void {
     if (turn.settled) return;
     if (!turn.superseded.signal.aborted) turn.superseded.abort(reason);
@@ -801,15 +867,20 @@ export class SwitchboardBrain implements Brain {
       // mind" has to be able to call it off — otherwise the hold introduced by
       // resolvePendingTransfer() would be the one thing the user cannot cancel.
       if (this.pendingTransfer !== null) {
-        const dropped = this.pendingTransfer;
-        this.pendingTransfer = null;
+        const dropped = this.pendingTransfer.lane;
+        this.clearPendingTransfer();
         log("info", `switchboard: dropped the pending transfer to ${dropped}`);
         return `Alright — I'll leave ${workingName(dropped, this.lanes[dropped])} out of it.`;
       }
       return null; // "that's all" mid-chat with Cicero is just a turn
     }
     const released = this.active;
+    const dropped = this.pendingTransfer?.lane ?? null;
+    this.clearPendingTransfer();
     log("info", `switchboard: released ${released} — back to the front desk`);
+    if (dropped !== null) {
+      log("info", `switchboard: dropped the pending transfer to ${dropped}`);
+    }
     this.active = null;
     // The front desk never heard the lane conversation, so the memo carries
     // the tail of what it missed (the mirror of the handoff briefing a lane
@@ -824,7 +895,9 @@ export class SwitchboardBrain implements Brain {
       : "";
     this.laneLog = [];
     this.leaveMemo(`System note: the user just ended a side conversation with ${name} and returned to the main line.${recap}`);
-    return "Back with you.";
+    return dropped === null
+      ? "Back with you."
+      : `Back with you — and I'll leave ${workingName(dropped, this.lanes[dropped])} out of it.`;
   }
 
   /**
@@ -897,9 +970,10 @@ export class SwitchboardBrain implements Brain {
    * pins on the live lease, so no output is published by the dead turn.
    */
   private async resolvePendingTransfer(turn: AcceptedTurn): Promise<string | null> {
-    const lane = this.pendingTransfer;
-    if (lane === null || !this.lanes[lane]) return null;
-    if (this.active === lane) { this.pendingTransfer = null; return null; }
+    const pending = this.pendingTransfer;
+    if (pending === null || !this.lanes[pending.lane]) return null;
+    const lane = pending.lane;
+    if (this.active === lane) { this.clearPendingTransfer(); return null; }
     const name = workingName(lane, this.lanes[lane]);
     // Up at last — this turn completes the handoff the earlier one couldn't.
     if (this.started.has(lane)) return this.pinLane(lane, turn);
@@ -908,7 +982,7 @@ export class SwitchboardBrain implements Brain {
     // a "still coming" ack must never outlive the start it describes, or the
     // user holds for a lane that is never going to arrive.
     if (!starting || starting.retired) {
-      this.pendingTransfer = null;
+      this.clearPendingTransfer();
       return `I couldn't reach ${lane} right now.`;
     }
     return `Still getting ${name} on the line — one moment.`;
@@ -945,7 +1019,7 @@ export class SwitchboardBrain implements Brain {
         // seconds and the user, hearing silence, speaks again. Record the ask
         // BEFORE waiting so a barge-in that kills this turn cannot erase the
         // fact that a transfer was requested.
-        this.pendingTransfer = lane;
+        this.setPendingTransfer(lane, turn);
         await raceWithSignal(this.startLane(lane), turn.signal);
         this.assertAcceptedTurn(turn);
       }
@@ -953,14 +1027,14 @@ export class SwitchboardBrain implements Brain {
       // Supersession/caller cancellation is control flow, not a failed lane
       // start to translate into a stale spoken acknowledgment.
       this.assertAcceptedTurn(turn);
-      this.pendingTransfer = null;
+      this.clearPendingTransfer();
       return `I couldn't reach ${lane} right now.`;
     }
     // Any pin that RAN to a conclusion resolves the pending state — including a
     // pin of some other lane, which is the user changing their mind ("get the
     // worker… no, the coder"). Only supersession leaves it standing, and that
     // path rethrows above without reaching here.
-    this.pendingTransfer = null;
+    this.clearPendingTransfer();
     this.assertAcceptedTurn(turn);
     if (!this.started.has(lane)) return `I couldn't reach ${lane} right now.`;
     // Programmatic call context is held locally across a cold start. Only the
@@ -1428,6 +1502,7 @@ export class SwitchboardBrain implements Brain {
     options: BrainTurnOptions,
   ): Promise<string | "standup" | null> {
     this.assertAcceptedTurn(turn);
+    this.adoptPendingTransfer(turn);
     const m = normalizeUtterance(message);
     const pendingAck = this.relayPendingConfirmation(m);
     if (pendingAck !== null) return pendingAck;
@@ -1690,7 +1765,7 @@ export class SwitchboardBrain implements Brain {
     this.personaInstalled.clear();
     // A transfer asked for before this boundary is void: the lane it named no
     // longer exists in the form that was requested.
-    this.pendingTransfer = null;
+    this.clearPendingTransfer();
     this.control = false;
     this.lastExchange = null;
     this.laneLog = [];
@@ -1725,7 +1800,7 @@ export class SwitchboardBrain implements Brain {
     this.laneLog = [];
     // Same boundary rule as stop(): a transfer asked for before the restart is
     // void — its cold start is about to be retired out from under it.
-    this.pendingTransfer = null;
+    this.clearPendingTransfer();
 
     const started = [...this.started];
     const pending = [...this.laneStarts.entries()];

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -317,6 +317,14 @@ export class SwitchboardBrain implements Brain {
   /** Pinned lane name, or null = the front desk (primary). */
   private active: string | null = null;
   private started = new Set<string>();
+  /**
+   * A transfer whose lane was still cold when its turn ended. The request is
+   * NOT resurrected — a superseded turn must never publish into a newer one,
+   * so the dead turn neither pins nor briefs. This only records that the user
+   * asked, so the front desk stops answering as though they never did: a later
+   * turn reports the wait, or completes the pin itself once the lane is up.
+   */
+  private pendingTransfer: string | null = null;
   /** Cold starts outlive initiating turns and are shared by concurrent callers. */
   private laneStarts = new Map<string, LaneStartLifecycle>();
   /** Cleanup calls coalesce when a failing start races global shutdown. */
@@ -788,7 +796,18 @@ export class SwitchboardBrain implements Brain {
 
   private doRelease(turn: AcceptedTurn): string | null {
     this.assertAcceptedTurn(turn);
-    if (this.active === null) return null; // "that's all" mid-chat with Cicero is just a turn
+    if (this.active === null) {
+      // Nobody is on the line, but a cold transfer may still be coming. "Never
+      // mind" has to be able to call it off — otherwise the hold introduced by
+      // resolvePendingTransfer() would be the one thing the user cannot cancel.
+      if (this.pendingTransfer !== null) {
+        const dropped = this.pendingTransfer;
+        this.pendingTransfer = null;
+        log("info", `switchboard: dropped the pending transfer to ${dropped}`);
+        return `Alright — I'll leave ${workingName(dropped, this.lanes[dropped])} out of it.`;
+      }
+      return null; // "that's all" mid-chat with Cicero is just a turn
+    }
     const released = this.active;
     log("info", `switchboard: released ${released} — back to the front desk`);
     this.active = null;
@@ -871,6 +890,30 @@ export class SwitchboardBrain implements Brain {
     return lifecycle.promise;
   }
 
+  /**
+   * Answer for a transfer whose cold start outlived the turn that asked for it.
+   * Returns null when there is nothing outstanding, so an ordinary turn is
+   * untouched. This runs on the CURRENT turn — it reads switchboard state and
+   * pins on the live lease, so no output is published by the dead turn.
+   */
+  private async resolvePendingTransfer(turn: AcceptedTurn): Promise<string | null> {
+    const lane = this.pendingTransfer;
+    if (lane === null || !this.lanes[lane]) return null;
+    if (this.active === lane) { this.pendingTransfer = null; return null; }
+    const name = workingName(lane, this.lanes[lane]);
+    // Up at last — this turn completes the handoff the earlier one couldn't.
+    if (this.started.has(lane)) return this.pinLane(lane, turn);
+    const starting = this.laneStarts.get(lane);
+    // The start is gone without the lane having started: it failed. Say so —
+    // a "still coming" ack must never outlive the start it describes, or the
+    // user holds for a lane that is never going to arrive.
+    if (!starting || starting.retired) {
+      this.pendingTransfer = null;
+      return `I couldn't reach ${lane} right now.`;
+    }
+    return `Still getting ${name} on the line — one moment.`;
+  }
+
   private async pinLane(
     lane: string,
     turn: AcceptedTurn,
@@ -898,6 +941,11 @@ export class SwitchboardBrain implements Brain {
           def.brain.injectContext(def.persona);
           this.personaInstalled.add(lane);
         }
+        // The wait below can outlast this turn: a lane cold start runs for
+        // seconds and the user, hearing silence, speaks again. Record the ask
+        // BEFORE waiting so a barge-in that kills this turn cannot erase the
+        // fact that a transfer was requested.
+        this.pendingTransfer = lane;
         await raceWithSignal(this.startLane(lane), turn.signal);
         this.assertAcceptedTurn(turn);
       }
@@ -905,8 +953,14 @@ export class SwitchboardBrain implements Brain {
       // Supersession/caller cancellation is control flow, not a failed lane
       // start to translate into a stale spoken acknowledgment.
       this.assertAcceptedTurn(turn);
+      this.pendingTransfer = null;
       return `I couldn't reach ${lane} right now.`;
     }
+    // Any pin that RAN to a conclusion resolves the pending state — including a
+    // pin of some other lane, which is the user changing their mind ("get the
+    // worker… no, the coder"). Only supersession leaves it standing, and that
+    // path rethrows above without reaching here.
+    this.pendingTransfer = null;
     this.assertAcceptedTurn(turn);
     if (!this.started.has(lane)) return `I couldn't reach ${lane} right now.`;
     // Programmatic call context is held locally across a cold start. Only the
@@ -1410,6 +1464,13 @@ export class SwitchboardBrain implements Brain {
     this.assertAcceptedTurn(turn);
     const routed = await this.actOnIntent(label, m, turn, options);
     this.assertAcceptedTurn(turn);
+    if (routed === null) {
+      // Last stop before the front desk answers: if a transfer is still in
+      // flight, say so rather than replying as though nobody asked.
+      const held = await this.resolvePendingTransfer(turn);
+      this.assertAcceptedTurn(turn);
+      if (held !== null) return held;
+    }
     // A normal brain turn ends the "again" context — a later bare "again"
     // refers to the conversation, not to a roll call from minutes ago.
     if (routed === null) this.lastGroupAction = null;
@@ -1627,6 +1688,9 @@ export class SwitchboardBrain implements Brain {
     this.active = null;
     this.started.clear();
     this.personaInstalled.clear();
+    // A transfer asked for before this boundary is void: the lane it named no
+    // longer exists in the form that was requested.
+    this.pendingTransfer = null;
     this.control = false;
     this.lastExchange = null;
     this.laneLog = [];
@@ -1659,6 +1723,9 @@ export class SwitchboardBrain implements Brain {
     this.control = false;
     this.lastExchange = null;
     this.laneLog = [];
+    // Same boundary rule as stop(): a transfer asked for before the restart is
+    // void — its cold start is about to be retired out from under it.
+    this.pendingTransfer = null;
 
     const started = [...this.started];
     const pending = [...this.laneStarts.entries()];

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -1,5 +1,5 @@
 import type { BackgroundTurnOptions, Brain, BrainTurnOptions, PendingConfirmation } from "../types";
-import { TURN_SUPERSEDED_BY_NEWER } from "../types";
+import { turnCancellationContinuesConversation } from "../types";
 import { dialBackMemo, matchCallMe, SpeculativeSideEffectError } from "../call-intent";
 import { log } from "../logger";
 import { BrainTurnContext } from "./turn-context";
@@ -604,11 +604,17 @@ export class SwitchboardBrain implements Brain {
     if (this.acceptedTurn === turn) this.acceptedTurn = null;
   }
 
-  private isContinuingSupersession(turn: AcceptedTurn): boolean {
+  /**
+   * True when this turn was cancelled but the conversation carries on, so a
+   * pending cold transfer should wait for the successor turn instead of being
+   * dropped. Both signals are consulted: a switchboard-internal supersession
+   * aborts `signal`, while a transport barge-in aborts `callerSignal`.
+   */
+  private isContinuingCancellation(turn: AcceptedTurn): boolean {
     if (turn.signal.reason instanceof SwitchboardTurnSupersededError) return true;
+    if (turnCancellationContinuesConversation(turn.signal.reason)) return true;
     return turn.callerSignal?.aborted === true
-      && turn.callerSignal.reason instanceof Error
-      && turn.callerSignal.reason.message === TURN_SUPERSEDED_BY_NEWER;
+      && turnCancellationContinuesConversation(turn.callerSignal.reason);
   }
 
   private clearPendingTransfer(expected?: PendingTransfer): void {
@@ -624,7 +630,7 @@ export class SwitchboardBrain implements Brain {
     pending.disposition = "owned";
     const onAbort = (): void => {
       if (this.pendingTransfer !== pending || pending.owner !== turn) return;
-      if (this.isContinuingSupersession(turn)) {
+      if (this.isContinuingCancellation(turn)) {
         pending.disposition = "awaiting-successor";
         pending.detachAbort();
       } else {

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -344,6 +344,12 @@ function normalizeRef(raw: string): string {
 export class SwitchboardBrain implements Brain {
   /** Pinned lane name, or null = the front desk (primary). */
   private active: string | null = null;
+  /**
+   * A cold transfer can pin after its microphone has gone inactive but before
+   * the last live turn settles. The later conversation-end drop must release
+   * that pin without changing the persistence of an ordinary warm transfer.
+   */
+  private activeFromDeferredTransfer = false;
   private started = new Set<string>();
   /**
    * A transfer whose lane was still cold when its turn ended. The request is
@@ -632,7 +638,11 @@ export class SwitchboardBrain implements Brain {
     // alone would still let it pin the lane seconds later — steering a
     // conversation that had already ended. See pinLane.
     this.deferredGeneration++;
-    this.clearPendingTransfer();
+    if (this.activeFromDeferredTransfer) {
+      this.releaseActiveLane(false);
+    } else {
+      this.clearPendingTransfer();
+    }
   }
 
   /**
@@ -916,7 +926,23 @@ export class SwitchboardBrain implements Brain {
       }
       return null; // "that's all" mid-chat with Cicero is just a turn
     }
+    const dropped = this.pendingTransfer?.lane ?? null;
+    this.releaseActiveLane(true);
+    return dropped === null
+      ? "Back with you."
+      : `Back with you — and I'll leave ${workingName(dropped, this.lanes[dropped])} out of it.`;
+  }
+
+  /**
+   * `memo` is false when the conversation itself ended rather than returning to
+   * the front desk. The note below says the user came back to the main line,
+   * which did not happen, and it would carry the finished conversation's tail
+   * into whichever unrelated conversation answered next — the same leak across
+   * a conversation boundary that dropping the transfer exists to prevent.
+   */
+  private releaseActiveLane(memo: boolean): void {
     const released = this.active;
+    if (released === null) return;
     const dropped = this.pendingTransfer?.lane ?? null;
     this.clearPendingTransfer();
     log("info", `switchboard: released ${released} — back to the front desk`);
@@ -924,6 +950,7 @@ export class SwitchboardBrain implements Brain {
       log("info", `switchboard: dropped the pending transfer to ${dropped}`);
     }
     this.active = null;
+    this.activeFromDeferredTransfer = false;
     // The front desk never heard the lane conversation, so the memo carries
     // the tail of what it missed (the mirror of the handoff briefing a lane
     // gets on transfer). Recipient-neutral facts only: the one-shot channel
@@ -936,10 +963,9 @@ export class SwitchboardBrain implements Brain {
           .join("\n")}`
       : "";
     this.laneLog = [];
-    this.leaveMemo(`System note: the user just ended a side conversation with ${name} and returned to the main line.${recap}`);
-    return dropped === null
-      ? "Back with you."
-      : `Back with you — and I'll leave ${workingName(dropped, this.lanes[dropped])} out of it.`;
+    if (memo) {
+      this.leaveMemo(`System note: the user just ended a side conversation with ${name} and returned to the main line.${recap}`);
+    }
   }
 
   /**
@@ -1085,6 +1111,7 @@ export class SwitchboardBrain implements Brain {
     // pin of some other lane, which is the user changing their mind ("get the
     // worker… no, the coder"). Only supersession leaves it standing, and that
     // path rethrows above without reaching here.
+    const deferred = this.pendingTransfer?.lane === lane;
     this.clearPendingTransfer();
     this.assertAcceptedTurn(turn);
     if (!this.started.has(lane)) return `I couldn't reach ${lane} right now.`;
@@ -1104,6 +1131,7 @@ export class SwitchboardBrain implements Brain {
     // only an actual change of counterpart starts a fresh recap tail.
     if (this.active !== lane) this.laneLog = [];
     this.active = lane;
+    this.activeFromDeferredTransfer = deferred;
     log("info", `switchboard: pinned to ${lane}`);
     return def.greeting ?? `${lane[0].toUpperCase()}${lane.slice(1)} here.`;
   }
@@ -1816,6 +1844,7 @@ export class SwitchboardBrain implements Brain {
     // Reset routing before awaiting cleanup so no caller can observe or reuse a
     // stopped lane if start() is called again on this Switchboard instance.
     this.active = null;
+    this.activeFromDeferredTransfer = false;
     this.started.clear();
     this.personaInstalled.clear();
     // A transfer asked for before this boundary is void: the lane it named no
@@ -1896,7 +1925,10 @@ export class SwitchboardBrain implements Brain {
           } catch (err: unknown) {
             this.started.delete(name);
             this.personaInstalled.delete(name);
-            if (this.active === name) this.active = null;
+            if (this.active === name) {
+              this.active = null;
+              this.activeFromDeferredTransfer = false;
+            }
             await this.stopLane(name).catch((error: unknown) => {
               this.logLaneCleanupFailure(name, error);
             });

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -215,7 +215,12 @@ const STRICT_VERB = "let me (?:talk|speak) (?:to|with)|switch(?: me)?(?: over)? 
 // fall through to the classifier instead of dead-ending at the roster.
 const LOOSE_VERB = "(?:talk|speak) (?:to|with)|put|get me|give me|pass me (?:over |through )?to|hand me (?:over )?to|patch me (?:through |over )?to";
 const PIN_RE = new RegExp(`^${LEAD_IN}${ASK_WRAP}(?:(${STRICT_VERB})|(?:${LOOSE_VERB}))\\s+(?:the\\s+)?(?!me\\b|you\\b|us\\b)(.{1,60}?)(?:\\s+on(?: the line)?)?(?:\\s+please)?$`, "i");
-const RELEASE_RE = new RegExp(`^${LEAD_IN}(?:thanks\\s+|thank you\\s+)?(?:(?:go |switch )?back to (?:you|cicero|jarvis)|(?:cicero|jarvis) come back|switch back|that(?:'s| is) all(?: for now)?|hang up|end (?:the )?(?:call|transfer)|never\\s?mind(?: (?:about )?(?:that|it))?|forget (?:it|that))(?:\\s+please)?$`, "i");
+const RELEASE_RE = new RegExp(`^${LEAD_IN}(?:thanks\\s+|thank you\\s+)?(?:(?:go |switch )?back to (?:you|cicero|jarvis)|(?:cicero|jarvis) come back|switch back|that(?:'s| is) all(?: for now)?|hang up|end (?:the )?(?:call|transfer))(?:\\s+please)?$`, "i");
+// Calling off a transfer that has not connected yet. Deliberately NOT part of
+// RELEASE_RE: with somebody already on the line, "never mind" is something the
+// user is saying TO them ("never mind, I'll do it myself"), not an instruction
+// to hang up. It only means "cancel" while the line is still ringing.
+const CANCEL_PENDING_RE = new RegExp(`^${LEAD_IN}(?:never\\s?mind(?: (?:about )?(?:that|it))?|forget (?:it|that))(?:\\s+please)?$`, "i");
 // Roll call: every employee checks in, each sentence rendered in that lane's
 // own voice (the voice queue below feeds activeLaneVoice per sentence).
 // "Group call" style requests land here too — there's no conference mode, so
@@ -1115,6 +1120,10 @@ export class SwitchboardBrain implements Brain {
     const m = normalizeUtterance(message);
     if (ROLLCALL_RE.test(m)) return this.doRollcall(turn);
     if (RELEASE_RE.test(m)) return this.doRelease(turn);
+    // Only while nobody has picked up: see CANCEL_PENDING_RE.
+    if (this.active === null && this.pendingTransfer !== null && CANCEL_PENDING_RE.test(m)) {
+      return this.doRelease(turn);
+    }
     // Spoken dial-back ("call me", "have ada call me") — must beat PIN_RE:
     // "have ada call me" would otherwise read as a transfer to "ada call".
     if (this.callMe) {

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -963,6 +963,10 @@ export class SwitchboardBrain implements Brain {
           .join("\n")}`
       : "";
     this.laneLog = [];
+    // A conversation-end release is a boundary, so its last exchange cannot
+    // brief a lane in the next conversation. An ordinary return deliberately
+    // keeps it because the user is still in the same conversation.
+    if (!memo) this.lastExchange = null;
     if (memo) {
       this.leaveMemo(`System note: the user just ended a side conversation with ${name} and returned to the main line.${recap}`);
     }

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -346,8 +346,9 @@ export class SwitchboardBrain implements Brain {
   private active: string | null = null;
   /**
    * A cold transfer can pin after its microphone has gone inactive but before
-   * the last live turn settles. The later conversation-end drop must release
-   * that pin without changing the persistence of an ordinary warm transfer.
+   * the last live turn settles. Until the lane answers an ordinary turn, the
+   * later conversation-end drop must release that unused pin without changing
+   * the persistence of an established or ordinary warm transfer.
    */
   private activeFromDeferredTransfer = false;
   private started = new Set<string>();
@@ -1666,6 +1667,11 @@ export class SwitchboardBrain implements Brain {
     if (!reply.trim()) return;
     this.lastExchange = { speaker: this.active ?? "Cicero", user, reply };
     if (this.active !== null) {
+      // The greeting belongs to the transfer control path and never reaches
+      // this successful ordinary-answer boundary. Once the lane answers here,
+      // dropping the pin at conversation end would lose a line the operator
+      // actually used and make a cold transfer less sticky than a warm one.
+      this.activeFromDeferredTransfer = false;
       // Bounded before retained: the release recap needs a tail, not a log.
       this.laneLog.push({ user: clipText(user, 200), reply: clipText(reply, 240) });
       if (this.laneLog.length > SwitchboardBrain.LANE_LOG_TURNS) this.laneLog.shift();

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -83,8 +83,20 @@ interface AcceptedTurn {
   detachCaller: () => void;
 }
 
+/**
+ * Who asked for the transfer, which decides what a cancellation means.
+ *
+ * A conversational ask survives cancellation: the operator is mid-conversation
+ * and the next thing they say should still reach the lane they asked for. A
+ * programmatic ask does not: `transferTo`'s signal is documented to cancel
+ * startup AND prevent a late pin, so its caller must be able to call the whole
+ * thing off, not merely abandon this turn.
+ */
+type TransferOrigin = "conversation" | "programmatic";
+
 interface PendingTransfer {
   readonly lane: string;
+  readonly origin: TransferOrigin;
   /** The accepted turn whose cancellation disposition controls this ask. */
   owner: AcceptedTurn;
   /** Retained only while waiting for the continuing conversation's next turn. */
@@ -437,7 +449,7 @@ export class SwitchboardBrain implements Brain {
         }
       }
 
-      await this.pinLane(lane, turn, context);
+      await this.pinLane(lane, turn, context, "programmatic");
       this.assertAcceptedTurn(turn);
       if (this.active !== lane) return null; // lane failed to start — pin never took
       return workingName(lane, this.lanes[lane]);
@@ -622,12 +634,17 @@ export class SwitchboardBrain implements Brain {
     pending.detachAbort();
     pending.owner = turn;
     pending.disposition = "owned";
-    // Any cancellation of the owning turn parks the transfer for the next turn
-    // to adopt. Whether the conversation is actually over is not knowable from
-    // the abort reason — see Brain.dropDeferredWork, which is how a transport
-    // says so.
+    // Cancelling the owning turn parks a conversational transfer for the next
+    // turn to adopt. Whether the conversation is actually over is not knowable
+    // from the abort reason — see Brain.dropDeferredWork, which is how a
+    // transport says so. A programmatic transfer is the opposite: its caller's
+    // signal is documented to prevent a late pin, so cancellation is final.
     const onAbort = (): void => {
       if (this.pendingTransfer !== pending || pending.owner !== turn) return;
+      if (pending.origin === "programmatic") {
+        this.clearPendingTransfer(pending);
+        return;
+      }
       pending.disposition = "awaiting-successor";
       pending.detachAbort();
     };
@@ -640,10 +657,11 @@ export class SwitchboardBrain implements Brain {
     if (turn.signal.aborted || turn.callerSignal?.aborted) onAbort();
   }
 
-  private setPendingTransfer(lane: string, turn: AcceptedTurn): void {
+  private setPendingTransfer(lane: string, turn: AcceptedTurn, origin: TransferOrigin): void {
     this.clearPendingTransfer();
     const pending: PendingTransfer = {
       lane,
+      origin,
       owner: turn,
       disposition: "owned",
       detachAbort: () => {},
@@ -992,6 +1010,7 @@ export class SwitchboardBrain implements Brain {
     lane: string,
     turn: AcceptedTurn,
     explicitContext: string | null = null,
+    origin: TransferOrigin = "conversation",
   ): Promise<string> {
     this.assertAcceptedTurn(turn);
     const def = this.lanes[lane];
@@ -1019,7 +1038,7 @@ export class SwitchboardBrain implements Brain {
         // seconds and the user, hearing silence, speaks again. Record the ask
         // BEFORE waiting so a barge-in that kills this turn cannot erase the
         // fact that a transfer was requested.
-        this.setPendingTransfer(lane, turn);
+        this.setPendingTransfer(lane, turn, origin);
         await raceWithSignal(this.startLane(lane), turn.signal);
         this.assertAcceptedTurn(turn);
       }

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -353,6 +353,8 @@ export class SwitchboardBrain implements Brain {
    * turn reports the wait, or completes the pin itself once the lane is up.
    */
   private pendingTransfer: PendingTransfer | null = null;
+  /** Incremented by dropDeferredWork; see its comment and pinLane. */
+  private deferredGeneration = 0;
   /** Cold starts outlive initiating turns and are shared by concurrent callers. */
   private laneStarts = new Map<string, LaneStartLifecycle>();
   /** Cleanup calls coalesce when a failing start races global shutdown. */
@@ -625,7 +627,24 @@ export class SwitchboardBrain implements Brain {
    * that is still starting must not steer whatever is said next.
    */
   dropDeferredWork(): void {
+    // Bumped before the clear, and never by an ordinary release: a cold start
+    // already in flight has its own live turn signal, so clearing the record
+    // alone would still let it pin the lane seconds later — steering a
+    // conversation that had already ended. See pinLane.
+    this.deferredGeneration++;
     this.clearPendingTransfer();
+  }
+
+  /**
+   * What a pin says when the conversation it belonged to ended underneath it.
+   * Deliberately not the "I couldn't reach" line — the lane was reachable; the
+   * transfer was called off, and reporting a failure that did not happen would
+   * be the wrong thing for a programmatic caller to read.
+   */
+  private calledOffReply(lane: string): string {
+    this.clearPendingTransfer();
+    log("info", `switchboard: transfer to ${lane} was called off mid-start`);
+    return `Never mind ${lane} then.`;
   }
 
   private clearPendingTransfer(expected?: PendingTransfer): void {
@@ -1019,8 +1038,15 @@ export class SwitchboardBrain implements Brain {
   ): Promise<string> {
     this.assertAcceptedTurn(turn);
     const def = this.lanes[lane];
+    // A cold start outlives the moment that asked for it, and the turn signal
+    // does not always die with the conversation: deactivating the microphone
+    // leaves its turn running. So the drop is tracked separately, and a pin
+    // that was called off mid-start abandons the lane instead of pinning it.
+    const generation = this.deferredGeneration;
+    const calledOff = (): boolean => this.deferredGeneration !== generation;
     try {
       while (!this.started.has(lane)) {
+        if (calledOff()) return this.calledOffReply(lane);
         const prior = this.laneStarts.get(lane);
         if (prior?.retired) {
           // A new board session must not overlap the old session's unresolved
@@ -1046,6 +1072,7 @@ export class SwitchboardBrain implements Brain {
         this.setPendingTransfer(lane, turn, origin);
         await raceWithSignal(this.startLane(lane), turn.signal);
         this.assertAcceptedTurn(turn);
+        if (calledOff()) return this.calledOffReply(lane);
       }
     } catch (err: unknown) {
       // Supersession/caller cancellation is control flow, not a failed lane

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,6 +2,12 @@ import { existsSync, readFileSync, rmSync, watch } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "node:os";
 import type { RuntimeConfig } from "./config";
+import {
+  DAEMON_STOPPING,
+  LOCAL_TURN_BARGE_IN,
+  LOCAL_TURN_STOPPED,
+  LOCAL_TURN_SUPERSEDED,
+} from "./types";
 import type { Listener, Router, Brain, BrainTurnOptions, Speaker, TerminalAdapter, RouterResult } from "./types";
 import { registerKnownSecrets, clearKnownSecrets } from "./redact";
 import { log, logStep, logError } from "./logger";
@@ -1892,7 +1898,7 @@ export class CiceroDaemon {
       });
       this.conversational.onStopCommand(() => {
         this.pendingRecovery = null;
-        this.activeLocalTurn?.abort("stop command");
+        this.activeLocalTurn?.abort(LOCAL_TURN_STOPPED);
       });
     }
     // Headless: skip starting any local-mic capture (clap, conversational, hotkey).
@@ -1972,7 +1978,7 @@ export class CiceroDaemon {
   }
 
   private dispatchCommand(text: string): Promise<void> {
-    this.activeLocalTurn?.abort("superseded by a newer local turn");
+    this.activeLocalTurn?.abort(LOCAL_TURN_SUPERSEDED);
     const controller = new AbortController();
     this.activeLocalTurn = controller;
     let task!: Promise<void>;
@@ -2074,7 +2080,7 @@ export class CiceroDaemon {
     // mid-way through saying; the live speaking-text provider goes empty the
     // moment the speaker is interrupted below.
     this.conversational?.noteInterrupted(spoken.join(" "));
-    this.activeLocalTurn?.abort("barge-in");
+    this.activeLocalTurn?.abort(LOCAL_TURN_BARGE_IN);
     this.streamingSpeaker.interrupt();
   }
 
@@ -2852,7 +2858,7 @@ export class CiceroDaemon {
       log("info", `Shutdown voice-input cancellation failed: ${error instanceof Error ? error.message : String(error)}`);
     });
     this.lifecycleAbort.abort();
-    this.activeLocalTurn?.abort("daemon stopping");
+    this.activeLocalTurn?.abort(DAEMON_STOPPING);
     this.activeLocalTurn = null;
     this.lifecycle = "stopping";
     const stopping = this.stopAfterStartup(this.startPromise, ingressStop);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2102,7 +2102,11 @@ export class CiceroDaemon {
    */
   private anyInputSurfaceActive(): boolean {
     if (this.voiceDesiredActive) return true;
-    return (this.webVoice?.clientCount() ?? 0) > 0;
+    // Not `clientCount() > 0`: a browser that dropped its socket is still in the
+    // conversation for the length of its reconnect grace, and counting it as
+    // gone let a microphone deactivation during that window call off work the
+    // page would have come straight back to.
+    return this.webVoice?.conversationLive() === true;
   }
 
   /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1562,7 +1562,7 @@ export class CiceroDaemon {
         // deferred) becomes one-shot brain context, so "call me" or "what do
         // we do about that?" right after an announcement lands on-topic.
         onNotified: (text) => this.brain.injectContext(notificationTurnContext(text, new Date())),
-        onConversationEnded: () => { this.dropDeferredBrainWork(); },
+        onConversationEnded: () => { this.noteInputSurfaceDeparted(); },
         onDictate: async () => {
           if (!this.dictation) throw new Error("dictation is not enabled on this daemon");
           await this.dictation.toggle();
@@ -2094,6 +2094,29 @@ export class CiceroDaemon {
     try { this.brain.dropDeferredWork?.(); } catch { /* best-effort */ }
   }
 
+  /**
+   * True while the operator can still say something. Cicero is one assistant
+   * behind every surface — the same brain, switchboard and active lane — so a
+   * conversation is not over because one way in went away, only when the last
+   * one does.
+   */
+  private anyInputSurfaceActive(): boolean {
+    if (this.voiceDesiredActive) return true;
+    return (this.webVoice?.clientCount() ?? 0) > 0;
+  }
+
+  /**
+   * One way in went away (a browser closed, the microphone was deactivated).
+   * Deferred work belongs to the conversation, not to the surface that happened
+   * to carry it, so it survives while any other surface can still adopt it —
+   * otherwise closing an idle tab called off a transfer the operator was
+   * waiting on at the microphone, and vice versa.
+   */
+  private noteInputSurfaceDeparted(): void {
+    if (this.anyInputSurfaceActive()) return;
+    this.dropDeferredBrainWork();
+  }
+
   private finalizeStreamingTurn(text: string, result: RouterResult, signal: AbortSignal): boolean {
     if (signal.aborted || !this.streamingSpeaker) return false;
     this.conversational?.noteSpoken(this.streamingSpeaker.getSnapshot().spoken.join(" "));
@@ -2571,6 +2594,11 @@ export class CiceroDaemon {
     this.voiceDesiredActive = false;
     dashBus.setVoiceActive(false);
     this.beginVoiceInputHandoff();
+    // Every way of putting the microphone down lands here — "stop listening",
+    // the hotkey, the dashboard, a clap, a capture failure — so this is the one
+    // place that has to notice, rather than a list of them that will be
+    // incomplete again next time.
+    this.noteInputSurfaceDeparted();
   }
 
   /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1562,7 +1562,13 @@ export class CiceroDaemon {
         // deferred) becomes one-shot brain context, so "call me" or "what do
         // we do about that?" right after an announcement lands on-topic.
         onNotified: (text) => this.brain.injectContext(notificationTurnContext(text, new Date())),
-        onConversationEnded: () => { this.noteInputSurfaceDeparted(); },
+        onConversationEnded: (ending) => {
+          if (ending?.definitive) {
+            this.dropDeferredBrainWork();
+          } else {
+            this.noteInputSurfaceDeparted();
+          }
+        },
         onDictate: async () => {
           if (!this.dictation) throw new Error("dictation is not enabled on this daemon");
           await this.dictation.toggle();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1989,7 +1989,13 @@ export class CiceroDaemon {
         }
       })
       .finally(() => {
-        if (this.activeLocalTurn === controller) this.activeLocalTurn = null;
+        if (this.activeLocalTurn === controller) {
+          this.activeLocalTurn = null;
+          // A browser departure may have been suppressed while this turn was
+          // still the conversation. Re-evaluate at the owned completion point
+          // so its deferred work does not survive after the turn itself ends.
+          this.noteInputSurfaceDeparted();
+        }
         this.localTurnTasks.delete(task);
       });
     this.localTurnTasks.add(task);
@@ -2095,13 +2101,19 @@ export class CiceroDaemon {
   }
 
   /**
-   * True while the operator can still say something. Cicero is one assistant
-   * behind every surface — the same brain, switchboard and active lane — so a
-   * conversation is not over because one way in went away, only when the last
-   * one does.
+   * True while an operator surface or its accepted turn is still active. Cicero
+   * is one assistant behind every surface — the same brain, switchboard and
+   * active lane — so a conversation is not over because one way in went away,
+   * only when the last surface and its owned work are done.
    */
   private anyInputSurfaceActive(): boolean {
     if (this.voiceDesiredActive) return true;
+    // A running turn is the conversation even if the surface that delivered
+    // it has just gone away. Ignoring that interval let the last browser close
+    // call off a cold transfer while the local or operator-chat turn was still
+    // waiting to adopt it.
+    if (this.activeLocalTurn !== null) return true;
+    if ((this.webVoice?.activeJobCount() ?? 0) > 0) return true;
     // Not `clientCount() > 0`: a browser that dropped its socket is still in the
     // conversation for the length of its reconnect grace, and counting it as
     // gone let a microphone deactivation during that window call off work the

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1563,11 +1563,11 @@ export class CiceroDaemon {
         // we do about that?" right after an announcement lands on-topic.
         onNotified: (text) => this.brain.injectContext(notificationTurnContext(text, new Date())),
         onConversationEnded: (ending) => {
-          if (ending?.definitive) {
-            this.dropDeferredBrainWork();
-          } else {
-            this.noteInputSurfaceDeparted();
-          }
+          // A fresh web conversation proves that the older web job cannot own
+          // the work it replaces, but says nothing about a local turn or the
+          // operator still speaking at the microphone. Skipping those local
+          // signals too would let an unrelated browser discard their transfer.
+          this.noteInputSurfaceDeparted(ending?.definitive ? "web-job" : undefined);
         },
         onDictate: async () => {
           if (!this.dictation) throw new Error("dictation is not enabled on this daemon");
@@ -2112,14 +2112,14 @@ export class CiceroDaemon {
    * active lane — so a conversation is not over because one way in went away,
    * only when the last surface and its owned work are done.
    */
-  private anyInputSurfaceActive(): boolean {
+  private anyInputSurfaceActive(ignoredSignal?: "web-job"): boolean {
     if (this.voiceDesiredActive) return true;
     // A running turn is the conversation even if the surface that delivered
     // it has just gone away. Ignoring that interval let the last browser close
     // call off a cold transfer while the local or operator-chat turn was still
     // waiting to adopt it.
     if (this.activeLocalTurn !== null) return true;
-    if ((this.webVoice?.activeJobCount() ?? 0) > 0) return true;
+    if (ignoredSignal !== "web-job" && (this.webVoice?.activeJobCount() ?? 0) > 0) return true;
     // Not `clientCount() > 0`: a browser that dropped its socket is still in the
     // conversation for the length of its reconnect grace, and counting it as
     // gone let a microphone deactivation during that window call off work the
@@ -2134,8 +2134,8 @@ export class CiceroDaemon {
    * otherwise closing an idle tab called off a transfer the operator was
    * waiting on at the microphone, and vice versa.
    */
-  private noteInputSurfaceDeparted(): void {
-    if (this.anyInputSurfaceActive()) return;
+  private noteInputSurfaceDeparted(ignoredSignal?: "web-job"): void {
+    if (this.anyInputSurfaceActive(ignoredSignal)) return;
     this.dropDeferredBrainWork();
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,12 +2,6 @@ import { existsSync, readFileSync, rmSync, watch } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "node:os";
 import type { RuntimeConfig } from "./config";
-import {
-  DAEMON_STOPPING,
-  LOCAL_TURN_BARGE_IN,
-  LOCAL_TURN_STOPPED,
-  LOCAL_TURN_SUPERSEDED,
-} from "./types";
 import type { Listener, Router, Brain, BrainTurnOptions, Speaker, TerminalAdapter, RouterResult } from "./types";
 import { registerKnownSecrets, clearKnownSecrets } from "./redact";
 import { log, logStep, logError } from "./logger";
@@ -1568,6 +1562,7 @@ export class CiceroDaemon {
         // deferred) becomes one-shot brain context, so "call me" or "what do
         // we do about that?" right after an announcement lands on-topic.
         onNotified: (text) => this.brain.injectContext(notificationTurnContext(text, new Date())),
+        onConversationEnded: () => { this.dropDeferredBrainWork(); },
         onDictate: async () => {
           if (!this.dictation) throw new Error("dictation is not enabled on this daemon");
           await this.dictation.toggle();
@@ -1898,7 +1893,12 @@ export class CiceroDaemon {
       });
       this.conversational.onStopCommand(() => {
         this.pendingRecovery = null;
-        this.activeLocalTurn?.abort(LOCAL_TURN_STOPPED);
+        this.activeLocalTurn?.abort("stop command");
+        // A stop-class barge-in fires the interrupt callback first, so this
+        // controller is usually already aborted with "barge-in" and the reason
+        // above never lands. Telling the brain directly is what actually calls
+        // off work it was holding for this conversation.
+        this.dropDeferredBrainWork();
       });
     }
     // Headless: skip starting any local-mic capture (clap, conversational, hotkey).
@@ -1978,7 +1978,7 @@ export class CiceroDaemon {
   }
 
   private dispatchCommand(text: string): Promise<void> {
-    this.activeLocalTurn?.abort(LOCAL_TURN_SUPERSEDED);
+    this.activeLocalTurn?.abort("superseded by a newer local turn");
     const controller = new AbortController();
     this.activeLocalTurn = controller;
     let task!: Promise<void>;
@@ -2080,8 +2080,18 @@ export class CiceroDaemon {
     // mid-way through saying; the live speaking-text provider goes empty the
     // moment the speaker is interrupted below.
     this.conversational?.noteInterrupted(spoken.join(" "));
-    this.activeLocalTurn?.abort(LOCAL_TURN_BARGE_IN);
+    this.activeLocalTurn?.abort("barge-in");
     this.streamingSpeaker.interrupt();
+  }
+
+  /**
+   * Tell the brain that work it deferred for this conversation must not be
+   * carried into a later turn. Fire-and-forget: a brain without the capability
+   * has nothing deferred, and a throw here must not take down a stop or a
+   * shutdown.
+   */
+  private dropDeferredBrainWork(): void {
+    try { this.brain.dropDeferredWork?.(); } catch { /* best-effort */ }
   }
 
   private finalizeStreamingTurn(text: string, result: RouterResult, signal: AbortSignal): boolean {
@@ -2858,8 +2868,9 @@ export class CiceroDaemon {
       log("info", `Shutdown voice-input cancellation failed: ${error instanceof Error ? error.message : String(error)}`);
     });
     this.lifecycleAbort.abort();
-    this.activeLocalTurn?.abort(DAEMON_STOPPING);
+    this.activeLocalTurn?.abort("daemon stopping");
     this.activeLocalTurn = null;
+    this.dropDeferredBrainWork();
     this.lifecycle = "stopping";
     const stopping = this.stopAfterStartup(this.startPromise, ingressStop);
     this.stopPromise = stopping;

--- a/src/types.ts
+++ b/src/types.ts
@@ -507,6 +507,21 @@ export interface Brain {
   restart(): Promise<void>;
   health(): Promise<boolean>;
   /** Lane switchboard: name of the pinned lane, or null at the front desk. */
+  /**
+   * Deferred work this brain is holding on the current conversation's behalf —
+   * a cold transfer that is still starting, say — must not be carried into a
+   * later turn. The transport calls this when the conversation ends or the
+   * operator calls the work off.
+   *
+   * It exists because a turn's abort reason cannot answer that question. The
+   * reason is fixed by the FIRST abort, while the disposition is often decided
+   * by a later event on the same turn: the browser sends `abort` and then
+   * closes its socket, and a spoken "stop" reaches the daemon as a barge-in
+   * followed by a stop command. Classifying by reason silently kept a transfer
+   * alive across both. Optional; brains holding nothing deferred omit it.
+   */
+  dropDeferredWork?(): void;
+
   activeLane?(): string | null;
   /** Lane switchboard: pin a lane by name/alias (typed dial-back routing).
    * Resolves the employee's working name, or null when nobody matched.
@@ -565,81 +580,4 @@ export interface TerminalAdapter {
   spawnTab(opts: SpawnTabOptions): Promise<Tab>;
   closeTab(id: string): Promise<void>;
   health(): Promise<{ ok: boolean; reason?: string }>;
-}
-
-/*
- * Turn-cancellation reasons a transport can raise, and — the part that matters —
- * whether each one means the CONVERSATION is continuing or going away. Both
- * voice surfaces are covered: the browser (src/web-voice/server.ts) and the
- * local microphone (src/daemon.ts).
- *
- * A brain needs that distinction, not the wording. `SwitchboardBrain` keeps a
- * pending cold transfer alive across a cancellation that leaves the speaker on
- * the line, so the next turn can finish the handoff, and drops it when the
- * conversation itself ends. Both failure modes are silent and neither is
- * cosmetic: classify a barge-in as terminal and transfers are discarded exactly
- * as in the incident this behaviour was written to fix; classify a teardown as
- * continuing and a stale ask can pin a lane in some later conversation that
- * never requested it.
- *
- * They live here because the transport and the brain have to agree, and they
- * previously agreed only by the same string literal being typed out in two
- * files.
- */
-
-/** A queued turn on the SAME connection superseded this one. */
-export const TURN_SUPERSEDED_BY_NEWER = "superseded by a newer turn";
-/**
- * The client asked to abort the active turn. Push-to-talk raises this BEFORE it
- * has the replacement audio to send, and the first abort fixes the reason, so a
- * later supersession cannot overwrite it — an ordinary barge-in arrives here,
- * not under TURN_SUPERSEDED_BY_NEWER.
- */
-export const TURN_ABORTED_BY_CLIENT = "turn aborted by client";
-/** The voice socket closed: this conversation is over. */
-export const VOICE_SOCKET_CLOSED = "voice socket closed";
-/** The voice server is shutting down: every conversation is over. */
-export const VOICE_SERVER_SHUTTING_DOWN = "web voice server shutting down";
-
-/*
- * The local microphone surface is a second transport with the same contract. It
- * aborts with bare strings rather than Errors, which is why the predicate below
- * accepts both.
- */
-
-/** A newer spoken turn arrived while this one was still running. */
-export const LOCAL_TURN_SUPERSEDED = "superseded by a newer local turn";
-/** The operator spoke over the reply — a barge-in, the speaker is still there. */
-export const LOCAL_TURN_BARGE_IN = "barge-in";
-/**
- * The operator said "stop". They are still on the line, but unlike a barge-in
- * this is an explicit cancellation of the work in flight, so a transfer they no
- * longer want must not survive it.
- */
-export const LOCAL_TURN_STOPPED = "stop command";
-/** The daemon is shutting down: every conversation is over. */
-export const DAEMON_STOPPING = "daemon stopping";
-
-const CONTINUING_CANCELLATION_REASONS: ReadonlySet<string> = new Set([
-  TURN_SUPERSEDED_BY_NEWER,
-  TURN_ABORTED_BY_CLIENT,
-  LOCAL_TURN_SUPERSEDED,
-  LOCAL_TURN_BARGE_IN,
-]);
-
-/**
- * True when a cancellation ends the TURN but not the conversation — the speaker
- * is still there and another turn is coming.
- *
- * Unrecognised reasons are treated as terminal on purpose. Of the two ways to be
- * wrong, dropping a transfer costs the user one repeated request inside a live
- * conversation, while retaining one can act on a later, unrelated conversation's
- * behalf. If you add a transport cancellation that leaves the speaker on the
- * line, add it here — otherwise transfers will quietly stop surviving it.
- */
-export function turnCancellationContinuesConversation(reason: unknown): boolean {
-  const message = reason instanceof Error
-    ? reason.message
-    : typeof reason === "string" ? reason : null;
-  return message !== null && CONTINUING_CANCELLATION_REASONS.has(message);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -566,3 +566,17 @@ export interface TerminalAdapter {
   closeTab(id: string): Promise<void>;
   health(): Promise<{ ok: boolean; reason?: string }>;
 }
+
+/**
+ * Abort reason a transport uses when a queued turn on the SAME connection has
+ * superseded the current one — an ordinary barge-in, as opposed to the
+ * conversation itself going away.
+ *
+ * It lives here because two modules have to agree on it and the failure mode is
+ * silent: `SwitchboardBrain` keeps a pending cold transfer alive across this
+ * reason so the successor turn can finish the handoff, and clears it for every
+ * other cancellation. If a transport reworded its own copy of this string, the
+ * switchboard would quietly start discarding transfers on every barge-in — the
+ * exact bug that behaviour was added to fix.
+ */
+export const TURN_SUPERSEDED_BY_NEWER = "superseded by a newer turn";

--- a/src/types.ts
+++ b/src/types.ts
@@ -567,16 +567,79 @@ export interface TerminalAdapter {
   health(): Promise<{ ok: boolean; reason?: string }>;
 }
 
-/**
- * Abort reason a transport uses when a queued turn on the SAME connection has
- * superseded the current one — an ordinary barge-in, as opposed to the
- * conversation itself going away.
+/*
+ * Turn-cancellation reasons a transport can raise, and — the part that matters —
+ * whether each one means the CONVERSATION is continuing or going away. Both
+ * voice surfaces are covered: the browser (src/web-voice/server.ts) and the
+ * local microphone (src/daemon.ts).
  *
- * It lives here because two modules have to agree on it and the failure mode is
- * silent: `SwitchboardBrain` keeps a pending cold transfer alive across this
- * reason so the successor turn can finish the handoff, and clears it for every
- * other cancellation. If a transport reworded its own copy of this string, the
- * switchboard would quietly start discarding transfers on every barge-in — the
- * exact bug that behaviour was added to fix.
+ * A brain needs that distinction, not the wording. `SwitchboardBrain` keeps a
+ * pending cold transfer alive across a cancellation that leaves the speaker on
+ * the line, so the next turn can finish the handoff, and drops it when the
+ * conversation itself ends. Both failure modes are silent and neither is
+ * cosmetic: classify a barge-in as terminal and transfers are discarded exactly
+ * as in the incident this behaviour was written to fix; classify a teardown as
+ * continuing and a stale ask can pin a lane in some later conversation that
+ * never requested it.
+ *
+ * They live here because the transport and the brain have to agree, and they
+ * previously agreed only by the same string literal being typed out in two
+ * files.
  */
+
+/** A queued turn on the SAME connection superseded this one. */
 export const TURN_SUPERSEDED_BY_NEWER = "superseded by a newer turn";
+/**
+ * The client asked to abort the active turn. Push-to-talk raises this BEFORE it
+ * has the replacement audio to send, and the first abort fixes the reason, so a
+ * later supersession cannot overwrite it — an ordinary barge-in arrives here,
+ * not under TURN_SUPERSEDED_BY_NEWER.
+ */
+export const TURN_ABORTED_BY_CLIENT = "turn aborted by client";
+/** The voice socket closed: this conversation is over. */
+export const VOICE_SOCKET_CLOSED = "voice socket closed";
+/** The voice server is shutting down: every conversation is over. */
+export const VOICE_SERVER_SHUTTING_DOWN = "web voice server shutting down";
+
+/*
+ * The local microphone surface is a second transport with the same contract. It
+ * aborts with bare strings rather than Errors, which is why the predicate below
+ * accepts both.
+ */
+
+/** A newer spoken turn arrived while this one was still running. */
+export const LOCAL_TURN_SUPERSEDED = "superseded by a newer local turn";
+/** The operator spoke over the reply — a barge-in, the speaker is still there. */
+export const LOCAL_TURN_BARGE_IN = "barge-in";
+/**
+ * The operator said "stop". They are still on the line, but unlike a barge-in
+ * this is an explicit cancellation of the work in flight, so a transfer they no
+ * longer want must not survive it.
+ */
+export const LOCAL_TURN_STOPPED = "stop command";
+/** The daemon is shutting down: every conversation is over. */
+export const DAEMON_STOPPING = "daemon stopping";
+
+const CONTINUING_CANCELLATION_REASONS: ReadonlySet<string> = new Set([
+  TURN_SUPERSEDED_BY_NEWER,
+  TURN_ABORTED_BY_CLIENT,
+  LOCAL_TURN_SUPERSEDED,
+  LOCAL_TURN_BARGE_IN,
+]);
+
+/**
+ * True when a cancellation ends the TURN but not the conversation — the speaker
+ * is still there and another turn is coming.
+ *
+ * Unrecognised reasons are treated as terminal on purpose. Of the two ways to be
+ * wrong, dropping a transfer costs the user one repeated request inside a live
+ * conversation, while retaining one can act on a later, unrelated conversation's
+ * behalf. If you add a transport cancellation that leaves the speaker on the
+ * line, add it here — otherwise transfers will quietly stop surviving it.
+ */
+export function turnCancellationContinuesConversation(reason: unknown): boolean {
+  const message = reason instanceof Error
+    ? reason.message
+    : typeof reason === "string" ? reason : null;
+  return message !== null && CONTINUING_CANCELLATION_REASONS.has(message);
+}

--- a/src/web-voice/page.ts
+++ b/src/web-voice/page.ts
@@ -736,21 +736,25 @@ function scheduleReconnect() {
   const delay = [1000, 2000, 5000][Math.min(reconnectAttempt, 2)];
   reconnectAttempt++;
   setStatus("reconnecting… (attempt " + reconnectAttempt + ")");
-  reconnectTimer = setTimeout(() => { reconnectTimer = null; if (convOn) connectWs(); }, delay);
+  reconnectTimer = setTimeout(() => { reconnectTimer = null; if (convOn) connectWs(true); }, delay);
 }
 // Coming back online / to the foreground: retry immediately, not on the timer.
 function retryNow() {
   if (!convOn || (ws && ws.readyState <= 1)) return;
   if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-  connectWs();
+  connectWs(true);
 }
 window.addEventListener("online", retryNow);
 document.addEventListener("visibilitychange", () => { if (!document.hidden) { retryNow(); requestWakeLock(); } });
 
-function connectWs() {
+// The resume flag separates an automatic reconnect from the operator pressing Start.
+// The server cannot tell them apart from the socket alone, and Stop pressed
+// during the backoff has no open socket to send its goodbye on — so a restart
+// would otherwise inherit the stopped conversation's deferred work.
+function connectWs(resume = false) {
   const scheme = location.protocol === "https:" ? "wss:" : "ws:";
   wsSessionId = "";
-  const sock = new WebSocket(scheme + "//" + location.host + "/ws?protocol=2&token=" + encodeURIComponent(TOKEN));
+  const sock = new WebSocket(scheme + "//" + location.host + "/ws?protocol=2&token=" + encodeURIComponent(TOKEN) + (resume ? "&resume=1" : ""));
   ws = sock;
   ws.binaryType = "arraybuffer";
   ws.onopen = () => { setDot(true); setStatus("connected — securing session…"); };

--- a/src/web-voice/page.ts
+++ b/src/web-voice/page.ts
@@ -831,6 +831,10 @@ function stopConversation() {
   reconnectAttempt = 0;
   if (pttBargeTimer) { clearTimeout(pttBargeTimer); pttBargeTimer = null; }
   abortActiveTurn();
+  // Tell the server this is the operator stopping, not the network dropping:
+  // the two are indistinguishable from a closed socket, and only this one means
+  // "call off anything you were still working on for me".
+  if (ws && ws.readyState === 1) { try { ws.send(JSON.stringify({ type: "bye" })); } catch (e) { /* ignore */ } }
   if (ws) { try { ws.close(); } catch (e) { /* ignore */ } ws = null; }
   wsSessionId = ""; captureTurnId = null;
   stopPlayback();

--- a/src/web-voice/page.ts
+++ b/src/web-voice/page.ts
@@ -813,7 +813,7 @@ async function ensureAudio() {
   }
 }
 
-async function startConversation() {
+async function startConversation(resume = false) {
   if (!TOKEN) {
     setStatus("authorization required — reopen the tokened Cicero URL once");
     return;
@@ -821,7 +821,7 @@ async function startConversation() {
   if (!(await ensureAudio())) return;
   if (audioCtx.state === "suspended") { try { await audioCtx.resume(); } catch (e) { /* ignore */ } }
   convOn = true; toggleLabel.textContent = "Stop conversation"; toggle.classList.add("on");
-  connectWs();
+  connectWs(resume);
   requestWakeLock();
 }
 
@@ -1065,7 +1065,7 @@ renderAuto();
         return;
       }
     }
-    await startConversation();
+    await startConversation(true);
     if (!convOn) {
       revealAutoStartFallback(); // preserve ensureAudio's useful mic error
       return;

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -63,6 +63,8 @@ interface WsData {
   protocol: 1 | 2;
   /** The page says this connection continues a conversation rather than starting one. */
   resume: boolean;
+  departed: boolean;
+  departureCloseTimer: ReturnType<typeof setTimeout> | null;
   busy: boolean;               // a turn is being processed right now
   // Latest input waiting to be processed (barge-in wins): a captured
   // utterance WAV, or a typed message ({type:"text"} control frame).
@@ -101,12 +103,15 @@ export interface WebVoiceServerOptions {
   /**
    * This voice conversation is over — the LAST voice socket closed, or the
    * server is shutting down. Every browser shares one brain and active lane, so
-   * this fires once for the shared conversation, not once per socket. The daemon uses it to tell the brain to drop work it was
-   * holding for the conversation, which the turn's abort reason cannot convey:
-   * the page sends `abort` and then closes, and the first abort fixes the
-   * reason, so the close is invisible to anything reading it. Fire-and-forget.
+   * this fires once for the shared conversation, not once per socket. The
+   * daemon uses it to tell the brain to drop work it was holding for the
+   * conversation, which the turn's abort reason cannot convey: the page sends
+   * `abort` and then closes, and the first abort fixes the reason, so the close
+   * is invisible to anything reading it. A definitive ending means a new
+   * conversation has arrived and the old work must be dropped even while its
+   * earlier job is still draining. Fire-and-forget.
    */
-  onConversationEnded?: () => void;
+  onConversationEnded?: (ending?: { definitive?: boolean }) => void;
   /**
    * How long to wait, after the last voice socket goes away, before deciding
    * the conversation is over. The PWA reconnects automatically (1s → 2s → 5s
@@ -285,6 +290,7 @@ const BODY_READ_TIMEOUT_MS = 5_000;
 /** Long enough to cover the page's 1s → 2s → 5s reconnect backoff several times over. */
 const DEFAULT_CONVERSATION_END_GRACE_MS = 30_000;
 const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 95_000;
+const GOODBYE_CLOSE_TIMEOUT_MS = 1_000;
 const MAX_BACKGROUND_WEB_JOBS = MAX_CONCURRENT_WEB_JOBS;
 const MAX_VOICE_NAME_CHARS = 128;
 const MAX_HEALTH_METRIC_CHARS = 128;
@@ -401,10 +407,16 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
   // would deliver it again once the job finished, so it is remembered and
   // re-reported at the release instead.
   let endReportedDuringJob = false;
-  const endConversationNow = (): void => {
+  const endConversationNow = (definitive = false): void => {
     cancelConversationEnd();
-    if (activeJobs > 0) endReportedDuringJob = true;
-    try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
+    if (definitive) {
+      endReportedDuringJob = false;
+    } else if (activeJobs > 0) {
+      endReportedDuringJob = true;
+    }
+    try {
+      opts.onConversationEnded?.(definitive ? { definitive: true } : undefined);
+    } catch { /* fire-and-forget */ }
   };
 
   const scheduleConversationEnd = (): void => {
@@ -1079,6 +1091,8 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
                 sessionId: crypto.randomUUID(),
                 protocol,
                 resume,
+                departed: false,
+                departureCloseTimer: null,
                 busy: false,
                 pending: null,
                 current: null,
@@ -1438,17 +1452,22 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           // armed while clients are connected (it re-checks on fire), so without
           // that condition a second device pressing Start would end a
           // conversation the first one is still in.
-          if (!ws.data.resume && clients.size === 0 && conversationEndTimer !== null) {
+          const startsNewConversation = !ws.data.resume && clients.size === 0;
+          if (startsNewConversation && conversationEndTimer !== null) {
             endConversationNow();
+          } else if (startsNewConversation && endReportedDuringJob) {
+            // This job predates the newly attached conversation, so it cannot
+            // keep the previous one's deferred transfer alive. Without a
+            // definitive ending, the replacement adopts that stale transfer.
+            endConversationNow(true);
           }
           sockets.add(ws);
           clients.add(ws);
           // An ending remembered while a job was still running is owed only
-          // until somebody is listening again. A socket can replace the one
-          // that departed before that job drains, and the drain then declines
-          // to consume the ending because a client is attached — so without
-          // this the debt outlives its own conversation and is finally paid by
-          // an unrelated later turn, whose deferred work it discards.
+          // until somebody is listening again. A resume continues that same
+          // conversation and cancels the debt; a fresh connection consumed it
+          // definitively above. Keeping either debt would let a later,
+          // unrelated socketless turn pay it and lose its own deferred work.
           endReportedDuringJob = false;
           if (ws.data.protocol === 2) {
             sendJson(ws, {
@@ -1495,6 +1514,12 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           if (!accepting) {
             protocolError(ws, "server shutting down");
             ws.close(1012, "Server shutting down");
+            return;
+          }
+          if (ws.data.departed) {
+            // The operator stopped this conversation. A frame arriving after
+            // goodbye belongs to no live conversation and must not start or
+            // continue a turn on the detached socket.
             return;
           }
           // Text frames are control messages: abort (barge-in) or a typed turn.
@@ -1566,7 +1591,25 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               // socket close. Waiting for close let a replacement socket join
               // first, after which neither event saw an empty room and the
               // stopped conversation survived into its replacement.
+              ws.data.departed = true;
               if (clients.delete(ws) && clients.size === 0) endConversationNow();
+              // Let the current ingress dispatch unwind before starting the
+              // close handshake; the terminal flag rejects frames already
+              // queued behind goodbye. The forced deadline keeps a peer that
+              // never completes that handshake from remaining server-owned.
+              ws.data.departureCloseTimer = setTimeout(() => {
+                ws.data.departureCloseTimer = null;
+                if (!sockets.has(ws)) return;
+                ws.data.departureCloseTimer = setTimeout(() => {
+                  ws.data.departureCloseTimer = null;
+                  if (!sockets.has(ws)) return;
+                  try {
+                    ws.terminate();
+                    sockets.delete(ws);
+                  } catch { /* shutdown or the close callback still owns cleanup */ }
+                }, GOODBYE_CLOSE_TIMEOUT_MS);
+                try { ws.close(1000, "Conversation ended"); } catch { /* the deadline will terminate it */ }
+              }, 0);
               return;
             }
             if (ws.data.protocol === 2 && msg.sessionId !== ws.data.sessionId) {
@@ -1697,6 +1740,10 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
         },
         close(ws) {
           if (ws.data.pendingClientSlot) pendingClients = Math.max(0, pendingClients - 1);
+          if (ws.data.departureCloseTimer !== null) {
+            clearTimeout(ws.data.departureCloseTimer);
+            ws.data.departureCloseTimer = null;
+          }
           sockets.delete(ws);
           const wasAttached = clients.delete(ws);
           abortTurn(ws.data.current, "voice socket closed");
@@ -1781,6 +1828,10 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       parked.length = 0;
 
       for (const ws of sockets) {
+        if (ws.data.departureCloseTimer !== null) {
+          clearTimeout(ws.data.departureCloseTimer);
+          ws.data.departureCloseTimer = null;
+        }
         abortTurn(ws.data.current, "web voice server shutting down");
         ws.data.pending = null;
         ws.data.latestProbeTurnId = null;

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -61,6 +61,8 @@ interface WsData {
   pendingClientSlot: boolean;
   sessionId: string;
   protocol: 1 | 2;
+  /** The page says this connection continues a conversation rather than starting one. */
+  resume: boolean;
   busy: boolean;               // a turn is being processed right now
   // Latest input waiting to be processed (barge-in wins): a captured
   // utterance WAV, or a typed message ({type:"text"} control frame).
@@ -1043,6 +1045,9 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           // pipeline but stay out of the persisted chat history.
           const record = url.searchParams.get("record") !== "0";
           const protocol = url.searchParams.get("protocol") === "2" ? 2 : 1;
+          // Set by the page's automatic reconnect paths only; see the `open`
+          // handler for what the difference decides.
+          const resume = url.searchParams.get("resume") === "1";
           pendingClients += 1;
           let upgraded = false;
           try {
@@ -1051,6 +1056,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
                 pendingClientSlot: true,
                 sessionId: crypto.randomUUID(),
                 protocol,
+                resume,
                 busy: false,
                 pending: null,
                 current: null,
@@ -1399,6 +1405,20 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           if (!accepting) {
             ws.close(1012, "Server shutting down");
             return;
+          }
+          // A closed socket cannot say why it closed, and the page cannot tell
+          // us either while it is between reconnect attempts: pressing Stop
+          // during the backoff has no open socket to send the goodbye on. So the
+          // page states which kind of connection this is instead. An operator
+          // pressing Start is a new conversation, and any conversation still
+          // sitting out its grace is over — otherwise its deferred cold transfer
+          // survived the Stop and steered the conversation that replaced it.
+          // Only when nobody else is attached: the timer is deliberately left
+          // armed while clients are connected (it re-checks on fire), so without
+          // that condition a second device pressing Start would end a
+          // conversation the first one is still in.
+          if (!ws.data.resume && clients.size === 0 && conversationEndTimer !== null) {
+            endConversationNow();
           }
           clients.add(ws);
           if (ws.data.protocol === 2) {

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -74,6 +74,13 @@ interface WsData {
   record: boolean;
   /** In-flight speculative turn from the last confident "complete" probe (see speculative.ts). */
   spec: SpecState | null;
+  /**
+   * The page said goodbye before closing, so this disconnect is the operator
+   * ending the conversation rather than the network dropping it. Without it the
+   * two are indistinguishable at the server, and they mean opposite things for
+   * work the brain has deferred.
+   */
+  saidGoodbye: boolean;
 }
 
 export interface WebVoiceServerOptions {
@@ -105,6 +112,14 @@ export interface WebVoiceServerOptions {
    * reason, so the close is invisible to anything reading it. Fire-and-forget.
    */
   onConversationEnded?: () => void;
+  /**
+   * How long to wait, after the last voice socket goes away, before deciding
+   * the conversation is over. The PWA reconnects automatically (1s → 2s → 5s
+   * backoff) whenever the operator has not stopped it, so treating every drop
+   * as an ending discarded work across an ordinary network blip. An explicit
+   * goodbye skips this wait entirely. Default 30s; tests inject something small.
+   */
+  conversationEndGraceMs?: number;
   /**
    * Toggle native dictation on the daemon. Separate from onNotify because it
    * neither renders nor fans out — it starts or ends a local capture.
@@ -262,6 +277,8 @@ function abortTurn(turn: TurnState | null, reason: string): void {
 }
 
 const BODY_READ_TIMEOUT_MS = 5_000;
+/** Long enough to cover the page's 1s → 2s → 5s reconnect backoff several times over. */
+const DEFAULT_CONVERSATION_END_GRACE_MS = 30_000;
 const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 95_000;
 const MAX_BACKGROUND_WEB_JOBS = MAX_CONCURRENT_WEB_JOBS;
 const MAX_VOICE_NAME_CHARS = 128;
@@ -344,6 +361,50 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
   let stopPromise: Promise<void> | null = null;
   // Live voice clients — notify broadcasts go to every open socket.
   const clients = new Set<import("bun").ServerWebSocket<WsData>>();
+
+  /*
+   * Deciding the conversation is over.
+   *
+   * A dropped socket and a deliberate Stop look identical at this end, and they
+   * mean opposite things to a brain holding deferred work: the PWA reconnects
+   * by itself after an unplanned close, so ending the conversation on every
+   * disconnect threw that work away across an ordinary network blip. The page
+   * says goodbye when the operator stops; anything else gets a grace period
+   * that a reconnecting client cancels just by arriving.
+   *
+   * The timer is owned here: replaced when another wait starts, cleared when
+   * the ending fires, and cleared on shutdown, so it can never outlive the
+   * server.
+   */
+  const conversationEndGraceMs = Number.isFinite(opts.conversationEndGraceMs)
+    && (opts.conversationEndGraceMs ?? -1) >= 0
+    ? Math.floor(opts.conversationEndGraceMs!)
+    : DEFAULT_CONVERSATION_END_GRACE_MS;
+  let conversationEndTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancelConversationEnd = (): void => {
+    if (conversationEndTimer === null) return;
+    clearTimeout(conversationEndTimer);
+    conversationEndTimer = null;
+  };
+
+  const endConversationNow = (): void => {
+    cancelConversationEnd();
+    try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
+  };
+
+  const scheduleConversationEnd = (): void => {
+    cancelConversationEnd();
+    if (conversationEndGraceMs === 0) { endConversationNow(); return; }
+    conversationEndTimer = setTimeout(() => {
+      conversationEndTimer = null;
+      // Re-checked rather than cancelled on connect: this is the single place
+      // that decides, so a client that arrived during the wait (a reconnect) or
+      // arrived and left again is handled by the same question either way.
+      if (clients.size === 0) endConversationNow();
+    }, conversationEndGraceMs);
+    conversationEndTimer.unref?.();
+  };
   const debugConfirmation = (reason: string, nonce?: string, approved?: boolean): void => {
     // The project logger intentionally has no debug level. Keep rejected
     // controls out of the operator event stream while retaining a debug trace.
@@ -987,6 +1048,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
                 latestProbeTurnId: null,
                 record,
                 spec: null,
+                saidGoodbye: false,
               },
             });
           } finally {
@@ -1436,6 +1498,14 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               broadcastConfirmationResolved(replyNonce);
               return;
             }
+            if (msg.type === "bye") {
+              // Deliberately ahead of the session-id gate: this frame carries no
+              // authority, only the operator's intent to stop, and refusing it
+              // over a stale session id would silently downgrade a Stop into a
+              // dropped connection.
+              ws.data.saidGoodbye = true;
+              return;
+            }
             if (ws.data.protocol === 2 && msg.sessionId !== ws.data.sessionId) {
               protocolError(ws, "session id does not match this connection");
               return;
@@ -1572,7 +1642,8 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           // when the last of them leaves, so reporting it per socket would let
           // one browser closing call off work another is still waiting on.
           if (clients.size === 0) {
-            try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
+            if (ws.data.saidGoodbye) endConversationNow();
+            else scheduleConversationEnd();
           }
           ws.data.pending = null;
           ws.data.latestProbeTurnId = null;
@@ -1641,7 +1712,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       if (!shutdownController.signal.aborted) {
         shutdownController.abort(new Error("web voice server shutting down"));
       }
-      try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
+      endConversationNow();
       pendingClients = 0;
       parked.length = 0;
 

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -76,13 +76,6 @@ interface WsData {
   record: boolean;
   /** In-flight speculative turn from the last confident "complete" probe (see speculative.ts). */
   spec: SpecState | null;
-  /**
-   * The page said goodbye before closing, so this disconnect is the operator
-   * ending the conversation rather than the network dropping it. Without it the
-   * two are indistinguishable at the server, and they mean opposite things for
-   * work the brain has deferred.
-   */
-  saidGoodbye: boolean;
 }
 
 export interface WebVoiceServerOptions {
@@ -204,6 +197,11 @@ export interface WebVoiceHandle {
   port: number;
   /** Connected voice clients right now (for status/logging). */
   clientCount: () => number;
+  /**
+   * Foreground web request or turn jobs currently holding an admission lease.
+   * This excludes speculative and detached background work.
+   */
+  activeJobCount: () => number;
   /**
    * A voice conversation is still in progress — either a socket is attached, or
    * the last one dropped recently enough that the page is expected back.
@@ -366,8 +364,11 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
   const shutdownController = new AbortController();
   let accepting = true;
   let stopPromise: Promise<void> | null = null;
-  // Live voice clients — notify broadcasts go to every open socket.
+  // Attached voice clients — notify broadcasts go to every one still in the conversation.
   const clients = new Set<import("bun").ServerWebSocket<WsData>>();
+  // Transport ownership outlives conversation attachment for the brief span
+  // between a goodbye frame and that socket's eventual close callback.
+  const sockets = new Set<import("bun").ServerWebSocket<WsData>>();
 
   /*
    * Deciding the conversation is over.
@@ -395,8 +396,14 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     conversationEndTimer = null;
   };
 
+  // An ending reported while a foreground job is running is one the daemon
+  // will decline to act on, because that job is itself a live surface. Nothing
+  // would deliver it again once the job finished, so it is remembered and
+  // re-reported at the release instead.
+  let endReportedDuringJob = false;
   const endConversationNow = (): void => {
     cancelConversationEnd();
+    if (activeJobs > 0) endReportedDuringJob = true;
     try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
   };
 
@@ -627,6 +634,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     req: Request,
     action: (signal: AbortSignal) => Promise<Response>,
     busyResponse: () => Response = unavailableResponse,
+    onReleased?: () => void,
   ): Promise<Response> => {
     if (!acquireJob()) {
       const response = busyResponse();
@@ -642,6 +650,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       throw new Error("web request handler failed", { cause: error });
     } finally {
       releaseJob();
+      onReleased?.();
     }
   };
   // Notifications that arrived with no client connected are parked and spoken
@@ -1064,7 +1073,6 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
                 latestProbeTurnId: null,
                 record,
                 spec: null,
-                saidGoodbye: false,
               },
             });
           } finally {
@@ -1230,6 +1238,17 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               log("error", `web-voice chat failed: ${message}`);
               return Response.json({ error: message }, { status: 500 });
             }
+          }, unavailableResponse, () => {
+            // A chat job is an input surface until its foreground lease is
+            // released. Re-report only an ending that actually arrived while
+            // this job held the daemon back: firing on every release would end
+            // conversations that never ended, and on a box driven entirely
+            // through /api/chat that would drop a transfer parked by the turn
+            // that just finished.
+            if (!endReportedDuringJob || activeJobs > 0) return;
+            if (clients.size !== 0 || conversationEndTimer !== null) return;
+            endReportedDuringJob = false;
+            endConversationNow();
           });
         }
 
@@ -1420,6 +1439,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           if (!ws.data.resume && clients.size === 0 && conversationEndTimer !== null) {
             endConversationNow();
           }
+          sockets.add(ws);
           clients.add(ws);
           if (ws.data.protocol === 2) {
             sendJson(ws, {
@@ -1533,7 +1553,11 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               // authority, only the operator's intent to stop, and refusing it
               // over a stale session id would silently downgrade a Stop into a
               // dropped connection.
-              ws.data.saidGoodbye = true;
+              // Goodbye is the departure, not a hint to interpret a later
+              // socket close. Waiting for close let a replacement socket join
+              // first, after which neither event saw an empty room and the
+              // stopped conversation survived into its replacement.
+              if (clients.delete(ws) && clients.size === 0) endConversationNow();
               return;
             }
             if (ws.data.protocol === 2 && msg.sessionId !== ws.data.sessionId) {
@@ -1664,17 +1688,18 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
         },
         close(ws) {
           if (ws.data.pendingClientSlot) pendingClients = Math.max(0, pendingClients - 1);
-          clients.delete(ws);
+          sockets.delete(ws);
+          const wasAttached = clients.delete(ws);
           abortTurn(ws.data.current, "voice socket closed");
           // Every connected browser reaches the same brain, switchboard and
           // active lane (docs/web-voice.md, "Deliberate multi-client
           // boundary") — they are one conversation on several screens. It ends
           // when the last of them leaves, so reporting it per socket would let
           // one browser closing call off work another is still waiting on.
-          if (clients.size === 0) {
-            if (ws.data.saidGoodbye) endConversationNow();
-            else scheduleConversationEnd();
-          }
+          // A goodbye already detached this socket and made the lifecycle
+          // decision. Its eventual transport close must not report another
+          // ending or start a reconnect grace for a client that already left.
+          if (wasAttached && clients.size === 0) scheduleConversationEnd();
           ws.data.pending = null;
           ws.data.latestProbeTurnId = null;
           const spec = ws.data.spec;
@@ -1718,7 +1743,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       }).then(() => {
         if (
           server.pendingRequests === 0 &&
-          clients.size === 0 &&
+          sockets.size === 0 &&
           isDrained()
         ) return;
         return runtimeStop;
@@ -1746,7 +1771,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       pendingClients = 0;
       parked.length = 0;
 
-      for (const ws of clients) {
+      for (const ws of sockets) {
         abortTurn(ws.data.current, "web voice server shutting down");
         ws.data.pending = null;
         ws.data.latestProbeTurnId = null;
@@ -1759,6 +1784,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           // A forced terminate transfers socket ownership back to the runtime
           // synchronously. Bun need not emit close for an already-closing peer;
           // retaining it here would make every bounded stop retry wait forever.
+          sockets.delete(ws);
           clients.delete(ws);
         } catch { /* runtime still owns it; close callback/retry will confirm */ }
       }
@@ -1792,6 +1818,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       scheme,
       port: server.port ?? port,
       clientCount: () => clients.size,
+      activeJobCount: () => activeJobs,
       // A conversation whose grace has not expired is still live even with no
       // socket attached: the page reconnects by itself, and another surface
       // going away meanwhile must not conclude that nobody is left.

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -97,8 +97,9 @@ export interface WebVoiceServerOptions {
    * ("PR #142 is up") instead of only answering. Optional.
    */
   /**
-   * This voice conversation is over — the socket closed, or the server is
-   * shutting down. The daemon uses it to tell the brain to drop work it was
+   * This voice conversation is over — the LAST voice socket closed, or the
+   * server is shutting down. Every browser shares one brain and active lane, so
+   * this fires once for the shared conversation, not once per socket. The daemon uses it to tell the brain to drop work it was
    * holding for the conversation, which the turn's abort reason cannot convey:
    * the page sends `abort` and then closes, and the first abort fixes the
    * reason, so the close is invisible to anything reading it. Fire-and-forget.
@@ -1565,7 +1566,14 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           if (ws.data.pendingClientSlot) pendingClients = Math.max(0, pendingClients - 1);
           clients.delete(ws);
           abortTurn(ws.data.current, "voice socket closed");
-          try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
+          // Every connected browser reaches the same brain, switchboard and
+          // active lane (docs/web-voice.md, "Deliberate multi-client
+          // boundary") — they are one conversation on several screens. It ends
+          // when the last of them leaves, so reporting it per socket would let
+          // one browser closing call off work another is still waiting on.
+          if (clients.size === 0) {
+            try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
+          }
           ws.data.pending = null;
           ws.data.latestProbeTurnId = null;
           const spec = ws.data.spec;

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -598,6 +598,21 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
   };
   const releaseJob = (): void => {
     activeJobs = Math.max(0, activeJobs - 1);
+    // Re-report only an ending that actually arrived while a job held the
+    // daemon back. Firing on every release would end conversations that never
+    // ended, and on a box driven entirely through the HTTP API that would drop
+    // a transfer parked by the turn that just finished. The latch is consumed
+    // before the fire-and-forget hook so this release path cannot report it
+    // twice even if the hook fails.
+    if (
+      activeJobs === 0 &&
+      endReportedDuringJob &&
+      clients.size === 0 &&
+      conversationEndTimer === null
+    ) {
+      endReportedDuringJob = false;
+      endConversationNow();
+    }
     resolveIfDrained();
   };
   const releaseSocketCallback = (): void => {
@@ -634,7 +649,6 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     req: Request,
     action: (signal: AbortSignal) => Promise<Response>,
     busyResponse: () => Response = unavailableResponse,
-    onReleased?: () => void,
   ): Promise<Response> => {
     if (!acquireJob()) {
       const response = busyResponse();
@@ -650,7 +664,6 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       throw new Error("web request handler failed", { cause: error });
     } finally {
       releaseJob();
-      onReleased?.();
     }
   };
   // Notifications that arrived with no client connected are parked and spoken
@@ -1238,18 +1251,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
               log("error", `web-voice chat failed: ${message}`);
               return Response.json({ error: message }, { status: 500 });
             }
-          }, unavailableResponse, () => {
-            // A chat job is an input surface until its foreground lease is
-            // released. Re-report only an ending that actually arrived while
-            // this job held the daemon back: firing on every release would end
-            // conversations that never ended, and on a box driven entirely
-            // through /api/chat that would drop a transfer parked by the turn
-            // that just finished.
-            if (!endReportedDuringJob || activeJobs > 0) return;
-            if (clients.size !== 0 || conversationEndTimer !== null) return;
-            endReportedDuringJob = false;
-            endConversationNow();
-          });
+          }, unavailableResponse);
         }
 
         // Health-record ingest: one row or an array of rows, appended to

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -203,6 +203,11 @@ export interface WebVoiceHandle {
   /** Connected voice clients right now (for status/logging). */
   clientCount: () => number;
   /**
+   * A voice conversation is still in progress — either a socket is attached, or
+   * the last one dropped recently enough that the page is expected back.
+   */
+  conversationLive: () => boolean;
+  /**
    * Speak a notification through the same path as POST /api/notify (render,
    * broadcast, park when nobody's connected) — for in-process callers like the
    * kanban watcher. Resolves null when unavailable, saturated, or quiescing.
@@ -395,6 +400,11 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
 
   const scheduleConversationEnd = (): void => {
     cancelConversationEnd();
+    // Shutdown already ended the conversation before closing its sockets, and
+    // each of those closes lands here. Re-arming would leave a timer running
+    // past the server's own teardown and report a second ending nobody is
+    // there for.
+    if (!accepting) return;
     if (conversationEndGraceMs === 0) { endConversationNow(); return; }
     conversationEndTimer = setTimeout(() => {
       conversationEndTimer = null;
@@ -1762,6 +1772,10 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       scheme,
       port: server.port ?? port,
       clientCount: () => clients.size,
+      // A conversation whose grace has not expired is still live even with no
+      // socket attached: the page reconnects by itself, and another surface
+      // going away meanwhile must not conclude that nobody is left.
+      conversationLive: () => clients.size > 0 || conversationEndTimer !== null,
       notify,
       confirmPending,
       stop,

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -1,6 +1,7 @@
 import { log } from "../logger";
 import { isConfirmationNonce } from "../brain/approval";
 import type { Brain } from "../types";
+import { TURN_SUPERSEDED_BY_NEWER } from "../types";
 import { presentedToken, tokenMatches } from "../http-auth";
 import { PAGE } from "./page";
 import { MANIFEST, ICON_SVG } from "./pwa";
@@ -802,7 +803,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     // Latest input wins on this socket only. Its current sink is immediately
     // invalidated, so even a handler that emits after observing the abort
     // cannot leak stale text/audio into the replacement turn.
-    abortTurn(ws.data.current, "superseded by a newer turn");
+    abortTurn(ws.data.current, TURN_SUPERSEDED_BY_NEWER);
     ws.data.pending = { input, turnId };
     if (ws.data.busy) return; // the running drain loop will pick it up
     ws.data.busy = true;

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -1,12 +1,6 @@
 import { log } from "../logger";
 import { isConfirmationNonce } from "../brain/approval";
 import type { Brain } from "../types";
-import {
-  TURN_ABORTED_BY_CLIENT,
-  TURN_SUPERSEDED_BY_NEWER,
-  VOICE_SERVER_SHUTTING_DOWN,
-  VOICE_SOCKET_CLOSED,
-} from "../types";
 import { presentedToken, tokenMatches } from "../http-auth";
 import { PAGE } from "./page";
 import { MANIFEST, ICON_SVG } from "./pwa";
@@ -102,6 +96,14 @@ export interface WebVoiceServerOptions {
    * audioBase64} to every connected voice client — Cicero speaks up unprompted
    * ("PR #142 is up") instead of only answering. Optional.
    */
+  /**
+   * This voice conversation is over — the socket closed, or the server is
+   * shutting down. The daemon uses it to tell the brain to drop work it was
+   * holding for the conversation, which the turn's abort reason cannot convey:
+   * the page sends `abort` and then closes, and the first abort fixes the
+   * reason, so the close is invisible to anything reading it. Fire-and-forget.
+   */
+  onConversationEnded?: () => void;
   /**
    * Toggle native dictation on the daemon. Separate from onNotify because it
    * neither renders nor fans out — it starts or ends a local capture.
@@ -808,7 +810,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
     // Latest input wins on this socket only. Its current sink is immediately
     // invalidated, so even a handler that emits after observing the abort
     // cannot leak stale text/audio into the replacement turn.
-    abortTurn(ws.data.current, TURN_SUPERSEDED_BY_NEWER);
+    abortTurn(ws.data.current, "superseded by a newer turn");
     ws.data.pending = { input, turnId };
     if (ws.data.busy) return; // the running drain loop will pick it up
     ws.data.busy = true;
@@ -823,7 +825,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           controller,
           signal: AbortSignal.any([controller.signal, shutdownController.signal]),
         };
-        if (shutdownController.signal.aborted) abortTurn(state, VOICE_SERVER_SHUTTING_DOWN);
+        if (shutdownController.signal.aborted) abortTurn(state, "web voice server shutting down");
         ws.data.current = state;
         // Any in-flight speculation belongs to exactly one turn: a WAV turn
         // gets to adopt it; a typed turn (different input entirely) kills it.
@@ -1443,10 +1445,10 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
                   protocolError(ws, "abort requires a valid turn id");
                   return;
                 }
-                if (ws.data.current?.turnId === msg.turnId) abortTurn(ws.data.current, TURN_ABORTED_BY_CLIENT);
+                if (ws.data.current?.turnId === msg.turnId) abortTurn(ws.data.current, "turn aborted by client");
                 if (ws.data.pending?.turnId === msg.turnId) ws.data.pending = null;
               } else if (ws.data.current) {
-                abortTurn(ws.data.current, TURN_ABORTED_BY_CLIENT);
+                abortTurn(ws.data.current, "turn aborted by client");
               }
               return;
             }
@@ -1562,7 +1564,8 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
         close(ws) {
           if (ws.data.pendingClientSlot) pendingClients = Math.max(0, pendingClients - 1);
           clients.delete(ws);
-          abortTurn(ws.data.current, VOICE_SOCKET_CLOSED);
+          abortTurn(ws.data.current, "voice socket closed");
+          try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
           ws.data.pending = null;
           ws.data.latestProbeTurnId = null;
           const spec = ws.data.spec;
@@ -1628,13 +1631,14 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       // request into dependencies after shutdown has begun.
       accepting = false;
       if (!shutdownController.signal.aborted) {
-        shutdownController.abort(new Error(VOICE_SERVER_SHUTTING_DOWN));
+        shutdownController.abort(new Error("web voice server shutting down"));
       }
+      try { opts.onConversationEnded?.(); } catch { /* fire-and-forget */ }
       pendingClients = 0;
       parked.length = 0;
 
       for (const ws of clients) {
-        abortTurn(ws.data.current, VOICE_SERVER_SHUTTING_DOWN);
+        abortTurn(ws.data.current, "web voice server shutting down");
         ws.data.pending = null;
         ws.data.latestProbeTurnId = null;
         const spec = ws.data.spec;

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -1,7 +1,12 @@
 import { log } from "../logger";
 import { isConfirmationNonce } from "../brain/approval";
 import type { Brain } from "../types";
-import { TURN_SUPERSEDED_BY_NEWER } from "../types";
+import {
+  TURN_ABORTED_BY_CLIENT,
+  TURN_SUPERSEDED_BY_NEWER,
+  VOICE_SERVER_SHUTTING_DOWN,
+  VOICE_SOCKET_CLOSED,
+} from "../types";
 import { presentedToken, tokenMatches } from "../http-auth";
 import { PAGE } from "./page";
 import { MANIFEST, ICON_SVG } from "./pwa";
@@ -818,7 +823,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           controller,
           signal: AbortSignal.any([controller.signal, shutdownController.signal]),
         };
-        if (shutdownController.signal.aborted) abortTurn(state, "web voice server shutting down");
+        if (shutdownController.signal.aborted) abortTurn(state, VOICE_SERVER_SHUTTING_DOWN);
         ws.data.current = state;
         // Any in-flight speculation belongs to exactly one turn: a WAV turn
         // gets to adopt it; a typed turn (different input entirely) kills it.
@@ -1438,10 +1443,10 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
                   protocolError(ws, "abort requires a valid turn id");
                   return;
                 }
-                if (ws.data.current?.turnId === msg.turnId) abortTurn(ws.data.current, "turn aborted by client");
+                if (ws.data.current?.turnId === msg.turnId) abortTurn(ws.data.current, TURN_ABORTED_BY_CLIENT);
                 if (ws.data.pending?.turnId === msg.turnId) ws.data.pending = null;
               } else if (ws.data.current) {
-                abortTurn(ws.data.current, "turn aborted by client");
+                abortTurn(ws.data.current, TURN_ABORTED_BY_CLIENT);
               }
               return;
             }
@@ -1557,7 +1562,7 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
         close(ws) {
           if (ws.data.pendingClientSlot) pendingClients = Math.max(0, pendingClients - 1);
           clients.delete(ws);
-          abortTurn(ws.data.current, "voice socket closed");
+          abortTurn(ws.data.current, VOICE_SOCKET_CLOSED);
           ws.data.pending = null;
           ws.data.latestProbeTurnId = null;
           const spec = ws.data.spec;
@@ -1623,13 +1628,13 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
       // request into dependencies after shutdown has begun.
       accepting = false;
       if (!shutdownController.signal.aborted) {
-        shutdownController.abort(new Error("web voice server shutting down"));
+        shutdownController.abort(new Error(VOICE_SERVER_SHUTTING_DOWN));
       }
       pendingClients = 0;
       parked.length = 0;
 
       for (const ws of clients) {
-        abortTurn(ws.data.current, "web voice server shutting down");
+        abortTurn(ws.data.current, VOICE_SERVER_SHUTTING_DOWN);
         ws.data.pending = null;
         ws.data.latestProbeTurnId = null;
         const spec = ws.data.spec;

--- a/src/web-voice/server.ts
+++ b/src/web-voice/server.ts
@@ -1443,6 +1443,13 @@ export function startWebVoiceServer(opts: WebVoiceServerOptions): WebVoiceHandle
           }
           sockets.add(ws);
           clients.add(ws);
+          // An ending remembered while a job was still running is owed only
+          // until somebody is listening again. A socket can replace the one
+          // that departed before that job drains, and the drain then declines
+          // to consume the ending because a client is attached — so without
+          // this the debt outlives its own conversation and is finally paid by
+          // an unrelated later turn, whose deferred work it discards.
+          endReportedDuringJob = false;
           if (ws.data.protocol === 2) {
             sendJson(ws, {
               type: "hello",

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -408,6 +408,85 @@ test("a cold transfer called off mid-start does not pin the lane it was starting
   }
 });
 
+test("ending a conversation releases a deferred transfer that already pinned", async () => {
+  // The microphone can go inactive while its last local turn still keeps the
+  // conversation live. If the cold start pins during that turn, the eventual
+  // conversation-end drop must release the pin too or the next conversation
+  // bypasses the front desk and reaches the old worker.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    cold.release();
+    expect(await transfer).toBe("Worker here.");
+    expect(sb.activeLane()).toBe("worker");
+
+    sb.dropDeferredWork();
+
+    expect(sb.activeLane()).toBeNull();
+    expect(await sb.send("new conversation")).toBe("front reply");
+    expect(calls).not.toContain("worker:send:new conversation");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("ending a conversation leaves the front desk no memo about it", async () => {
+  // Releasing a lane normally tells whoever answers next that the user came
+  // back from a side conversation, and carries its last exchanges along. After
+  // a conversation ends nobody came back, and that recap would be the finished
+  // conversation's tail arriving inside an unrelated later one.
+  const calls: string[] = [];
+  const injected: string[] = [];
+  const front = { ...fakeBrain("front", calls), injectContext: (context: string) => injected.push(context) };
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(front, { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    await Bun.sleep(0);
+    cold.release();
+    expect(await transfer).toBe("Worker here.");
+
+    sb.dropDeferredWork();
+    expect(await sb.send("new conversation")).toBe("front reply");
+    expect(injected.join("\n")).not.toContain("returned to the main line");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("ending a conversation does not release an ordinary explicit transfer", async () => {
+  // A deliberate transfer to an already-started lane is the existing sticky
+  // product behavior. Conversation cleanup must not mistake that live pin for
+  // deferred work merely because both routes select the same employee.
+  const calls: string[] = [];
+  const sb = board(calls);
+  try {
+    await sb.start();
+    await sb.send("talk to the coder");
+    await sb.send("back to cicero");
+
+    expect(await sb.send("talk to the coder")).toBe("Coder here.");
+    expect(sb.activeLane()).toBe("coder");
+
+    sb.dropDeferredWork();
+
+    expect(sb.activeLane()).toBe("coder");
+    expect(await sb.send("new conversation")).toBe("coder reply");
+    expect(calls).toContain("coder:send:new conversation");
+  } finally {
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
 test("a cold transfer nobody called off still pins the lane", async () => {
   // The other direction: refusing a late pin must be tied to the drop, not
   // applied to every start that takes a while.

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -463,6 +463,65 @@ test("ending a conversation leaves the front desk no memo about it", async () =>
   }
 });
 
+test("ending a conversation clears its exchange before the next transfer", async () => {
+  // A deferred pin can settle before the conversation-end notification arrives.
+  // Releasing that pin clears its recap, but the handoff record must go too or
+  // the next conversation's first transfer briefs a new lane on the old caller.
+  const calls: string[] = [];
+  const thinkContexts: string[] = [];
+  const cold = coldLane(calls);
+  const think = {
+    ...fakeBrain("think", calls),
+    injectContext: (context: string) => { thinkContexts.push(context); },
+  };
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    worker: { brain: cold.brain },
+    think: { brain: think },
+  });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    await Bun.sleep(0);
+    cold.release();
+    expect(await transfer).toBe("Worker here.");
+    expect(await sb.send("the old conversation's private detail")).toBe("worker reply");
+
+    sb.dropDeferredWork();
+    expect(await sb.send("talk to think")).toBe("Think here.");
+    expect(thinkContexts.join("\n")).not.toContain("the old conversation's private detail");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("returning to the front desk preserves the exchange for a later transfer", async () => {
+  // Returning to Cicero is still inside one conversation. The next lane should
+  // receive the prior lane's exchange so the user does not have to repeat it.
+  const calls: string[] = [];
+  const thinkContexts: string[] = [];
+  const coder = fakeBrain("coder", calls);
+  const think = {
+    ...fakeBrain("think", calls),
+    injectContext: (context: string) => { thinkContexts.push(context); },
+  };
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    coder: { brain: coder },
+    think: { brain: think },
+  });
+  try {
+    await sb.start();
+    expect(await sb.send("talk to coder")).toBe("Coder here.");
+    expect(await sb.send("keep this same-conversation detail")).toBe("coder reply");
+    expect(await sb.send("back to Cicero")).toBe("Back with you.");
+
+    expect(await sb.send("talk to think")).toBe("Think here.");
+    expect(thinkContexts.join("\n")).toContain("keep this same-conversation detail");
+  } finally {
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
 test("ending a conversation does not release an ordinary explicit transfer", async () => {
   // A deliberate transfer to an already-started lane is the existing sticky
   // product behavior. Conversation cleanup must not mistake that live pin for

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -239,6 +239,8 @@ function coldLane(calls: string[], name = "worker") {
 }
 
 test("a transfer talked over during a cold start is not silently dropped", async () => {
+  // Forward guard for these review fixes: the PR already preserves a genuine
+  // barge-in; cancellation ownership must not clear that intentional handoff.
   // Live incident 2026-07-30: "get Rick" started a 14-second ACP lane cold
   // start with no further speech to cover it. The user spoke into the silence,
   // that barge-in superseded the pending transfer, and the request evaporated —
@@ -249,17 +251,21 @@ test("a transfer talked over during a cold start is not silently dropped", async
   const calls: string[] = [];
   const cold = coldLane(calls);
   const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  const transport = new AbortController();
   try {
     await sb.start();
-    const transfer = sb.send("talk to the worker");
+    const transfer = sb.send("talk to the worker", { signal: transport.signal });
     void transfer.catch(() => { /* asserted below */ });
     await Bun.sleep(0);
     expect(cold.startCount()).toBe(1);
 
-    // The barge-in still supersedes: the invariant is preserved.
+    // The web transport aborts the old same-socket turn before its drain loop
+    // admits the queued successor. The dead turn still rejects and publishes
+    // nothing; the successor owns the pending ask.
+    transport.abort(new Error("superseded by a newer turn"));
+    await expect(transfer).rejects.toThrow("superseded by a newer turn");
     expect(await settlesWithin(sb.send("hello?"), "barge-in"))
       .toBe("Still getting Worker on the line — one moment.");
-    await expect(transfer).rejects.toThrow("superseded by a newer accepted turn");
     expect(sb.activeLane()).toBeNull(); // nothing pinned late by the dead turn
 
     cold.release();
@@ -269,6 +275,31 @@ test("a transfer talked over during a cold start is not silently dropped", async
     expect(sb.activeLane()).toBe("worker");
     // Resolved once — a later turn is an ordinary lane turn, not another ack.
     expect(await sb.send("what's up")).toBe("worker reply");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("a transport-cancelled cold transfer does not steer a later conversation", async () => {
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  const transport = new AbortController();
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker", { signal: transport.signal });
+    void transfer.catch(() => { /* asserted below */ });
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    transport.abort(new Error("voice socket closed"));
+    await expect(transfer).rejects.toThrow("voice socket closed");
+
+    cold.release();
+    await Bun.sleep(0);
+    expect(await sb.send("new conversation")).toBe("front reply");
+    expect(sb.activeLane()).toBeNull();
   } finally {
     cold.release();
     await sb.stop().catch(() => { /* test cleanup */ });
@@ -324,6 +355,38 @@ test("'never mind' calls off a transfer that is still coming", async () => {
     cold.release();
     await Bun.sleep(0);
     expect(await sb.send("you there?")).toBe("front reply"); // stays at the front desk
+    expect(sb.activeLane()).toBeNull();
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("'that's all' releases an active lane and cancels a pending cold transfer", async () => {
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    coder: { brain: fakeBrain("coder", calls) },
+    worker: { brain: cold.brain },
+  });
+  try {
+    await sb.start();
+    expect(await sb.send("talk to the coder")).toBe("Coder here.");
+
+    const transfer = sb.send("talk to the worker");
+    void transfer.catch(() => { /* asserted below */ });
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+    expect(sb.activeLane()).toBe("coder");
+
+    expect(await settlesWithin(sb.send("that's all"), "release and cancel"))
+      .toBe("Back with you — and I'll leave Worker out of it.");
+    await expect(transfer).rejects.toThrow("superseded by a newer accepted turn");
+    expect(sb.activeLane()).toBeNull();
+
+    cold.release();
+    await Bun.sleep(0);
+    expect(await sb.send("new topic")).toBe("front reply");
     expect(sb.activeLane()).toBeNull();
   } finally {
     cold.release();
@@ -876,6 +939,35 @@ test("stop does not wait for a lane start that never settles", async () => {
   expect(stops).toBe(1);
   expect(sb.activeLane()).toBeNull();
   await expect(settlesWithin(transfer, "retired transfer")).rejects.toThrow("switchboard stopping");
+});
+
+test("stop clears a pending cold transfer before the next board session", async () => {
+  // Forward guard: stop already cleared the scalar pending state before the
+  // pending-transfer ownership fix made cancellation disposition explicit.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    void transfer.catch(() => { /* superseded below */ });
+    await Bun.sleep(0);
+    expect(await settlesWithin(sb.send("hello?"), "barge-in"))
+      .toBe("Still getting Worker on the line — one moment.");
+    await expect(transfer).rejects.toThrow("superseded by a newer accepted turn");
+
+    await settlesWithin(sb.stop(), "switchboard stop");
+    cold.release();
+    await Bun.sleep(0);
+    await Bun.sleep(0);
+
+    await sb.start();
+    expect(await sb.send("fresh conversation")).toBe("front reply");
+    expect(sb.activeLane()).toBeNull();
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
 });
 
 test("stop preempts a primary start that never settles", async () => {

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -226,6 +226,138 @@ test("a lane that fails to start reports it and stays unpinned", async () => {
   expect(await sb.send("hello")).toBe("front reply");
 });
 
+/** A lane whose start hangs until the returned release() is called. */
+function coldLane(calls: string[], name = "worker") {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let starts = 0;
+  const brain: Brain = {
+    ...fakeBrain(name, calls),
+    start: async () => { starts++; await gate; calls.push(`${name}:start`); },
+  };
+  return { brain, release: () => release(), startCount: () => starts };
+}
+
+test("a transfer talked over during a cold start is not silently dropped", async () => {
+  // Live incident 2026-07-30: "get Rick" started a 14-second ACP lane cold
+  // start with no further speech to cover it. The user spoke into the silence,
+  // that barge-in superseded the pending transfer, and the request evaporated —
+  // the lane came up and sat there while every later turn went to the front
+  // desk. The superseded turn must still reject (late work must never publish
+  // into a newer turn), but the front desk must stop pretending it was never
+  // asked.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    void transfer.catch(() => { /* asserted below */ });
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    // The barge-in still supersedes: the invariant is preserved.
+    expect(await settlesWithin(sb.send("hello?"), "barge-in"))
+      .toBe("Still getting Worker on the line — one moment.");
+    await expect(transfer).rejects.toThrow("superseded by a newer accepted turn");
+    expect(sb.activeLane()).toBeNull(); // nothing pinned late by the dead turn
+
+    cold.release();
+    await Bun.sleep(0);
+    // With the lane up, the NEXT turn completes the pin itself.
+    expect(await settlesWithin(sb.send("you there?"), "pin")).toBe("Worker here.");
+    expect(sb.activeLane()).toBe("worker");
+    // Resolved once — a later turn is an ordinary lane turn, not another ack.
+    expect(await sb.send("what's up")).toBe("worker reply");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("a pending cold transfer that fails to start reports it instead of stalling", async () => {
+  // The "still coming" ack must never outlive the start it describes, or the
+  // user is told to hold for a lane that is never going to arrive.
+  const calls: string[] = [];
+  let failStart!: (e: Error) => void;
+  const gate = new Promise<void>((_, reject) => { failStart = reject; });
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    worker: { brain: { ...fakeBrain("worker", calls), start: () => gate } },
+  });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    void transfer.catch(() => { /* asserted below */ });
+    await Bun.sleep(0);
+    expect(await settlesWithin(sb.send("hello?"), "barge-in"))
+      .toBe("Still getting Worker on the line — one moment.");
+    await expect(transfer).rejects.toThrow("superseded by a newer accepted turn");
+
+    failStart(new Error("worker down"));
+    await Bun.sleep(0);
+    expect(await settlesWithin(sb.send("you there?"), "failure ack"))
+      .toBe("I couldn't reach worker right now.");
+    expect(sb.activeLane()).toBeNull();
+    expect(await sb.send("hello")).toBe("front reply"); // cleared, not sticky
+  } finally {
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("'never mind' calls off a transfer that is still coming", async () => {
+  // The hold must be cancellable, or it is the one state the user cannot exit.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    void transfer.catch(() => { /* superseded below */ });
+    await Bun.sleep(0);
+    expect(await settlesWithin(sb.send("hello?"), "barge-in"))
+      .toBe("Still getting Worker on the line — one moment.");
+    await expect(transfer).rejects.toThrow("superseded by a newer accepted turn");
+
+    expect(await settlesWithin(sb.send("that's all"), "cancel"))
+      .toBe("Alright — I'll leave Worker out of it.");
+
+    cold.release();
+    await Bun.sleep(0);
+    expect(await sb.send("you there?")).toBe("front reply"); // stays at the front desk
+    expect(sb.activeLane()).toBeNull();
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("a newer transfer replaces a pending cold one — no stale lane arrives", async () => {
+  // "get the worker… no, the coder" must not leave the worker queued to seize
+  // the line the moment its slow start lands.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    worker: { brain: cold.brain },
+    coder: { brain: fakeBrain("coder", calls) },
+  });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    void transfer.catch(() => { /* superseded below */ });
+    await Bun.sleep(0);
+    expect(await settlesWithin(sb.send("talk to the coder"), "second transfer")).toBe("Coder here.");
+    expect(sb.activeLane()).toBe("coder");
+
+    cold.release();
+    await Bun.sleep(0);
+    expect(await sb.send("still there?")).toBe("coder reply"); // coder keeps the line
+    expect(sb.activeLane()).toBe("coder");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
 test("'that's all' at the front desk is a normal turn, not a release ack", async () => {
   const calls: string[] = [];
   const sb = board(calls);

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1886,6 +1886,12 @@ test("transferTo caller cancellation cannot pin a lane after a late start", asyn
   releaseStart();
   await Bun.sleep(0);
   expect(sb.activeLane()).toBeNull();
+  // The revealing turn: checking only the instant after startup missed that a
+  // cancelled programmatic transfer could still be adopted by whatever the
+  // operator said next. transferTo's signal is documented to prevent a LATE
+  // pin, not merely to abandon its own turn.
+  expect(await sb.send("hello?")).toBe("front reply");
+  expect(sb.activeLane()).toBeNull();
   await sb.stop();
 });
 

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -462,6 +462,30 @@ test("'never mind' calls off a transfer that is still coming", async () => {
   }
 });
 
+test("'never mind' spoken to somebody on the line goes to them, not the switchboard", async () => {
+  // "never mind" cancels a transfer that has not connected yet. Once the coder
+  // has picked up it is something the user is saying TO the coder ("never mind,
+  // I'll do it myself"), and hanging up on them instead loses the utterance.
+  // Explicit release phrases still release.
+  const calls: string[] = [];
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), {
+    coder: { brain: fakeBrain("coder", calls) },
+  });
+  try {
+    await sb.start();
+    expect(await sb.send("talk to the coder")).toBe("Coder here.");
+    expect(sb.activeLane()).toBe("coder");
+
+    expect(await sb.send("never mind")).toBe("coder reply");
+    expect(sb.activeLane()).toBe("coder");
+
+    expect(await sb.send("that's all")).toBe("Back with you.");
+    expect(sb.activeLane()).toBeNull();
+  } finally {
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
 test("'that's all' releases an active lane and cancels a pending cold transfer", async () => {
   const calls: string[] = [];
   const cold = coldLane(calls);

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -437,6 +437,32 @@ test("ending a conversation releases a deferred transfer that already pinned", a
   }
 });
 
+test("a cold transfer becomes sticky after its lane answers an ordinary turn", async () => {
+  // The cold-start greeting only completes the transfer. Once the operator
+  // actually talks to that lane and gets an answer, ending the conversation
+  // must not discard a pin that is now indistinguishable from a warm transfer.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    await Bun.sleep(0);
+    cold.release();
+    expect(await transfer).toBe("Worker here.");
+
+    expect(await sb.send("help me with this")).toBe("worker reply");
+    sb.dropDeferredWork();
+
+    expect(sb.activeLane()).toBe("worker");
+    expect(await sb.send("new conversation")).toBe("worker reply");
+    expect(calls).toContain("worker:send:new conversation");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
 test("ending a conversation leaves the front desk no memo about it", async () => {
   // Releasing a lane normally tells whoever answers next that the user came
   // back from a side conversation, and carries its last exchanges along. After
@@ -480,11 +506,11 @@ test("ending a conversation clears its exchange before the next transfer", async
   });
   try {
     await sb.start();
+    expect(await sb.send("the old conversation's private detail")).toBe("front reply");
     const transfer = sb.send("talk to the worker");
     await Bun.sleep(0);
     cold.release();
     expect(await transfer).toBe("Worker here.");
-    expect(await sb.send("the old conversation's private detail")).toBe("worker reply");
 
     sb.dropDeferredWork();
     expect(await sb.send("talk to think")).toBe("Think here.");

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -380,6 +380,56 @@ test("an explicit local stop drops the transfer even though the reason says barg
   }
 });
 
+test("a cold transfer called off mid-start does not pin the lane it was starting", async () => {
+  // Deactivating the microphone ends the conversation WITHOUT aborting the turn
+  // that asked for the transfer, so the cold start runs to completion on a live
+  // signal. Clearing the pending record alone did not stop it: it finished the
+  // wait and pinned the lane seconds after everyone had left.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    sb.dropDeferredWork();
+    cold.release();
+
+    expect(await transfer).toBe("Never mind worker then.");
+    expect(sb.activeLane()).toBeNull();
+    // ...and the conversation that follows starts at the front desk.
+    expect(await sb.send("new conversation")).toBe("front reply");
+    expect(sb.activeLane()).toBeNull();
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("a cold transfer nobody called off still pins the lane", async () => {
+  // The other direction: refusing a late pin must be tied to the drop, not
+  // applied to every start that takes a while.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker");
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    cold.release();
+
+    expect(await transfer).toBe("Worker here.");
+    expect(sb.activeLane()).toBe("worker");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
 test("a transport-cancelled cold transfer does not steer a later conversation", async () => {
   const calls: string[] = [];
   const cold = coldLane(calls);

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1,6 +1,17 @@
 import { test, expect } from "bun:test";
 import { SwitchboardBrain, type LaneDef } from "../../src/brain/switchboard";
 import { SpeculativeSideEffectError } from "../../src/brain/dial-back";
+import {
+  DAEMON_STOPPING,
+  LOCAL_TURN_BARGE_IN,
+  LOCAL_TURN_STOPPED,
+  LOCAL_TURN_SUPERSEDED,
+  TURN_ABORTED_BY_CLIENT,
+  TURN_SUPERSEDED_BY_NEWER,
+  VOICE_SERVER_SHUTTING_DOWN,
+  VOICE_SOCKET_CLOSED,
+  turnCancellationContinuesConversation,
+} from "../../src/types";
 import type { Brain, BrainTurnOptions } from "../../src/types";
 
 const NONCE_A = "11111111-1111-4111-8111-111111111111";
@@ -275,6 +286,136 @@ test("a transfer talked over during a cold start is not silently dropped", async
     expect(sb.activeLane()).toBe("worker");
     // Resolved once — a later turn is an ordinary lane turn, not another ack.
     expect(await sb.send("what's up")).toBe("worker reply");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("every transport cancellation reason is classified", () => {
+  // The switchboard decides a pending transfer's fate from the abort reason, so
+  // the whitelist in types.ts and the reasons src/web-voice/server.ts actually
+  // raises have to stay in step. The literals below are asserted rather than
+  // imported on purpose: importing the constant would make this test agree with
+  // whatever the constant says, which is how the push-to-talk reason was missed
+  // in the first place.
+  expect(TURN_SUPERSEDED_BY_NEWER).toBe("superseded by a newer turn");
+  expect(TURN_ABORTED_BY_CLIENT).toBe("turn aborted by client");
+  expect(VOICE_SOCKET_CLOSED).toBe("voice socket closed");
+  expect(VOICE_SERVER_SHUTTING_DOWN).toBe("web voice server shutting down");
+  expect(LOCAL_TURN_SUPERSEDED).toBe("superseded by a newer local turn");
+  expect(LOCAL_TURN_BARGE_IN).toBe("barge-in");
+  expect(LOCAL_TURN_STOPPED).toBe("stop command");
+  expect(DAEMON_STOPPING).toBe("daemon stopping");
+
+  // Speaker still on the line.
+  expect(turnCancellationContinuesConversation(new Error(TURN_SUPERSEDED_BY_NEWER))).toBe(true);
+  expect(turnCancellationContinuesConversation(new Error(TURN_ABORTED_BY_CLIENT))).toBe(true);
+  // Conversation over.
+  expect(turnCancellationContinuesConversation(new Error(VOICE_SOCKET_CLOSED))).toBe(false);
+  expect(turnCancellationContinuesConversation(new Error(VOICE_SERVER_SHUTTING_DOWN))).toBe(false);
+
+  // The local microphone surface aborts with bare strings, not Errors.
+  expect(turnCancellationContinuesConversation(LOCAL_TURN_SUPERSEDED)).toBe(true);
+  expect(turnCancellationContinuesConversation(LOCAL_TURN_BARGE_IN)).toBe(true);
+  // "stop" is the operator cancelling the work, not talking over it.
+  expect(turnCancellationContinuesConversation(LOCAL_TURN_STOPPED)).toBe(false);
+  expect(turnCancellationContinuesConversation(DAEMON_STOPPING)).toBe(false);
+
+  // Anything unrecognised is terminal.
+  expect(turnCancellationContinuesConversation(new Error("something new"))).toBe(false);
+  expect(turnCancellationContinuesConversation("something new")).toBe(false);
+  expect(turnCancellationContinuesConversation(undefined)).toBe(false);
+  expect(turnCancellationContinuesConversation({ message: TURN_ABORTED_BY_CLIENT })).toBe(false);
+});
+
+test("a push-to-talk barge-in keeps the pending cold transfer alive", async () => {
+  // The browser's PTT interruption aborts the active turn BEFORE it has the
+  // replacement audio to send (page.ts abortActiveTurn, then endPtt sends the
+  // WAV), and the server records that as "turn aborted by client". abortTurn
+  // fixes the reason on the FIRST abort, so the later same-socket supersession
+  // can never overwrite it. This is an ordinary barge-in with the speaker still
+  // on the line, so the transfer must survive it exactly as a queued-turn
+  // supersession does — treating it as the conversation going away reinstates
+  // the very incident this feature exists to fix.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  const transport = new AbortController();
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker", { signal: transport.signal });
+    void transfer.catch(() => { /* asserted below */ });
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    transport.abort(new Error("turn aborted by client"));
+    await expect(transfer).rejects.toThrow("turn aborted by client");
+    expect(await settlesWithin(sb.send("hello?"), "barge-in"))
+      .toBe("Still getting Worker on the line — one moment.");
+
+    cold.release();
+    await Bun.sleep(0);
+    expect(await settlesWithin(sb.send("you there?"), "pin")).toBe("Worker here.");
+    expect(sb.activeLane()).toBe("worker");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("a local-microphone barge-in keeps the pending cold transfer alive", async () => {
+  // src/daemon.ts aborts the active local turn with a bare string rather than an
+  // Error. Same contract as the browser barge-in, different reason shape — a
+  // classifier that only understood Errors dropped every local transfer.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  const transport = new AbortController();
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker", { signal: transport.signal });
+    void transfer.catch(() => { /* asserted below */ });
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    transport.abort(LOCAL_TURN_BARGE_IN);
+    await expect(transfer).rejects.toThrow();
+    expect(await settlesWithin(sb.send("hello?"), "local barge-in"))
+      .toBe("Still getting Worker on the line — one moment.");
+
+    cold.release();
+    await Bun.sleep(0);
+    expect(await settlesWithin(sb.send("you there?"), "pin")).toBe("Worker here.");
+    expect(sb.activeLane()).toBe("worker");
+  } finally {
+    cold.release();
+    await sb.stop().catch(() => { /* test cleanup */ });
+  }
+});
+
+test("an explicit local stop drops the pending cold transfer", async () => {
+  // "stop" cancels the work in flight. The operator is still on the line, but
+  // they asked for this to go away — the next thing they say must not be
+  // steered into a lane they just cancelled.
+  const calls: string[] = [];
+  const cold = coldLane(calls);
+  const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
+  const transport = new AbortController();
+  try {
+    await sb.start();
+    const transfer = sb.send("talk to the worker", { signal: transport.signal });
+    void transfer.catch(() => { /* asserted below */ });
+    await Bun.sleep(0);
+    expect(cold.startCount()).toBe(1);
+
+    transport.abort(LOCAL_TURN_STOPPED);
+    await expect(transfer).rejects.toThrow();
+
+    cold.release();
+    await Bun.sleep(0);
+    expect(await sb.send("new conversation")).toBe("front reply");
+    expect(sb.activeLane()).toBeNull();
   } finally {
     cold.release();
     await sb.stop().catch(() => { /* test cleanup */ });

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1,17 +1,6 @@
 import { test, expect } from "bun:test";
 import { SwitchboardBrain, type LaneDef } from "../../src/brain/switchboard";
 import { SpeculativeSideEffectError } from "../../src/brain/dial-back";
-import {
-  DAEMON_STOPPING,
-  LOCAL_TURN_BARGE_IN,
-  LOCAL_TURN_STOPPED,
-  LOCAL_TURN_SUPERSEDED,
-  TURN_ABORTED_BY_CLIENT,
-  TURN_SUPERSEDED_BY_NEWER,
-  VOICE_SERVER_SHUTTING_DOWN,
-  VOICE_SOCKET_CLOSED,
-  turnCancellationContinuesConversation,
-} from "../../src/types";
 import type { Brain, BrainTurnOptions } from "../../src/types";
 
 const NONCE_A = "11111111-1111-4111-8111-111111111111";
@@ -292,43 +281,6 @@ test("a transfer talked over during a cold start is not silently dropped", async
   }
 });
 
-test("every transport cancellation reason is classified", () => {
-  // The switchboard decides a pending transfer's fate from the abort reason, so
-  // the whitelist in types.ts and the reasons src/web-voice/server.ts actually
-  // raises have to stay in step. The literals below are asserted rather than
-  // imported on purpose: importing the constant would make this test agree with
-  // whatever the constant says, which is how the push-to-talk reason was missed
-  // in the first place.
-  expect(TURN_SUPERSEDED_BY_NEWER).toBe("superseded by a newer turn");
-  expect(TURN_ABORTED_BY_CLIENT).toBe("turn aborted by client");
-  expect(VOICE_SOCKET_CLOSED).toBe("voice socket closed");
-  expect(VOICE_SERVER_SHUTTING_DOWN).toBe("web voice server shutting down");
-  expect(LOCAL_TURN_SUPERSEDED).toBe("superseded by a newer local turn");
-  expect(LOCAL_TURN_BARGE_IN).toBe("barge-in");
-  expect(LOCAL_TURN_STOPPED).toBe("stop command");
-  expect(DAEMON_STOPPING).toBe("daemon stopping");
-
-  // Speaker still on the line.
-  expect(turnCancellationContinuesConversation(new Error(TURN_SUPERSEDED_BY_NEWER))).toBe(true);
-  expect(turnCancellationContinuesConversation(new Error(TURN_ABORTED_BY_CLIENT))).toBe(true);
-  // Conversation over.
-  expect(turnCancellationContinuesConversation(new Error(VOICE_SOCKET_CLOSED))).toBe(false);
-  expect(turnCancellationContinuesConversation(new Error(VOICE_SERVER_SHUTTING_DOWN))).toBe(false);
-
-  // The local microphone surface aborts with bare strings, not Errors.
-  expect(turnCancellationContinuesConversation(LOCAL_TURN_SUPERSEDED)).toBe(true);
-  expect(turnCancellationContinuesConversation(LOCAL_TURN_BARGE_IN)).toBe(true);
-  // "stop" is the operator cancelling the work, not talking over it.
-  expect(turnCancellationContinuesConversation(LOCAL_TURN_STOPPED)).toBe(false);
-  expect(turnCancellationContinuesConversation(DAEMON_STOPPING)).toBe(false);
-
-  // Anything unrecognised is terminal.
-  expect(turnCancellationContinuesConversation(new Error("something new"))).toBe(false);
-  expect(turnCancellationContinuesConversation("something new")).toBe(false);
-  expect(turnCancellationContinuesConversation(undefined)).toBe(false);
-  expect(turnCancellationContinuesConversation({ message: TURN_ABORTED_BY_CLIENT })).toBe(false);
-});
-
 test("a push-to-talk barge-in keeps the pending cold transfer alive", async () => {
   // The browser's PTT interruption aborts the active turn BEFORE it has the
   // replacement audio to send (page.ts abortActiveTurn, then endPtt sends the
@@ -368,6 +320,7 @@ test("a local-microphone barge-in keeps the pending cold transfer alive", async 
   // src/daemon.ts aborts the active local turn with a bare string rather than an
   // Error. Same contract as the browser barge-in, different reason shape — a
   // classifier that only understood Errors dropped every local transfer.
+  // Literal, not a shared constant: the point is what the daemon really sends.
   const calls: string[] = [];
   const cold = coldLane(calls);
   const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
@@ -379,7 +332,7 @@ test("a local-microphone barge-in keeps the pending cold transfer alive", async 
     await Bun.sleep(0);
     expect(cold.startCount()).toBe(1);
 
-    transport.abort(LOCAL_TURN_BARGE_IN);
+    transport.abort("barge-in");
     await expect(transfer).rejects.toThrow();
     expect(await settlesWithin(sb.send("hello?"), "local barge-in"))
       .toBe("Still getting Worker on the line — one moment.");
@@ -394,10 +347,11 @@ test("a local-microphone barge-in keeps the pending cold transfer alive", async 
   }
 });
 
-test("an explicit local stop drops the pending cold transfer", async () => {
+test("an explicit local stop drops the transfer even though the reason says barge-in", async () => {
   // "stop" cancels the work in flight. The operator is still on the line, but
   // they asked for this to go away — the next thing they say must not be
-  // steered into a lane they just cancelled.
+  // steered into a lane they just cancelled. The abort reason cannot carry
+  // that: the interrupt callback runs first and fixes it as "barge-in".
   const calls: string[] = [];
   const cold = coldLane(calls);
   const sb = new SwitchboardBrain(fakeBrain("front", calls), { worker: { brain: cold.brain } });
@@ -409,8 +363,12 @@ test("an explicit local stop drops the pending cold transfer", async () => {
     await Bun.sleep(0);
     expect(cold.startCount()).toBe(1);
 
-    transport.abort(LOCAL_TURN_STOPPED);
+    transport.abort("barge-in");
     await expect(transfer).rejects.toThrow();
+    // A spoken "stop" reaches the daemon as a barge-in AND a stop command, in
+    // that order, so the reason on the wire says "barge-in". The stop is
+    // delivered out of band.
+    sb.dropDeferredWork();
 
     cold.release();
     await Bun.sleep(0);
@@ -436,6 +394,7 @@ test("a transport-cancelled cold transfer does not steer a later conversation", 
 
     transport.abort(new Error("voice socket closed"));
     await expect(transfer).rejects.toThrow("voice socket closed");
+    sb.dropDeferredWork();
 
     cold.release();
     await Bun.sleep(0);
@@ -490,7 +449,7 @@ test("'never mind' calls off a transfer that is still coming", async () => {
       .toBe("Still getting Worker on the line — one moment.");
     await expect(transfer).rejects.toThrow("superseded by a newer accepted turn");
 
-    expect(await settlesWithin(sb.send("that's all"), "cancel"))
+    expect(await settlesWithin(sb.send("never mind"), "cancel"))
       .toBe("Alright — I'll leave Worker out of it.");
 
     cold.release();

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -1027,6 +1027,7 @@ describe("CiceroDaemon lifecycle", () => {
         scheme: "http",
         port: 18_443,
         clientCount: () => 0,
+        conversationLive: () => false,
         notify: () => Promise.resolve(null),
         stop: () => Promise.resolve(),
       }),
@@ -1119,6 +1120,7 @@ describe("CiceroDaemon lifecycle", () => {
         scheme: "http",
         port: 18_444,
         clientCount: () => 0,
+        conversationLive: () => false,
         notify: () => Promise.resolve(null),
         stop: () => Promise.resolve(),
       }),
@@ -1168,10 +1170,15 @@ describe("deferred brain work", () => {
     Object.defineProperty(brain, "dropDeferredWork", { value: spy, configurable: true });
   }
 
+  /**
+   * `clients` and `live` are deliberately separable: during the reconnect grace
+   * a real server reports no attached socket and a live conversation at the
+   * same time, which is the state the daemon has to read correctly.
+   */
   function startableDaemon(
     home: string,
     capture?: (opts: Record<string, unknown>) => void,
-    clientCount: () => number = () => 0,
+    webVoiceState: { clients?: number; live?: boolean } = {},
   ): CiceroDaemon {
     const config = loadConfig({}, { home });
     config.raw.headless = true;
@@ -1198,7 +1205,8 @@ describe("deferred brain work", () => {
         return {
           scheme: "http",
           port: 18_446,
-          clientCount,
+          clientCount: () => webVoiceState.clients ?? 0,
+          conversationLive: () => webVoiceState.live ?? (webVoiceState.clients ?? 0) > 0,
           notify: () => Promise.resolve(null),
           stop: () => Promise.resolve(),
         };
@@ -1290,7 +1298,26 @@ describe("deferred brain work", () => {
     // away from the microphone is still on the line in the browser, and the
     // transfer they asked for is still theirs.
     const home = mkdtempSync(join(tmpdir(), "cicero-deferred-deact-web-"));
-    const daemon = startableDaemon(home, undefined, () => 1);
+    const daemon = startableDaemon(home, undefined, { clients: 1 });
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      (daemon as unknown as { handleVoiceDeactivated: () => void }).handleVoiceDeactivated();
+      expect(dropped).toBe(0);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("putting the microphone down during the browser's reconnect grace keeps deferred work", async () => {
+    // The browser's socket is gone but its conversation is not: the page comes
+    // back by itself inside the grace window. Reading the attached-socket count
+    // here saw an empty room and called off the transfer, and the reconnect
+    // that followed had nothing left to adopt.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-deact-grace-"));
+    const daemon = startableDaemon(home, undefined, { clients: 0, live: true });
     let dropped = 0;
     try {
       await daemon.start();

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -1428,4 +1428,31 @@ describe("deferred brain work", () => {
       rmSync(home, { recursive: true, force: true });
     }
   });
+
+  test("a definitive browser ending drops deferred work despite an older active job", async () => {
+    // A fresh browser conversation cannot own a job that started before it
+    // attached. Consulting that old lease here lets the fresh conversation
+    // adopt deferred work left by the conversation it replaced.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-definitive-"));
+    let serverOptions: Record<string, unknown> | null = null;
+    const daemon = startableDaemon(home, (opts) => { serverOptions = opts; }, {
+      clients: 1,
+      live: true,
+      activeJobs: 1,
+    });
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      const ended = (serverOptions as unknown as {
+        onConversationEnded?: (ending?: { definitive?: boolean }) => void;
+      } | null)?.onConversationEnded;
+      expect(typeof ended).toBe("function");
+      ended?.({ definitive: true });
+      expect(dropped).toBe(1);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -1156,3 +1156,110 @@ describe("CiceroDaemon lifecycle", () => {
     }
   });
 });
+
+describe("deferred brain work", () => {
+  /**
+   * Override the capability on the daemon's REAL composed brain rather than
+   * replacing the brain: shutdown needs the rest of it, and the wrappers expose
+   * this as a getter-only accessor, so a plain assignment would throw.
+   */
+  function spyOnDropDeferredWork(daemon: CiceroDaemon, spy: () => void): void {
+    const brain = (daemon as unknown as { brain: object }).brain;
+    Object.defineProperty(brain, "dropDeferredWork", { value: spy, configurable: true });
+  }
+
+  function startableDaemon(home: string, capture?: (opts: Record<string, unknown>) => void): CiceroDaemon {
+    const config = loadConfig({}, { home });
+    config.raw.headless = true;
+    config.raw.dashboard = { enabled: false };
+    config.raw.tts_enabled = false;
+    config.raw.web_voice = {
+      enabled: true,
+      port: 0,
+      token: "test-token-that-is-long-enough",
+      tls: { enabled: false },
+    };
+    config.raw.brain = {
+      ...config.raw.brain,
+      backend: "qwen",
+      mode: "subprocess",
+      binary: process.execPath,
+      binary_args: ["-e", "console.log('ok')"],
+      thinking_filler: false,
+    };
+    return new CiceroDaemon(config, {
+      pidFile: join(home, "cicero.pid"),
+      webVoiceServerStarter: (opts: unknown) => {
+        capture?.(opts as Record<string, unknown>);
+        return {
+          scheme: "http",
+          port: 18_446,
+          clientCount: () => 0,
+          notify: () => Promise.resolve(null),
+          stop: () => Promise.resolve(),
+        };
+      },
+      providerFactory: () => ({
+        stt: { name: "t-stt", transcribe: () => Promise.resolve(null), health: () => Promise.resolve(true) },
+        tts: { name: "t-tts", generateAudio: () => Promise.resolve(new ArrayBuffer(0)), health: () => Promise.resolve(true) },
+        llm: { name: "t-llm", chatCompletion: () => Promise.resolve("ok"), health: () => Promise.resolve(true) },
+      }),
+    });
+  }
+
+  test("stopping the daemon tells the brain to drop work it deferred", async () => {
+    // A wiring test, and the wiring IS the fix: for a spoken "stop" the abort
+    // reason is already fixed as the barge-in by the time the stop command
+    // arrives, so this out-of-band notification is the only thing that calls
+    // the work off. There is no brain-injection seam on DaemonOptions, so the
+    // composed brain is swapped after start — move this onto a seam if one is
+    // added later.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-stop-"));
+    const daemon = startableDaemon(home);
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      await daemon.stop();
+      expect(dropped).toBe(1);
+    } finally {
+      await daemon.stop().catch(() => { /* already stopped */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("a voice conversation ending tells the brain to drop work it deferred", async () => {
+    // The browser's Stop aborts the turn and then closes the socket. The close
+    // is what means "conversation over", and it reaches the brain only through
+    // this callback.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-conv-"));
+    let serverOptions: Record<string, unknown> | null = null;
+    const daemon = startableDaemon(home, (opts) => { serverOptions = opts; });
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      const ended = (serverOptions as unknown as { onConversationEnded?: () => void } | null)?.onConversationEnded;
+      expect(typeof ended).toBe("function");
+      ended?.();
+      expect(dropped).toBe(1);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("a throwing dropDeferredWork does not wedge daemon shutdown", async () => {
+    // Fire-and-forget: one bad brain must not block a shutdown.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-throw-"));
+    const daemon = startableDaemon(home);
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { throw new Error("brain exploded"); });
+      await daemon.stop();
+    } finally {
+      await daemon.stop().catch(() => { /* already stopped */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -1429,6 +1429,75 @@ describe("deferred brain work", () => {
     }
   });
 
+  test("a definitive browser ending keeps deferred work while the microphone is live", async () => {
+    // The replacement browser proves only that the older web job cannot own
+    // the pending transfer. It knows nothing about the operator still waiting
+    // for that transfer at the local microphone.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-definitive-mic-"));
+    let serverOptions: Record<string, unknown> | null = null;
+    const daemon = startableDaemon(home, (opts) => { serverOptions = opts; }, {
+      activeJobs: 1,
+    });
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      (daemon as unknown as { voiceDesiredActive: boolean }).voiceDesiredActive = true;
+      const ended = (serverOptions as unknown as {
+        onConversationEnded?: (ending?: { definitive?: boolean }) => void;
+      } | null)?.onConversationEnded;
+      expect(typeof ended).toBe("function");
+      ended?.({ definitive: true });
+      expect(dropped).toBe(0);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("a definitive browser ending keeps deferred work while a local turn is in flight", async () => {
+    // A local turn still owns the shared conversation even when the arriving
+    // browser makes an older web lease irrelevant. Dropping both signals would
+    // call off work while that local turn was still waiting to adopt it.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-definitive-local-turn-"));
+    let serverOptions: Record<string, unknown> | null = null;
+    const daemon = startableDaemon(home, (opts) => { serverOptions = opts; }, {
+      activeJobs: 1,
+    });
+    let dropped = 0;
+    let releaseTurn!: () => void;
+    const turnGate = new Promise<void>((resolve) => { releaseTurn = resolve; });
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => { markStarted = resolve; });
+    let dispatched: Promise<void> | null = null;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      const state = daemon as unknown as {
+        handleCommand: (text: string, signal: AbortSignal) => Promise<void>;
+        dispatchCommand: (text: string) => Promise<void>;
+      };
+      state.handleCommand = async () => {
+        markStarted();
+        await turnGate;
+      };
+      dispatched = state.dispatchCommand("wait for the worker");
+      await started;
+
+      const ended = (serverOptions as unknown as {
+        onConversationEnded?: (ending?: { definitive?: boolean }) => void;
+      } | null)?.onConversationEnded;
+      expect(typeof ended).toBe("function");
+      ended?.({ definitive: true });
+      expect(dropped).toBe(0);
+    } finally {
+      releaseTurn();
+      await dispatched?.catch(() => {});
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test("a definitive browser ending drops deferred work despite an older active job", async () => {
     // A fresh browser conversation cannot own a job that started before it
     // attached. Consulting that old lease here lets the fresh conversation
@@ -1436,8 +1505,6 @@ describe("deferred brain work", () => {
     const home = mkdtempSync(join(tmpdir(), "cicero-deferred-definitive-"));
     let serverOptions: Record<string, unknown> | null = null;
     const daemon = startableDaemon(home, (opts) => { serverOptions = opts; }, {
-      clients: 1,
-      live: true,
       activeJobs: 1,
     });
     let dropped = 0;

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -1027,6 +1027,7 @@ describe("CiceroDaemon lifecycle", () => {
         scheme: "http",
         port: 18_443,
         clientCount: () => 0,
+        activeJobCount: () => 0,
         conversationLive: () => false,
         notify: () => Promise.resolve(null),
         stop: () => Promise.resolve(),
@@ -1120,6 +1121,7 @@ describe("CiceroDaemon lifecycle", () => {
         scheme: "http",
         port: 18_444,
         clientCount: () => 0,
+        activeJobCount: () => 0,
         conversationLive: () => false,
         notify: () => Promise.resolve(null),
         stop: () => Promise.resolve(),
@@ -1178,7 +1180,7 @@ describe("deferred brain work", () => {
   function startableDaemon(
     home: string,
     capture?: (opts: Record<string, unknown>) => void,
-    webVoiceState: { clients?: number; live?: boolean } = {},
+    webVoiceState: { clients?: number; live?: boolean; activeJobs?: number } = {},
   ): CiceroDaemon {
     const config = loadConfig({}, { home });
     config.raw.headless = true;
@@ -1206,6 +1208,7 @@ describe("deferred brain work", () => {
           scheme: "http",
           port: 18_446,
           clientCount: () => webVoiceState.clients ?? 0,
+          activeJobCount: () => webVoiceState.activeJobs ?? 0,
           conversationLive: () => webVoiceState.live ?? (webVoiceState.clients ?? 0) > 0,
           notify: () => Promise.resolve(null),
           stop: () => Promise.resolve(),
@@ -1348,6 +1351,76 @@ describe("deferred brain work", () => {
 
       // ...and once the microphone is down too, the conversation really is over.
       (daemon as unknown as { voiceDesiredActive: boolean }).voiceDesiredActive = false;
+      ended?.();
+      expect(dropped).toBe(1);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("the last browser leaving while a local turn runs keeps deferred work until the turn finishes", async () => {
+    // The local turn itself is the remaining conversation. Looking only at mic
+    // intent and web sockets dropped its transfer even though its owned command
+    // had not returned yet.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-close-local-turn-"));
+    let serverOptions: Record<string, unknown> | null = null;
+    const daemon = startableDaemon(home, (opts) => { serverOptions = opts; });
+    let dropped = 0;
+    let releaseTurn!: () => void;
+    const turnGate = new Promise<void>((resolve) => { releaseTurn = resolve; });
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => { markStarted = resolve; });
+    let dispatched: Promise<void> | null = null;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      const state = daemon as unknown as {
+        handleCommand: (text: string, signal: AbortSignal) => Promise<void>;
+        dispatchCommand: (text: string) => Promise<void>;
+      };
+      state.handleCommand = async () => {
+        markStarted();
+        await turnGate;
+      };
+      dispatched = state.dispatchCommand("wait for the worker");
+      await started;
+
+      const ended = (serverOptions as unknown as { onConversationEnded?: () => void } | null)?.onConversationEnded;
+      expect(typeof ended).toBe("function");
+      ended?.();
+      expect(dropped).toBe(0);
+
+      releaseTurn();
+      await dispatched;
+      expect(dropped).toBe(1);
+    } finally {
+      releaseTurn();
+      await dispatched?.catch(() => {});
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("the last browser leaving during an operator chat job keeps deferred work until its lease releases", async () => {
+    // /api/chat holds the server's existing foreground job lease across
+    // brain.send(). If the daemon ignores that lease, a simultaneous browser
+    // departure calls off work the operator chat is still waiting to adopt.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-close-chat-job-"));
+    let serverOptions: Record<string, unknown> | null = null;
+    const webVoiceState = { clients: 0, live: false, activeJobs: 1 };
+    const daemon = startableDaemon(home, (opts) => { serverOptions = opts; }, webVoiceState);
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      const ended = (serverOptions as unknown as { onConversationEnded?: () => void } | null)?.onConversationEnded;
+      expect(typeof ended).toBe("function");
+      ended?.();
+      expect(dropped).toBe(0);
+
+      webVoiceState.activeJobs = 0;
+      // The real server reuses this callback when the /api/chat lease releases.
       ended?.();
       expect(dropped).toBe(1);
     } finally {

--- a/tests/daemon-lifecycle.test.ts
+++ b/tests/daemon-lifecycle.test.ts
@@ -1168,7 +1168,11 @@ describe("deferred brain work", () => {
     Object.defineProperty(brain, "dropDeferredWork", { value: spy, configurable: true });
   }
 
-  function startableDaemon(home: string, capture?: (opts: Record<string, unknown>) => void): CiceroDaemon {
+  function startableDaemon(
+    home: string,
+    capture?: (opts: Record<string, unknown>) => void,
+    clientCount: () => number = () => 0,
+  ): CiceroDaemon {
     const config = loadConfig({}, { home });
     config.raw.headless = true;
     config.raw.dashboard = { enabled: false };
@@ -1194,7 +1198,7 @@ describe("deferred brain work", () => {
         return {
           scheme: "http",
           port: 18_446,
-          clientCount: () => 0,
+          clientCount,
           notify: () => Promise.resolve(null),
           stop: () => Promise.resolve(),
         };
@@ -1259,6 +1263,68 @@ describe("deferred brain work", () => {
       await daemon.stop();
     } finally {
       await daemon.stop().catch(() => { /* already stopped */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("putting the microphone down with nobody else connected drops deferred work", async () => {
+    // Every way of deactivating the mic — "stop listening", the hotkey, the
+    // dashboard, a clap, a capture failure — funnels through the same
+    // deactivation callback, so this covers all of them.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-deact-"));
+    const daemon = startableDaemon(home);
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      (daemon as unknown as { handleVoiceDeactivated: () => void }).handleVoiceDeactivated();
+      expect(dropped).toBe(1);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("putting the microphone down while a browser is connected keeps deferred work", async () => {
+    // Cicero is one assistant behind every surface. The operator who walked
+    // away from the microphone is still on the line in the browser, and the
+    // transfer they asked for is still theirs.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-deact-web-"));
+    const daemon = startableDaemon(home, undefined, () => 1);
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      (daemon as unknown as { handleVoiceDeactivated: () => void }).handleVoiceDeactivated();
+      expect(dropped).toBe(0);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("the last browser closing while the microphone is live keeps deferred work", async () => {
+    // The mirror image: an idle PWA being closed must not call off a transfer
+    // the operator is waiting on at the microphone.
+    const home = mkdtempSync(join(tmpdir(), "cicero-deferred-close-mic-"));
+    let serverOptions: Record<string, unknown> | null = null;
+    const daemon = startableDaemon(home, (opts) => { serverOptions = opts; });
+    let dropped = 0;
+    try {
+      await daemon.start();
+      spyOnDropDeferredWork(daemon, () => { dropped++; });
+      (daemon as unknown as { voiceDesiredActive: boolean }).voiceDesiredActive = true;
+      const ended = (serverOptions as unknown as { onConversationEnded?: () => void } | null)?.onConversationEnded;
+      expect(typeof ended).toBe("function");
+      ended?.();
+      expect(dropped).toBe(0);
+
+      // ...and once the microphone is down too, the conversation really is over.
+      (daemon as unknown as { voiceDesiredActive: boolean }).voiceDesiredActive = false;
+      ended?.();
+      expect(dropped).toBe(1);
+    } finally {
+      await daemon.stop().catch(() => { /* best effort */ });
       rmSync(home, { recursive: true, force: true });
     }
   });

--- a/tests/listener/full-duplex.test.ts
+++ b/tests/listener/full-duplex.test.ts
@@ -84,6 +84,23 @@ test("a bare 'stop' halts playback without dispatching a turn", async () => {
   expect(received).toBeNull();
 });
 
+test("a bare 'stop' interrupts before it reports the stop", async () => {
+  // Ordering, pinned deliberately: the interrupt must land first so playback
+  // cuts immediately. The consequence is that the turn's abort reason is fixed
+  // as the barge-in and the stop can never replace it, which is why the daemon
+  // tells the brain about a stop out of band (Brain.dropDeferredWork) instead
+  // of encoding it in the reason. Reorder this and revisit that decision.
+  const l = makeListener("stop", SPOKEN);
+  const order: string[] = [];
+  l.onBargeIn(() => { order.push("barge-in"); });
+  l.onStopCommand(() => { order.push("stop"); });
+  l.detectBargeIn = async () => "/tmp/cicero-test-stop-order.wav";
+
+  await l.runFullDuplexTurn(new Promise<void>(() => {}));
+
+  expect(order).toEqual(["barge-in", "stop"]);
+});
+
 test("when the reply finishes before any speech, nothing is interrupted", async () => {
   const l = makeListener("", SPOKEN);
   let interrupted = false;

--- a/tests/web-voice/page.test.ts
+++ b/tests/web-voice/page.test.ts
@@ -12,18 +12,24 @@ test("web-voice page script parses and opts into the identity-safe protocol", ()
   expect(script).toContain('history.replaceState(null, ""');
 });
 
-test("automatic reconnects identify resumes while Start opens a new conversation", () => {
+test("automatic recovery identifies resumes while Start opens a new conversation", () => {
   const script = PAGE.match(/<script>([\s\S]*)<\/script>/)?.[1] ?? "";
   // These are source-level guards because this test cannot execute the page.
-  // Automatic recovery must preserve the waiting conversation, while an
-  // operator pressing Start must end any old conversation still in its grace.
+  // Backoff recovery and reload auto-start must preserve the waiting
+  // conversation, while an operator pressing Start must end any old
+  // conversation still in its grace.
   const schedule = script.slice(script.indexOf("function scheduleReconnect"), script.indexOf("function retryNow"));
   const retry = script.slice(script.indexOf("function retryNow"), script.indexOf('window.addEventListener("online"'));
   const start = script.slice(script.indexOf("async function startConversation"), script.indexOf("function stopConversation"));
+  const click = script.slice(script.indexOf('toggle.addEventListener("click"'), script.indexOf("// Push-to-talk controls"));
+  const autoStart = script.slice(script.indexOf("(async function autoStartOnLoad"), script.indexOf("</script>"));
   expect(schedule).toContain("connectWs(true)");
   expect(retry).toContain("connectWs(true)");
-  expect(start).toContain("connectWs();");
-  expect(start).not.toContain("connectWs(true)");
+  expect(start).toContain("async function startConversation(resume = false)");
+  expect(start).toContain("connectWs(resume)");
+  expect(click).toContain("startConversation()");
+  expect(click).not.toContain("startConversation(true)");
+  expect(autoStart).toContain("await startConversation(true)");
 });
 
 test("orb scales with the viewport instead of a fixed pixel size", () => {

--- a/tests/web-voice/page.test.ts
+++ b/tests/web-voice/page.test.ts
@@ -12,6 +12,20 @@ test("web-voice page script parses and opts into the identity-safe protocol", ()
   expect(script).toContain('history.replaceState(null, ""');
 });
 
+test("automatic reconnects identify resumes while Start opens a new conversation", () => {
+  const script = PAGE.match(/<script>([\s\S]*)<\/script>/)?.[1] ?? "";
+  // These are source-level guards because this test cannot execute the page.
+  // Automatic recovery must preserve the waiting conversation, while an
+  // operator pressing Start must end any old conversation still in its grace.
+  const schedule = script.slice(script.indexOf("function scheduleReconnect"), script.indexOf("function retryNow"));
+  const retry = script.slice(script.indexOf("function retryNow"), script.indexOf('window.addEventListener("online"'));
+  const start = script.slice(script.indexOf("async function startConversation"), script.indexOf("function stopConversation"));
+  expect(schedule).toContain("connectWs(true)");
+  expect(retry).toContain("connectWs(true)");
+  expect(start).toContain("connectWs();");
+  expect(start).not.toContain("connectWs(true)");
+});
+
 test("orb scales with the viewport instead of a fixed pixel size", () => {
   expect(PAGE).toContain("#orb { width:clamp(230px, 80vmin, calc(100dvh - 260px)); aspect-ratio:1/1;");
   expect(PAGE).not.toContain("width:230px; height:230px");

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -562,6 +562,45 @@ test("global admission returns 429 instead of spawning unbounded chat work", asy
   expect((await Promise.all(active)).every((response) => response.status === 200)).toBe(true);
 });
 
+test("a say job re-reports a departure that arrived while its lease was active", async () => {
+  // Say holds the same foreground lease as chat but has no route-specific
+  // completion path. Re-reporting at the route left a stopped conversation's
+  // cold transfer available for the next turn when speech synthesis finished.
+  const entered = deferred();
+  const release = deferred();
+  let ended = 0;
+  const base = start({
+    onConversationEnded: () => {
+      ended++;
+      throw new Error("ending hook stays fire-and-forget");
+    },
+    onSay: async () => {
+      entered.resolve();
+      await release.promise;
+      return wav();
+    },
+  });
+  const ws = await connect(base);
+  const request = fetch(base + "/api/say", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "hold this synthesis" }),
+  });
+  await entered.promise;
+  ws.send(JSON.stringify({ type: "bye" }));
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(ended).toBe(1);
+
+  release.resolve();
+  expect((await request).status).toBe(200);
+  expect(handle!.activeJobCount()).toBe(0);
+  expect(ended).toBe(2);
+  ws.close();
+  await Bun.sleep(30);
+  expect(ended).toBe(2);
+});
+
 test("a chat turn that saw no departure does not report a conversation ending", async () => {
   // The other side of the re-report above, and it earns its place: firing on
   // every release would end conversations that never ended. On a box driven
@@ -583,7 +622,7 @@ test("a chat turn that saw no departure does not report a conversation ending", 
 test("activeJobCount exposes an operator chat lease and re-reports departure when it releases", async () => {
   // This is the real lease used by /api/chat. Returning a disconnected counter
   // here would let the daemon declare the conversation over while brain.send()
-  // was still waiting on a cold transfer; omitting the completion callback
+  // was still waiting on a cold transfer; omitting the release-time re-report
   // would then retain that work forever.
   const entered = deferred();
   const release = deferred();
@@ -611,6 +650,60 @@ test("activeJobCount exposes an operator chat lease and re-reports departure whe
 
   release.resolve();
   expect((await request).status).toBe(200);
+  expect(handle!.activeJobCount()).toBe(0);
+  expect(ended).toBe(2);
+  ws.close();
+  await Bun.sleep(30);
+  expect(ended).toBe(2);
+});
+
+test("overlapping jobs re-report a departure once when the last lease releases", async () => {
+  // The first release still leaves an HTTP input surface alive. Consuming the
+  // remembered ending there either ends too early or leaves the last route
+  // unable to report it when that route has no completion callback of its own.
+  const chatEntered = deferred();
+  const sayEntered = deferred();
+  const releaseChat = deferred();
+  const releaseSay = deferred();
+  let ended = 0;
+  const base = start({
+    onConversationEnded: () => { ended++; },
+    onChat: async () => {
+      chatEntered.resolve();
+      await releaseChat.promise;
+      return "ok";
+    },
+    onSay: async () => {
+      sayEntered.resolve();
+      await releaseSay.promise;
+      return wav();
+    },
+  });
+  const ws = await connect(base);
+  const chatRequest = fetch(base + "/api/chat", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "first lease" }),
+  });
+  const sayRequest = fetch(base + "/api/say", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "last lease" }),
+  });
+  await Promise.all([chatEntered.promise, sayEntered.promise]);
+  expect(handle!.activeJobCount()).toBe(2);
+  ws.send(JSON.stringify({ type: "bye" }));
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(ended).toBe(1);
+
+  releaseChat.resolve();
+  expect((await chatRequest).status).toBe(200);
+  expect(handle!.activeJobCount()).toBe(1);
+  expect(ended).toBe(1);
+
+  releaseSay.resolve();
+  expect((await sayRequest).status).toBe(200);
   expect(handle!.activeJobCount()).toBe(0);
   expect(ended).toBe(2);
   ws.close();

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -93,6 +93,7 @@ function start(opts: {
   shutdownDrainTimeoutMs?: number;
   vadDir?: string;
   onConversationEnded?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onConversationEnded"]>;
+  conversationEndGraceMs?: number;
 } = {}): string {
   handle = startWebVoiceServer({
     host: "127.0.0.1",
@@ -116,6 +117,7 @@ function start(opts: {
     shutdownDrainTimeoutMs: opts.shutdownDrainTimeoutMs,
     vadDir: opts.vadDir,
     onConversationEnded: opts.onConversationEnded,
+    conversationEndGraceMs: opts.conversationEndGraceMs ?? 0,
   });
   if (!handle) throw new Error("server failed to start");
   return `http://127.0.0.1:${handle.port}`;
@@ -2110,4 +2112,51 @@ test("one browser leaving does not end a conversation another is still in", asyn
   second.close();
   await Bun.sleep(50);
   expect(ended).toBe(1);
+});
+
+test("a dropped socket does not end the conversation while the page reconnects", async () => {
+  // The PWA reconnects by itself (1s → 2s → 5s) whenever the operator has not
+  // stopped it, so a tunnel or a sleeping laptop must not be read as "we're
+  // done" — that threw away a cold transfer the operator was still waiting on.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 300 });
+  const first = await connect(base);
+  first.close();
+  await Bun.sleep(60);
+  expect(ended).toBe(0);          // still within the grace
+  const second = await connect(base); // ...and the page comes back
+  await Bun.sleep(400);
+  expect(ended).toBe(0);          // the reconnect cancelled the ending outright
+  second.close();
+  await Bun.sleep(400);
+  expect(ended).toBe(1);          // nobody came back this time
+});
+
+test("saying goodbye ends the conversation without waiting out the grace", async () => {
+  // Stop is not a disconnect: it must take effect at once, or pressing Stop and
+  // Start again inside the grace would resurrect the work it called off.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 10_000 });
+  const ws = await connect(base);
+  ws.send(JSON.stringify({ type: "bye" }));
+  await Bun.sleep(30);
+  ws.close();
+  await Bun.sleep(60);
+  expect(ended).toBe(1);
+});
+
+test("a pending conversation end does not outlive the server", async () => {
+  // The timer is owned: a shutdown mid-grace must not leave it armed.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 200 });
+  const ws = await connect(base);
+  ws.close();
+  await Bun.sleep(20);
+  await handle!.stop();
+  handle = null;
+  const afterStop = ended;
+  expect(afterStop).toBeGreaterThanOrEqual(1); // shutdown ends it immediately
+  await Bun.sleep(400);
+  expect(ended).toBe(afterStop);              // ...and the armed timer never fires again
+  expect(base).toContain("127.0.0.1");
 });

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -2145,6 +2145,39 @@ test("saying goodbye ends the conversation without waiting out the grace", async
   expect(ended).toBe(1);
 });
 
+test("a conversation with no socket attached is still live during its grace", async () => {
+  // What the daemon reads to decide whether anybody is still on the line. The
+  // attached-socket count alone says "empty room" for the whole grace window,
+  // so another surface going away meanwhile concluded the conversation was over
+  // and called off work the reconnecting page would have come back to.
+  const base = start({ conversationEndGraceMs: 300 });
+  const ws = await connect(base);
+  expect(handle!.conversationLive()).toBe(true);
+  ws.close();
+  await Bun.sleep(60);
+  expect(handle!.clientCount()).toBe(0);
+  expect(handle!.conversationLive()).toBe(true);   // ...but not over
+  await Bun.sleep(400);
+  expect(handle!.conversationLive()).toBe(false);  // the grace ran out
+  expect(base).toContain("127.0.0.1");
+});
+
+test("shutting down with a socket attached does not re-arm the conversation end", async () => {
+  // stop() ends the conversation and then closes its sockets, and every one of
+  // those closes lands in the same handler that arms the grace timer. Arming it
+  // there scheduled a second ending for a server that had already torn down.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 200 });
+  const ws = await connect(base);
+  await handle!.stop();
+  handle = null;
+  expect(ended).toBe(1);
+  await Bun.sleep(400);
+  expect(ended).toBe(1);
+  ws.close();
+  expect(base).toContain("127.0.0.1");
+});
+
 test("a pending conversation end does not outlive the server", async () => {
   // The timer is owned: a shutdown mid-grace must not leave it armed.
   let ended = 0;

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -562,6 +562,62 @@ test("global admission returns 429 instead of spawning unbounded chat work", asy
   expect((await Promise.all(active)).every((response) => response.status === 200)).toBe(true);
 });
 
+test("a chat turn that saw no departure does not report a conversation ending", async () => {
+  // The other side of the re-report above, and it earns its place: firing on
+  // every release would end conversations that never ended. On a box driven
+  // entirely through /api/chat that means the turn which just parked a cold
+  // transfer immediately calls it off, because at release there is no socket
+  // attached and never was.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, onChat: async () => "ok" });
+  const response = await fetch(base + "/api/chat", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "no browser has ever been here" }),
+  });
+  expect(response.status).toBe(200);
+  expect(handle!.activeJobCount()).toBe(0);
+  expect(ended).toBe(0);
+});
+
+test("activeJobCount exposes an operator chat lease and re-reports departure when it releases", async () => {
+  // This is the real lease used by /api/chat. Returning a disconnected counter
+  // here would let the daemon declare the conversation over while brain.send()
+  // was still waiting on a cold transfer; omitting the completion callback
+  // would then retain that work forever.
+  const entered = deferred();
+  const release = deferred();
+  let ended = 0;
+  const base = start({
+    onConversationEnded: () => { ended++; },
+    onChat: async () => {
+      entered.resolve();
+      await release.promise;
+      return "ok";
+    },
+  });
+  const ws = await connect(base);
+  const request = fetch(base + "/api/chat", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "keep this conversation alive" }),
+  });
+  await entered.promise;
+  expect(handle!.activeJobCount()).toBe(1);
+  ws.send(JSON.stringify({ type: "bye" }));
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(ended).toBe(1);
+
+  release.resolve();
+  expect((await request).status).toBe(200);
+  expect(handle!.activeJobCount()).toBe(0);
+  expect(ended).toBe(2);
+  ws.close();
+  await Bun.sleep(30);
+  expect(ended).toBe(2);
+});
+
 test("body readers acquire global admission before parsing completes", async () => {
   const base = start({ onChat: async () => "ok" });
   const controllers: ReadableStreamDefaultController<Uint8Array>[] = [];
@@ -2195,6 +2251,57 @@ test("saying goodbye ends the conversation without waiting out the grace", async
   await Bun.sleep(30);
   ws.close();
   await Bun.sleep(60);
+  expect(ended).toBe(1);
+});
+
+test("goodbye ends before a replacement socket opens and the old close is a lifecycle no-op", async () => {
+  // Stop and Start can overlap at the transport layer. If goodbye is merely
+  // remembered until close, the replacement joins first and both handlers see
+  // another client, so the stopped conversation is never ended.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 10_000 });
+  const stopped = await connect(base);
+  stopped.send(JSON.stringify({ type: "bye" }));
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(handle!.clientCount()).toBe(0);
+  expect(ended).toBe(1);
+
+  const replacement = await connect(base);
+  stopped.close();
+  await Bun.sleep(60);
+  expect(ended).toBe(1);
+  expect(handle!.clientCount()).toBe(1);
+  replacement.close();
+});
+
+test("goodbye detaches one client without ending another client's conversation or arming grace", async () => {
+  // One browser's goodbye removes it at once, but the other browser remains the
+  // same single-operator conversation. The departed socket's later close must
+  // not leave a timer behind that can report a second ending.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 100 });
+  const departed = await connect(base);
+  const remaining = await connect(base);
+  departed.send(JSON.stringify({ type: "bye" }));
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 1 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(handle!.clientCount()).toBe(1);
+  expect(ended).toBe(0);
+
+  departed.close();
+  await Bun.sleep(180);
+  expect(ended).toBe(0);
+  expect(handle!.conversationLive()).toBe(true);
+
+  remaining.send(JSON.stringify({ type: "bye" }));
+  const endedBy = Date.now() + 1_000;
+  while (ended !== 1 && Date.now() < endedBy) await Bun.sleep(5);
+  expect(ended).toBe(1);
+  expect(handle!.clientCount()).toBe(0);
+  expect(handle!.conversationLive()).toBe(false);
+  remaining.close();
+  await Bun.sleep(180);
   expect(ended).toBe(1);
 });
 

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -139,9 +139,9 @@ function connectV2(base: string): Promise<{ ws: WebSocket; sessionId: string }> 
   });
 }
 
-function connect(base: string): Promise<WebSocket> {
+function connect(base: string, resume = false): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN);
+    const ws = new WebSocket(base.replace("http", "ws") + "/ws?token=" + TOKEN + (resume ? "&resume=1" : ""));
     const timer = setTimeout(() => reject(new Error("socket open timeout")), 3_000);
     ws.onopen = () => { clearTimeout(timer); resolve(ws); };
     ws.onerror = () => { clearTimeout(timer); reject(new Error("socket open failed")); };
@@ -2124,12 +2124,65 @@ test("a dropped socket does not end the conversation while the page reconnects",
   first.close();
   await Bun.sleep(60);
   expect(ended).toBe(0);          // still within the grace
-  const second = await connect(base); // ...and the page comes back
+  const second = await connect(base, true); // ...and the page comes back
   await Bun.sleep(400);
   expect(ended).toBe(0);          // the reconnect cancelled the ending outright
   second.close();
   await Bun.sleep(400);
   expect(ended).toBe(1);          // nobody came back this time
+});
+
+test("a fresh connection during the grace ends the conversation that was waiting", async () => {
+  // Pressing Start after an explicit Stop attempted during reconnect backoff is
+  // a new conversation. The old grace must end promptly or its deferred cold
+  // transfer survives into the new conversation and can pin the shared lane.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 10_000 });
+  const first = await connect(base);
+  first.close();
+  await Bun.sleep(30);
+  expect(ended).toBe(0);
+  const fresh = await connect(base);
+  await Bun.sleep(30);
+  expect(ended).toBe(1);
+  fresh.close();
+});
+
+test("a resume connection during the grace does not end the conversation", async () => {
+  // An automatic reconnect continues the same conversation after an ordinary
+  // network drop. Ending it on arrival would discard deferred work the operator
+  // is still waiting for even though the page never stopped.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 10_000 });
+  const first = await connect(base);
+  first.close();
+  await Bun.sleep(30);
+  expect(ended).toBe(0);
+  const resumed = await connect(base, true);
+  await Bun.sleep(30);
+  expect(ended).toBe(0);
+  resumed.close();
+});
+
+test("a second device starting does not end the conversation another is still in", async () => {
+  // A resume deliberately leaves the grace timer armed — it re-checks the room
+  // when it fires — so a client can be attached with a timer still pending. A
+  // fresh connection arriving in that state is a second screen joining, not a
+  // restart of an abandoned conversation, and ending the conversation there
+  // would call off a cold transfer the reconnected page is still waiting on.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 10_000 });
+  const first = await connect(base);
+  first.close();
+  await Bun.sleep(30);
+  const resumed = await connect(base, true);   // the page comes back; timer still armed
+  await Bun.sleep(30);
+  expect(ended).toBe(0);
+  const second = await connect(base);          // another device presses Start
+  await Bun.sleep(30);
+  expect(ended).toBe(0);
+  resumed.close();
+  second.close();
 });
 
 test("saying goodbye ends the conversation without waiting out the grace", async () => {

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -2094,3 +2094,20 @@ test("a throwing conversation-ended hook does not break socket teardown", async 
   const res = await fetch(`${base}/api/health`, { headers: { Authorization: `Bearer ${TOKEN}` } });
   expect(res.status).toBeLessThan(500);
 });
+
+test("one browser leaving does not end a conversation another is still in", async () => {
+  // Every connected browser reaches the same brain, switchboard and active lane
+  // (docs/web-voice.md, "Deliberate multi-client boundary"): one conversation on
+  // several screens. Reporting its end per socket let one browser closing call
+  // off a cold transfer another was still waiting on.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; } });
+  const first = await connect(base);
+  const second = await connect(base);
+  first.close();
+  await Bun.sleep(50);
+  expect(ended).toBe(0);
+  second.close();
+  await Bun.sleep(50);
+  expect(ended).toBe(1);
+});

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -694,14 +694,15 @@ test("a replacement socket does not leave its predecessor's ending owed to a lat
   const replacementAttachedBy = Date.now() + 1_000;
   while (handle!.clientCount() === 0 && Date.now() < replacementAttachedBy) await Bun.sleep(5);
   expect(handle!.clientCount()).toBe(1);
+  expect(ended).toBe(2);
   releaseSay.resolve();
   expect((await say).status).toBe(200);
-  expect(ended).toBe(1);
+  expect(ended).toBe(2);
 
   replacement.send(JSON.stringify({ type: "bye" }));
   const replacementDetachedBy = Date.now() + 1_000;
   while (handle!.clientCount() !== 0 && Date.now() < replacementDetachedBy) await Bun.sleep(5);
-  expect(ended).toBe(2);
+  expect(ended).toBe(3);
 
   const chat = await fetch(base + "/api/chat", {
     method: "POST",
@@ -710,9 +711,90 @@ test("a replacement socket does not leave its predecessor's ending owed to a lat
   });
   expect(chat.status).toBe(200);
   expect(handle!.activeJobCount()).toBe(0);
-  expect(ended).toBe(2);
+  expect(ended).toBe(3);
   first.close();
   replacement.close();
+});
+
+test("a new conversation definitively ends the previous conversation whose ending is owed", async () => {
+  // The old say lease began before the replacement conversation existed. Its
+  // presence must not let the new conversation inherit work that the daemon
+  // declined to drop when the old conversation first said goodbye.
+  const sayEntered = deferred();
+  const releaseSay = deferred();
+  const endings: boolean[] = [];
+  const base = start({
+    onConversationEnded: (ending?: { definitive?: boolean }) => {
+      endings.push(ending?.definitive === true);
+    },
+    onSay: async () => {
+      sayEntered.resolve();
+      await releaseSay.promise;
+      return wav();
+    },
+  });
+  const first = await connect(base);
+  const say = fetch(base + "/api/say", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "work from the old conversation" }),
+  });
+  await sayEntered.promise;
+  first.send(JSON.stringify({ type: "bye" }));
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(endings).toEqual([false]);
+
+  const fresh = await connect(base);
+  const attachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() === 0 && Date.now() < attachedBy) await Bun.sleep(5);
+  expect(endings).toEqual([false, true]);
+
+  releaseSay.resolve();
+  expect((await say).status).toBe(200);
+  expect(endings).toEqual([false, true]);
+  first.close();
+  fresh.close();
+});
+
+test("a resume does not definitively end the conversation whose ending is owed", async () => {
+  // An automatic reconnect continues the same conversation, so it must keep
+  // the deferred transfer that the still-running old lease may complete.
+  const sayEntered = deferred();
+  const releaseSay = deferred();
+  const endings: boolean[] = [];
+  const base = start({
+    onConversationEnded: (ending?: { definitive?: boolean }) => {
+      endings.push(ending?.definitive === true);
+    },
+    onSay: async () => {
+      sayEntered.resolve();
+      await releaseSay.promise;
+      return wav();
+    },
+  });
+  const first = await connect(base);
+  const say = fetch(base + "/api/say", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "work from the continuing conversation" }),
+  });
+  await sayEntered.promise;
+  first.send(JSON.stringify({ type: "bye" }));
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(endings).toEqual([false]);
+
+  const resumed = await connect(base, true);
+  const attachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() === 0 && Date.now() < attachedBy) await Bun.sleep(5);
+  expect(endings).toEqual([false]);
+
+  releaseSay.resolve();
+  expect((await say).status).toBe(200);
+  expect(endings).toEqual([false]);
+  first.close();
+  resumed.close();
 });
 
 test("overlapping jobs re-report a departure once when the last lease releases", async () => {
@@ -1716,6 +1798,29 @@ test("ws: a typed {type:'text'} frame runs the text turn and streams the reply",
   expect(JSON.parse(msgs[3] as string)).toEqual({ type: "done" });
 });
 
+test("ws: a text frame after goodbye does not produce a turn", async () => {
+  // Stop is terminal for this socket. A frame already following it through the
+  // transport cannot become input for a conversation the operator just ended.
+  let turns = 0;
+  const base = start({
+    onTextTurn: async (_text, sink) => {
+      turns += 1;
+      sink.done();
+    },
+  });
+  const ws = await connect(base);
+  const closed = new Promise<void>((resolve) => {
+    ws.addEventListener("close", () => resolve(), { once: true });
+  });
+  ws.send(JSON.stringify({ type: "bye" }));
+  ws.send(JSON.stringify({ type: "text", text: "too late" }));
+  await Promise.race([
+    closed,
+    Bun.sleep(2_000).then(() => { throw new Error("goodbye socket did not close"); }),
+  ]);
+  expect(turns).toBe(0);
+});
+
 test("ws: typed frame without onTextTurn reports 'typed input not available'", async () => {
   const base = start({ onStreamTurn: async () => { /* unused */ } });
   const reply = await new Promise<string>((resolve, reject) => {
@@ -2423,6 +2528,36 @@ test("goodbye ends before a replacement socket opens and the old close is a life
   await Bun.sleep(60);
   expect(ended).toBe(1);
   expect(handle!.clientCount()).toBe(1);
+  replacement.close();
+});
+
+test("goodbye releases owned connection slots and its close does not end the conversation twice", async () => {
+  // Detached sockets are still server-owned transports until they close. If
+  // goodbye leaves them open outside admission accounting, repeated Stops can
+  // accumulate more live transports than the connection limit is meant to own.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; }, conversationEndGraceMs: 10_000 });
+  const sockets = await Promise.all(
+    Array.from({ length: MAX_WEB_VOICE_CLIENTS }, () => connect(base)),
+  );
+  const closed = sockets.map((ws) => new Promise<void>((resolve) => {
+    ws.addEventListener("close", () => resolve(), { once: true });
+  }));
+  for (const ws of sockets) ws.send(JSON.stringify({ type: "bye" }));
+
+  const detachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < detachedBy) await Bun.sleep(5);
+  expect(handle!.clientCount()).toBe(0);
+  await Promise.race([
+    Promise.all(closed),
+    Bun.sleep(2_000).then(() => { throw new Error("goodbye sockets did not close"); }),
+  ]);
+  expect(ended).toBe(1);
+
+  const replacement = await connect(base);
+  expect(handle!.clientCount()).toBe(1);
+  await Bun.sleep(60);
+  expect(ended).toBe(1);
   replacement.close();
 });
 

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -92,6 +92,7 @@ function start(opts: {
   confirmations?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["confirmations"]>;
   shutdownDrainTimeoutMs?: number;
   vadDir?: string;
+  onConversationEnded?: NonNullable<Parameters<typeof startWebVoiceServer>[0]["onConversationEnded"]>;
 } = {}): string {
   handle = startWebVoiceServer({
     host: "127.0.0.1",
@@ -114,6 +115,7 @@ function start(opts: {
     confirmations: opts.confirmations,
     shutdownDrainTimeoutMs: opts.shutdownDrainTimeoutMs,
     vadDir: opts.vadDir,
+    onConversationEnded: opts.onConversationEnded,
   });
   if (!handle) throw new Error("server failed to start");
   return `http://127.0.0.1:${handle.port}`;
@@ -2055,4 +2057,40 @@ test("/vad serves only whitelisted, present assets — unauthenticated, immutabl
 test("/vad without a configured directory stays 404", async () => {
   const base = start({});
   expect((await fetch(`${base}/vad/ort.wasm.min.js`)).status).toBe(404);
+});
+
+test("a closed voice socket reports the conversation as ended", async () => {
+  // The page's Stop button aborts the active turn and THEN closes the socket.
+  // The abort reason is fixed by the first call, so the close is invisible to
+  // anything reading it — a brain holding deferred work for this conversation
+  // has to be told out of band, or it carries that work into the next one.
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; } });
+  const ws = await connect(base);
+  expect(ended).toBe(0);
+  ws.close();
+  await Bun.sleep(50);
+  expect(ended).toBe(1);
+});
+
+test("shutting the voice server down reports the conversation as ended", async () => {
+  let ended = 0;
+  const base = start({ onConversationEnded: () => { ended++; } });
+  const ws = await connect(base);
+  await handle!.stop();
+  handle = null;
+  try { ws.close(); } catch { /* already gone */ }
+  expect(ended).toBeGreaterThanOrEqual(1);
+  expect(base).toContain("127.0.0.1");
+});
+
+test("a throwing conversation-ended hook does not break socket teardown", async () => {
+  // Fire-and-forget: a brain that throws here must not take the socket handler
+  // down with it, or one bad brain wedges every disconnect.
+  const base = start({ onConversationEnded: () => { throw new Error("brain exploded"); } });
+  const ws = await connect(base);
+  ws.close();
+  await Bun.sleep(50);
+  const res = await fetch(`${base}/api/health`, { headers: { Authorization: `Bearer ${TOKEN}` } });
+  expect(res.status).toBeLessThan(500);
 });

--- a/tests/web-voice/server.test.ts
+++ b/tests/web-voice/server.test.ts
@@ -657,6 +657,64 @@ test("activeJobCount exposes an operator chat lease and re-reports departure whe
   expect(ended).toBe(2);
 });
 
+test("a replacement socket does not leave its predecessor's ending owed to a later chat", async () => {
+  // The first departure was remembered while synthesis ran, but its replacement
+  // arrived before that job drained and later delivered its own ending directly.
+  // Keeping the first debt after both events makes an unrelated socketless chat
+  // report a second ending and discard work belonging to the new conversation.
+  const sayEntered = deferred();
+  const releaseSay = deferred();
+  let ended = 0;
+  const base = start({
+    onConversationEnded: () => { ended++; },
+    onSay: async () => {
+      sayEntered.resolve();
+      await releaseSay.promise;
+      return wav();
+    },
+    onChat: async () => "later work stays parked",
+  });
+  const first = await connect(base);
+  const say = fetch(base + "/api/say", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "hold the old job" }),
+  });
+  await sayEntered.promise;
+  first.send(JSON.stringify({ type: "bye" }));
+  const firstDetachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < firstDetachedBy) await Bun.sleep(5);
+  expect(ended).toBe(1);
+
+  const replacement = await connect(base);
+  // The client sees its socket open when the handshake response arrives, which
+  // is before the server has run its own open handler and counted it. Draining
+  // the held job on that window is the ordinary departure-then-drain case, not
+  // the replacement case this test is about.
+  const replacementAttachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() === 0 && Date.now() < replacementAttachedBy) await Bun.sleep(5);
+  expect(handle!.clientCount()).toBe(1);
+  releaseSay.resolve();
+  expect((await say).status).toBe(200);
+  expect(ended).toBe(1);
+
+  replacement.send(JSON.stringify({ type: "bye" }));
+  const replacementDetachedBy = Date.now() + 1_000;
+  while (handle!.clientCount() !== 0 && Date.now() < replacementDetachedBy) await Bun.sleep(5);
+  expect(ended).toBe(2);
+
+  const chat = await fetch(base + "/api/chat", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "park work for the later conversation" }),
+  });
+  expect(chat.status).toBe(200);
+  expect(handle!.activeJobCount()).toBe(0);
+  expect(ended).toBe(2);
+  first.close();
+  replacement.close();
+});
+
 test("overlapping jobs re-report a departure once when the last lease releases", async () => {
   // The first release still leaves an HTTP input surface alive. Consuming the
   // remembered ending there either ends too early or leaves the last route


### PR DESCRIPTION
## The live failure

On a call, 2026-07-30. The ask was "get Rick"; Rick never arrived.

```
03:04:55  tone: <unk> 0.34 (3100ms)          <- "get Rick"
03:04:55  acp_adapter.entry: Starting hermes-agent ACP adapter
          ...14 seconds of dead air...
03:05:09  🧠 ACP brain connected (hermes) session=05fda3c1
03:05:11  Prompt on session d04f428a          <- the FRONT DESK, not Rick
```

**There is no `switchboard: pinned to think` line anywhere in that window.** The
lane came up and sat unpinned. Across the two failed calls the sidecar received
replies of 11 and 8 characters and nothing else — filler-length ("One moment.",
"Hold on.") — because no turn ever survived to completion.

It worked at 03:06:53 for one reason: the lane was warm by then, so the pin was
instant and nothing could supersede it.

## Cause

A lane cold start takes seconds — ~14s here for grok-4.5 plus its memory
provider. Cicero speaks one filler and then nothing. The caller speaks into the
silence, that barge-in opens a new turn and supersedes the pending transfer, and
`pinLane`'s post-wait assertion throws. The request is discarded silently. The
start itself is deliberately not cancelled, so the lane comes up anyway — with
nobody pinned to it and no indication to the user that anything was ever asked.

## Fix

The obvious repair — resurrect the transfer when the lane finishes loading — is
wrong here, and deliberately not what this does. AGENTS.md: *"Late work from an
aborted or superseded turn must not publish output into a newer turn."* Pinning a
lane on behalf of a turn the user already talked over is exactly that, and
`pinLane`'s comments and tests show the current behavior was a considered choice.

So the superseded turn is untouched: it still rejects, still pins nothing, still
injects no brief. What changes is that the **ask is recorded before the wait**, so
the front desk stops answering as though nobody asked. A later turn — on its own
live lease — either reports the wait or completes the pin itself.

```
You:    "get Rick"
Cicero: "One moment."
You:    "hello?"          (barge-in during the cold start)
Cicero: "Still getting Rick on the line — one moment."
You:    "you there?"
Rick:   "Yeah, Rick here."
```

Supporting rules, each with a regression:
- Any pin that runs to a conclusion clears the pending ask — **including a pin of
  a different lane**, which is the user changing their mind ("get the worker… no,
  the coder"). Without this a slow lane seizes the line when its start lands.
- A lifecycle boundary (`stop`/`restart`) voids it — the lane it named is being
  retired out from under it.
- A start that **fails** reports honestly rather than holding the caller for a
  lane that will never arrive. A "still coming" ack must not outlive its start.
- `"that's all"` cancels a pending transfer, so the hold is not the one state the
  user cannot exit.

## Scope — what this does NOT fix

- **It does not shorten the 14s cold start.** That is the ACP lane's own startup.
- **A caller who stays silent through the wait still hears silence** after the
  first filler. This fix is reactive: it answers correctly when you speak. Filling
  the wait proactively, or pre-warming lanes at boot, are separate changes.

## Verification

- `bun run typecheck` — clean
- `bun test tests/brain/switchboard.test.ts` — 113 pass, 0 fail
- Full `bun test` — 2417 pass / 6 skip / 2 fail / 1 error vs **2413 / 6 / 2 / 1 on
  the untouched baseline**: exactly +4 (the new regressions), identical failure
  count. Both failures are pre-existing and environmental — `terminal-send-errors`
  asserts stderr text that Bun colorizes with ANSI codes under a TTY; it fails the
  same way on a clean tree.
- `git diff --check` — clean

**Mutation proofs** (each neutered alone, then restored):

| Mutation | Result |
|---|---|
| `resolvePendingTransfer` never answers | 3 new regressions fail (110/3) |
| the ask is never recorded before the wait | 3 new regressions fail (110/3) |
| both lifecycle clears removed | existing `restart stays closed until retired cold-lane cleanup finishes` fails |
| a concluded pin no longer clears the ask | 2 existing tests fail (`back to cicero` release, magic-phrase execution) |

Not verified by CI: no real call was placed. The diagnosis is from the daemon log,
`tgcall.log` reply-sentence lengths, and `history.jsonl` for that call.

Companion to #73, which fixes the *other* failure from the same night — the typed
"have him call me" fallback answering with a supersession error. Independent
changes; either can land alone.
