### PR TITLE
fix(switchboard): a bare group-action name no longer fans out to every lane

### DIFF
--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -1116,17 +1116,30 @@ export class SwitchboardBrain implements Brain {
     if (!label) return null;
     // The classifier sometimes labels a bare "what's the status?" as a team
     // standup (seen live 2026-07-11 — the front desk hijacked a question meant
-    // for the pinned lane). Group actions demand a group word, an explicit
-    // request bound to the action name, or confirmation of a prior request.
-    const group = /\b(?:every(?:one|body)|team|office|all|each|agents?|staff|group|hands)\b/i;
+    // for the pinned lane). Group actions demand a group word, a request frame
+    // bound to the action name, or confirmation that repeats the name. Ambiguous
+    // verbs need an article because "have roll call me back" was an STT rendering
+    // of a named dial-back, and any utterance the dial-back matcher recognizes
+    // must win even when it also contains group evidence.
+    // "hands" only counts as a group in "hands on deck". Bare, it admitted any
+    // sentence the word wandered into — "take roll call off my hands" named no
+    // group at all and still fanned out to every lane. "all hands" keeps
+    // working through the "all" branch.
+    const group = /\b(?:every(?:one|body)|team|office|all|each|agents?|staff|group|hands\s+on\s+deck)\b/i;
     const literal = label === "rollcall" ? /\broll\s?-?calls?\b/i : /\bstand\s?-?ups?\b/i;
-    const request = new RegExp(String.raw`\b(?:(?:run|do|start|begin|initiate|hold|have|take)(?:\s+(?:a|an|the|another))?|give\s+me(?:\s+(?:a|an|the|another))?|let['’]s\s+(?:do|have)(?:\s+(?:a|an|the|another))?)\s+${literal.source}`, "i");
+    const request = new RegExp(String.raw`\b(?:(?:run|do|start|begin|initiate|hold)(?:\s+(?:a|an|the|another))?|(?:have|take|get)\s+(?:a|an|the|another)|(?:i\s+want|i(?:['’]d|\s+would)\s+like|i\s+need|can\s+you|could\s+you|would\s+you)(?:\s+(?:a|an|the|another))?|give\s+me(?:\s+(?:a|an|the|another))?|let['’]s\s+(?:do|have)(?:\s+(?:a|an|the|another))?)\s+${literal.source}`, "i");
     const confirmation = /^\s*(?:yes|yeah|yep|correct|right)\b|\bthat['’]s\s+what\s+i\s+(?:just\s+)?said\b/i;
-    if ((label === "standup" || label === "rollcall") && !group.test(utterance)
-      && !request.test(utterance) && !(confirmation.test(utterance) && literal.test(utterance))
-    ) {
-      log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" has no group request or confirmation — ignoring`);
-      return null;
+    if (label === "standup" || label === "rollcall") {
+      if (matchCallMe(utterance)) {
+        log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" is a dial-back request — ignoring`);
+        return null;
+      }
+      if (!group.test(utterance) && !request.test(utterance)
+        && !(confirmation.test(utterance) && literal.test(utterance))
+      ) {
+        log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" has no group request or confirmation — ignoring`);
+        return null;
+      }
     }
     if (label === "standup") return "standup";
     if (label === "rollcall") return this.doRollcall(turn);

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -328,6 +328,9 @@ export class SwitchboardBrain implements Brain {
   private rollcall: RollcallVoiceQueue | null = null;
   /** True when the last turn was answered lexically (ack/roll call/standup). */
   private control = false;
+  /** A rejected classifier label must not return through a front-desk reply
+   * that parrots the same group-action trigger later in the turn. */
+  private refusedGroupAction = false;
   /** The group action "again" repeats; cleared when a normal brain turn intervenes. */
   private lastGroupAction: "rollcall" | "standup" | null = null;
   /** The most recent real exchange, for handoff briefings on transfer. */
@@ -1131,12 +1134,14 @@ export class SwitchboardBrain implements Brain {
     const confirmation = /^\s*(?:yes|yeah|yep|correct|right)\b|\bthat['’]s\s+what\s+i\s+(?:just\s+)?said\b/i;
     if (label === "standup" || label === "rollcall") {
       if (matchCallMe(utterance)) {
+        this.refusedGroupAction = true;
         log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" is a dial-back request — ignoring`);
         return null;
       }
       if (!group.test(utterance) && !request.test(utterance)
         && !(confirmation.test(utterance) && literal.test(utterance))
       ) {
+        this.refusedGroupAction = true;
         log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" has no group request or confirmation — ignoring`);
         return null;
       }
@@ -1521,14 +1526,20 @@ export class SwitchboardBrain implements Brain {
   private replyTrigger(reply: string): "standup" | "rollcall" | null {
     if (this.active !== null) return null; // only the front desk drives the board
     const r = normalizeUtterance(reply);
-    if (/^(?:status from every(?:one|body)|standup)$/.test(r)) return "standup";
-    if (/^roll\s?-?call$/.test(r)) return "rollcall";
-    return null;
+    const trigger = /^(?:status from every(?:one|body)|standup)$/.test(r)
+      ? "standup"
+      : /^roll\s?-?call$/.test(r) ? "rollcall" : null;
+    if (trigger !== null && this.refusedGroupAction) {
+      log("info", `switchboard: front desk replied ${trigger} after the classifier label was refused — ignoring`);
+      return null;
+    }
+    return trigger;
   }
 
   send(message: string, options?: BrainTurnOptions): Promise<string> {
     return this.runAcceptedTurn(options, async (turn, turnOptions) => {
       this.control = false;
+      this.refusedGroupAction = false;
       const routed = await this.controlPlane(message, turn, turnOptions);
       this.assertAcceptedTurn(turn);
       if (routed === "standup") {
@@ -1579,6 +1590,7 @@ export class SwitchboardBrain implements Brain {
     turn: AcceptedTurn,
   ): AsyncIterable<string> {
     this.control = false;
+    this.refusedGroupAction = false;
     const routed = await this.controlPlane(message, turn, turnOptions);
     this.assertAcceptedTurn(turn);
     if (routed === "standup") {

--- a/src/brain/switchboard.ts
+++ b/src/brain/switchboard.ts
@@ -1116,14 +1116,16 @@ export class SwitchboardBrain implements Brain {
     if (!label) return null;
     // The classifier sometimes labels a bare "what's the status?" as a team
     // standup (seen live 2026-07-11 — the front desk hijacked a question meant
-    // for the pinned lane). Group actions demand a group word — or the action's
-    // own name — in the actual utterance; a caller who literally said "roll
-    // call" cannot be a hallucinated label (live miss 2026-07-12: "yes, initiate
-    // roll call" was discarded here and the persona apologized instead).
+    // for the pinned lane). Group actions demand a group word, an explicit
+    // request bound to the action name, or confirmation of a prior request.
     const group = /\b(?:every(?:one|body)|team|office|all|each|agents?|staff|group|hands)\b/i;
     const literal = label === "rollcall" ? /\broll\s?-?calls?\b/i : /\bstand\s?-?ups?\b/i;
-    if ((label === "standup" || label === "rollcall") && !group.test(utterance) && !literal.test(utterance)) {
-      log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" names no group — ignoring`);
+    const request = new RegExp(String.raw`\b(?:(?:run|do|start|begin|initiate|hold|have|take)(?:\s+(?:a|an|the|another))?|give\s+me(?:\s+(?:a|an|the|another))?|let['’]s\s+(?:do|have)(?:\s+(?:a|an|the|another))?)\s+${literal.source}`, "i");
+    const confirmation = /^\s*(?:yes|yeah|yep|correct|right)\b|\bthat['’]s\s+what\s+i\s+(?:just\s+)?said\b/i;
+    if ((label === "standup" || label === "rollcall") && !group.test(utterance)
+      && !request.test(utterance) && !(confirmation.test(utterance) && literal.test(utterance))
+    ) {
+      log("info", `switchboard: classifier said ${label} but "${utterance.slice(0, 50)}" has no group request or confirmation — ignoring`);
       return null;
     }
     if (label === "standup") return "standup";

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1352,6 +1352,20 @@ function classifierBoard(calls: string[], label: string | (() => Promise<string>
   return { sb: new SwitchboardBrain(fakeBrain("front", calls), lanes, wrapped), prompts };
 }
 
+function magicRollcallFront(calls: string[], streaming = false): Brain {
+  return {
+    ...fakeBrain("front", calls),
+    send: async (m: string) => { calls.push(`front:send:${m}`); return "roll call"; },
+    ...(streaming ? {
+      sendStream: async function* (m: string) {
+        calls.push(`front:stream:${m}`);
+        yield "roll ";
+        yield "call";
+      },
+    } : {}),
+  };
+}
+
 test("classifier routes phrasings the patterns miss", async () => {
   const calls: string[] = [];
   const { sb, prompts } = classifierBoard(calls, "transfer:coder");
@@ -1634,6 +1648,102 @@ test("classifier-labeled bare group-action names are ignored (2026-07-30 live re
     expect(await sb.send(utterance)).toBe("front reply");
     expect(sb.wasControlTurn()).toBe(false);
   }
+});
+
+test("a refused classifier rollcall cannot return through the front-desk reply", async () => {
+  const calls: string[] = [];
+  const lanes: Record<string, LaneDef> = {
+    coder: { brain: fakeBrain("coder", calls) },
+    think: { brain: fakeBrain("think", calls) },
+  };
+  const sb = new SwitchboardBrain(magicRollcallFront(calls), lanes, async () => "rollcall");
+  await sb.start();
+
+  expect(await sb.send("The roll call.")).toBe("roll call");
+  expect(sb.wasControlTurn()).toBe(false);
+  expect(calls.some((call) => call.startsWith("coder:send:") || call.startsWith("think:send:"))).toBe(false);
+});
+
+test("a refused classifier rollcall cannot return through a streamed front-desk reply", async () => {
+  const calls: string[] = [];
+  const lanes: Record<string, LaneDef> = {
+    coder: { brain: fakeBrain("coder", calls) },
+    think: { brain: fakeBrain("think", calls) },
+  };
+  const sb = new SwitchboardBrain(magicRollcallFront(calls, true), lanes, async () => "rollcall");
+  await sb.start();
+  let out = "";
+  for await (const chunk of sb.sendStream("The roll call.")) out += chunk;
+
+  expect(out).toBe("roll call");
+  expect(sb.wasControlTurn()).toBe(false);
+  expect(calls.some((call) => call.startsWith("coder:send:") || call.startsWith("think:send:"))).toBe(false);
+});
+
+test("a streamed front-desk rollcall reply still promotes when nothing was refused", async () => {
+  // The positive twin of the streaming refusal above, and it earns its place:
+  // wedging the streaming path into a permanently-refused state broke no test
+  // without it, so the promotion that path is supposed to perform had no cover
+  // at all.
+  const calls: string[] = [];
+  const lanes: Record<string, LaneDef> = {
+    coder: { brain: fakeBrain("coder", calls) },
+    think: { brain: fakeBrain("think", calls) },
+  };
+  const sb = new SwitchboardBrain(magicRollcallFront(calls, true), lanes, async () => "none");
+  await sb.start();
+  let out = "";
+  for await (const chunk of sb.sendStream("Check whether they should respond.")) out += chunk;
+
+  expect(out).toBe("Coder checking in. Think checking in.");
+  expect(sb.wasControlTurn()).toBe(true);
+});
+
+test("a front-desk rollcall reply still promotes when no classifier label was refused", async () => {
+  const calls: string[] = [];
+  const lanes: Record<string, LaneDef> = {
+    coder: { brain: fakeBrain("coder", calls) },
+    think: { brain: fakeBrain("think", calls) },
+  };
+  let classifications = 0;
+  const sb = new SwitchboardBrain(
+    magicRollcallFront(calls),
+    lanes,
+    async () => classifications++ === 0 ? "none" : "rollcall",
+  );
+  await sb.start();
+
+  expect(await sb.send("Check whether they should respond.")).toBe("Coder checking in. Think checking in.");
+  expect(sb.wasControlTurn()).toBe(true);
+  expect(await sb.send("The roll call.")).toBe("roll call");
+  expect(sb.wasControlTurn()).toBe(false);
+});
+
+test("a dial-back veto also blocks a front-desk group-action reply", async () => {
+  const calls: string[] = [];
+  const lanes: Record<string, LaneDef> = {
+    coder: { brain: fakeBrain("coder", calls) },
+    think: { brain: fakeBrain("think", calls) },
+  };
+  const sb = new SwitchboardBrain(magicRollcallFront(calls), lanes, async () => "rollcall");
+  await sb.start();
+
+  expect(await sb.send("Have everyone call me back.")).toBe("roll call");
+  expect(sb.wasControlTurn()).toBe(false);
+});
+
+test("a refused group action does not suppress a front-desk trigger on a later turn", async () => {
+  const calls: string[] = [];
+  const lanes: Record<string, LaneDef> = {
+    coder: { brain: fakeBrain("coder", calls) },
+    think: { brain: fakeBrain("think", calls) },
+  };
+  const sb = new SwitchboardBrain(magicRollcallFront(calls), lanes, async () => "rollcall");
+  await sb.start();
+
+  expect(await sb.send("The roll call.")).toBe("roll call");
+  expect(await sb.send("Hello.")).toBe("Coder checking in. Think checking in.");
+  expect(sb.wasControlTurn()).toBe(true);
 });
 
 test("classifier group-action request framing distinguishes commands from ambiguous bare verbs", async () => {

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1636,7 +1636,7 @@ test("classifier-labeled bare group-action names are ignored (2026-07-30 live re
   }
 });
 
-test("classifier group-action labels require a request or confirmation", async () => {
+test("classifier group-action request framing distinguishes commands from ambiguous bare verbs", async () => {
   const requests = [
     ["run the roll call", "rollcall"],
     ["do the roll call", "rollcall"],
@@ -1645,7 +1645,10 @@ test("classifier group-action labels require a request or confirmation", async (
     ["initiate the roll call", "rollcall"],
     ["hold a roll call", "rollcall"],
     ["have the roll call", "rollcall"],
+    ["have a roll call", "rollcall"],
     ["take a roll call", "rollcall"],
+    ["I'd like a roll call", "rollcall"],
+    ["I need a roll call", "rollcall"],
     ["give me a roll call", "rollcall"],
     ["let's have the standup", "standup"],
     ["Right, standup", "standup"],
@@ -1659,9 +1662,19 @@ test("classifier group-action labels require a request or confirmation", async (
     expect(label === "rollcall" ? reply.includes("checking in.") : reply.startsWith("Getting status from the team.")).toBe(true);
     expect(sb.wasControlTurn()).toBe(true);
   }
+  for (const utterance of [
+    "have roll call me back",
+    "take roll call off my hands",
+  ]) {
+    const calls: string[] = [];
+    const { sb } = classifierBoard(calls, "rollcall");
+    await sb.start();
+    expect(await sb.send(utterance)).toBe("front reply");
+    expect(sb.wasControlTurn()).toBe(false);
+  }
 });
 
-test("classifier confirmation without the named group action remains a normal brain turn", async () => {
+test("classifier group-action evidence yields to dial-back readings and requires a named confirmation", async () => {
   for (const utterance of [
     "yes, check on that",
     "right, transfer the status",
@@ -1673,6 +1686,11 @@ test("classifier confirmation without the named group action remains a normal br
     expect(await sb.send(utterance)).toBe("front reply");
     expect(sb.wasControlTurn()).toBe(false);
   }
+  const calls: string[] = [];
+  const { sb } = classifierBoard(calls, "rollcall");
+  await sb.start();
+  expect(await sb.send("have everyone call me back")).toBe("front reply");
+  expect(sb.wasControlTurn()).toBe(false);
 });
 
 test("'do another roll call' matches lexically — no classifier round-trip", async () => {

--- a/tests/brain/switchboard.test.ts
+++ b/tests/brain/switchboard.test.ts
@@ -1623,6 +1623,58 @@ test("classifier rollcall with the literal phrase but no group word is honored (
   }
 });
 
+test("classifier-labeled bare group-action names are ignored (2026-07-30 live regression)", async () => {
+  for (const [utterance, label] of [
+    ["The roll call.", "rollcall"],
+    ["the standup.", "standup"],
+  ] as const) {
+    const calls: string[] = [];
+    const { sb } = classifierBoard(calls, label);
+    await sb.start();
+    expect(await sb.send(utterance)).toBe("front reply");
+    expect(sb.wasControlTurn()).toBe(false);
+  }
+});
+
+test("classifier group-action labels require a request or confirmation", async () => {
+  const requests = [
+    ["run the roll call", "rollcall"],
+    ["do the roll call", "rollcall"],
+    ["start a roll call", "rollcall"],
+    ["begin roll call", "rollcall"],
+    ["initiate the roll call", "rollcall"],
+    ["hold a roll call", "rollcall"],
+    ["have the roll call", "rollcall"],
+    ["take a roll call", "rollcall"],
+    ["give me a roll call", "rollcall"],
+    ["let's have the standup", "standup"],
+    ["Right, standup", "standup"],
+    ["That's what I said: standup", "standup"],
+  ] as const;
+  for (const [utterance, label] of requests) {
+    const calls: string[] = [];
+    const { sb } = classifierBoard(calls, label);
+    await sb.start();
+    const reply = await sb.send(utterance);
+    expect(label === "rollcall" ? reply.includes("checking in.") : reply.startsWith("Getting status from the team.")).toBe(true);
+    expect(sb.wasControlTurn()).toBe(true);
+  }
+});
+
+test("classifier confirmation without the named group action remains a normal brain turn", async () => {
+  for (const utterance of [
+    "yes, check on that",
+    "right, transfer the status",
+    "yeah, check the build",
+  ]) {
+    const calls: string[] = [];
+    const { sb } = classifierBoard(calls, "rollcall");
+    await sb.start();
+    expect(await sb.send(utterance)).toBe("front reply");
+    expect(sb.wasControlTurn()).toBe(false);
+  }
+});
+
 test("'do another roll call' matches lexically — no classifier round-trip", async () => {
   const calls: string[] = [];
   const { sb, prompts } = classifierBoard(calls, "none");


### PR DESCRIPTION
## The live failure

Mid-call, 2026-07-30. The caller asked to have **Rick** — the working name of the
`think` lane — call them back. What the transcript recorded:

```
YOU:    "The roll call."
CICERO: Elliot checking in. Rick checking in. Thor checking in. Samantha
        checking in. Sherlock checking in. Tony checking in. Lucius
        checking in. House checking in.
```

**"Rick call" and "roll call" are near-homophones**, and `roll call` is the literal
trigger for an eight-lane group action. ~30 seconds of a live call, spent on check-ins
nobody asked for.

## Cause

The guard in `actOnIntent` accepted the action's own **name**, anywhere in the utterance,
as sufficient. Its stated reasoning: *"a caller who literally said 'roll call' cannot be a
hallucinated label."* That holds for the classifier — it cannot invent the phrase — but
**STT can hallucinate the words themselves**, which is exactly what happened.

Reproduced on `main` before the fix:

```
send("The roll call.")  ->  "Coder checking in. Think checking in."
```

## Fix

A classifier-labeled `rollcall`/`standup` is honored only when the utterance carries:

- a **group word** (`everyone`, `the team`, `all agents`…), or
- a **request verb bound to the action name** — "run the roll call", "give me a roll call",
  "let's do another standup", or
- a **confirmation together with the action name** — "Yes, that's what I just said, roll call."

Otherwise it becomes a normal brain turn.

### The confirmation clause requires the name deliberately

The first pass accepted a bare confirmation, which was **strictly worse than the original
defect**. A leading "yes" plus any word passing `CONTROLISH_RE` fanned out to every lane:

```
"yes, check on that"          ->  "Coder checking in. Think checking in."
"right, transfer the status"  ->  "Coder checking in. Think checking in."
"yeah, check the build"       ->  "Coder checking in. Think checking in."
```

All three correctly return `front reply` on the base commit. Caught in review, fixed, and
pinned by its own regression.

### The lexical patterns are untouched

`ROLLCALL_RE` / `STANDUP_RE` are anchored whole-utterance matches — high confidence, and
left exactly as they are. `"Okay, roll call."` still works through that path. Only the fuzzy
classifier bypass tightens, which is the one that actually misfired.

## Verification

Behavior matrix, run against the built code:

| Utterance | Result |
|---|---|
| `"The roll call."` | ignored ✅ *(the live bug)* |
| `"the standup."` | ignored ✅ |
| `"yes, check on that"` | ignored ✅ |
| `"right, transfer the status"` | ignored ✅ |
| `"yeah, check the build"` | ignored ✅ |
| `"Yes, that's what I just said, roll call."` | fires ✅ *(2026-07-12 live miss)* |
| `"Yes, initiate roll call."` | fires ✅ |
| `"run the roll call"` / `"give me a roll call"` | fires ✅ |
| `"let's do another standup"` | fires ✅ |
| `"status from everyone"` / `"I want everyone to check in."` | fires ✅ |

- `bun run typecheck` — clean
- `bun test tests/brain/switchboard.test.ts` — 114 pass, 0 fail
- Full `bun test` — 2419 pass / 6 skip / 2 fail / 1 error vs **2416 / 6 / 2 / 1 measured on
  this exact base commit**: +3 (the new regressions), identical failure count. Both failures
  are pre-existing and environmental — `terminal-send-errors` asserts stderr that Bun
  colorizes with ANSI codes under a TTY.
- `git diff --check` — clean

**Mutation proofs** (each neutered alone, then restored):

| Mutation | Result |
|---|---|
| revert to the old literal-only bypass | `classifier-labeled bare group-action names are ignored (2026-07-30 live regression)` fails |
| confirmation no longer requires the action name | `classifier confirmation without the named group action remains a normal brain turn` fails |

Not verified by CI: no real call was placed, and I cannot hear the original audio — whether
you said "the roll call" or STT mangled "Rick call" is not provable from the logs. The
collision is real either way, and the misfire above is reproducible.

Third of three from the same incident, all independent: #73 (dial-back superseding its own
turn), #74 (transfer dropped by barge-in during a cold start).
