### PR TITLE
feat(voice): keep talking through a slow turn instead of one filler then silence

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -362,8 +362,9 @@ export interface BrainConfig {
   // agent (tools + memory). Instant utilities (time, battery, mute, stop) stay local.
   // Trade-off: every turn pays the agent's latency (and, for a cloud brain, cost).
   agent_first?: boolean;
-  // Speak a short, varied "let me think…" filler at the start of a brain turn to
-  // cover the agent's thinking latency (it plays while the agent generates). Default on.
+  // Speak cached, varied "let me think…" audio during a slow brain turn,
+  // including bounded reassurances until content arrives. Default on; false
+  // disables both the initial filler and its reassurances.
   thinking_filler?: boolean;
 }
 

--- a/src/web-voice/turn.ts
+++ b/src/web-voice/turn.ts
@@ -216,15 +216,20 @@ export interface WebStreamDeps {
   /** Optional per-daemon-session voice controls for instant spoken commands. */
   voice?: VoiceControlOptions;
   /**
-   * Optional instant filler to cover the brain's time-to-first-token. Called
-   * once per turn (after the transcript, before the brain) and, if it returns a
-   * pre-rendered clip, played ONLY when the brain's first sentence hasn't
-   * arrived within {@link WebStreamDeps.fillerDelayMs} — a fast reply gets
-   * natural silence, not a verbal tic. Omit it (the default) for no filler.
+   * Optional cached filler picker to cover the brain's time-to-first-sentence.
+   * Called before the brain and again only when a slow turn needs another
+   * reassurance. Every returned clip MUST already be rendered; this path never
+   * synthesizes filler audio. The first clip plays only after
+   * {@link WebStreamDeps.fillerDelayMs}, so a fast reply gets natural silence.
+   * Omit it (the default) for no filler or reassurance.
    */
   filler?: (transcript?: string) => PreparedFiller | undefined;
   /** How long the reply may take before the filler speaks (default 1200ms; 0 = immediately). */
   fillerDelayMs?: number;
+  /** Delay between cached reassurances after the first filler (default 4000ms). */
+  fillerReassuranceIntervalMs?: number;
+  /** Maximum further reassurances after the first filler (default 3; 0 disables repeats). */
+  fillerMaxReassurances?: number;
   /** Optional TLDR gate — see {@link TldrOptions}. Omit to speak every sentence. */
   tldr?: TldrOptions;
   /**
@@ -266,6 +271,12 @@ export interface WebStreamDeps {
   /** Per-invocation daemon snapshot. Captured only when this path starts the brain. */
   operationalContext?: (signal?: AbortSignal) => Promise<string | null>;
 }
+
+export const DEFAULT_FILLER_DELAY_MS = 1_200;
+export const DEFAULT_FILLER_REASSURANCE_INTERVAL_MS = 4_000;
+export const DEFAULT_FILLER_MAX_REASSURANCES = 3;
+export const MAX_FILLER_REASSURANCES_PER_TURN = 10;
+const DISTINCT_FILLER_PICK_ATTEMPTS = 2;
 
 /**
  * Long-turn parking: when the brain hasn't produced its FIRST sentence within
@@ -1073,11 +1084,14 @@ async function streamReply(
   if (deps.signal?.aborted || sink.aborted()) return;
 
   let fillerTimer: ReturnType<typeof setTimeout> | undefined;
+  let fillerCancelled = false;
   const cancelFiller = () => {
+    fillerCancelled = true;
     if (fillerTimer !== undefined) { clearTimeout(fillerTimer); fillerTimer = undefined; }
   };
   const turnAbort = pretokens ? null : new AbortController();
   const abortFromTransport = (): void => {
+    cancelFiller();
     if (turnAbort && !turnAbort.signal.aborted) turnAbort.abort(deps.signal?.reason);
   };
   if (deps.signal) {
@@ -1090,24 +1104,58 @@ async function streamReply(
     // it's cached), but only speak it if the brain's first sentence hasn't shown
     // up within the gate. A fast reply gets natural silence instead of a filler
     // on every turn, which reads as a scripted tic in real conversation.
-    const fillerCandidate = deps.filler?.(transcript);
-    let filler: PreparedFiller | undefined;
-    if (fillerCandidate?.audio.byteLength) {
+    const admitFiller = (candidate: PreparedFiller | undefined): PreparedFiller | undefined => {
+      if (!candidate?.audio.byteLength) return undefined;
       try {
-        admitProviderAudio(fillerCandidate.audio);
-        filler = fillerCandidate;
+        return { text: candidate.text, audio: admitProviderAudio(candidate.audio) };
       } catch {
         // Optional cached filler is corrupt/oversized; the real reply continues.
+        return undefined;
       }
-    }
-    if (filler && !sink.aborted()) {
+    };
+    const firstFiller = admitFiller(deps.filler?.(transcript));
+    const reassuranceIntervalMs = boundedFillerInterval(
+      deps.fillerReassuranceIntervalMs,
+    );
+    const maxReassurances = boundedFillerReassurances(
+      deps.fillerMaxReassurances,
+    );
+    let lastFillerText: string | undefined;
+    let reassurancesSpoken = 0;
+    const nextDistinctFiller = (): PreparedFiller | undefined => {
+      for (let attempt = 0; attempt < DISTINCT_FILLER_PICK_ATTEMPTS; attempt++) {
+        const candidate = admitFiller(deps.filler?.(transcript));
+        if (candidate && candidate.text !== lastFillerText) return candidate;
+      }
+      return undefined;
+    };
+    const armFiller = (clip: PreparedFiller, delayMs: number, reassurance: boolean): void => {
+      if (fillerCancelled || deps.signal?.aborted || sink.aborted()) {
+        cancelFiller();
+        return;
+      }
       fillerTimer = setTimeout(() => {
         fillerTimer = undefined;
-        if (sink.aborted()) return;
-        sink.sentence(filler.text);
-        sink.audio(filler.audio);
-        timer.mark("filler_audio");
-      }, deps.fillerDelayMs ?? 1200);
+        if (fillerCancelled || deps.signal?.aborted || sink.aborted()) {
+          cancelFiller();
+          return;
+        }
+        sink.sentence(clip.text);
+        if (deps.signal?.aborted || sink.aborted()) {
+          cancelFiller();
+          return;
+        }
+        sink.audio(clip.audio);
+        lastFillerText = clip.text;
+        if (reassurance) reassurancesSpoken += 1;
+        timer.mark(reassurance ? "reassurance_audio" : "filler_audio");
+        if (reassurancesSpoken >= maxReassurances) return;
+        const next = nextDistinctFiller();
+        if (next) armFiller(next, reassuranceIntervalMs, true);
+      }, delayMs);
+    };
+    if (firstFiller) {
+      armFiller(firstFiller, boundedFillerDelay(deps.fillerDelayMs), false);
     }
 
     // Mark the brain's first token (time-to-first-token) as it flows past. For a
@@ -1141,7 +1189,12 @@ async function streamReply(
     let parked = false;
     let parkDeadline = 0;
     const parkedTexts: string[] = [];
-    const stopConsuming = () => deps.signal?.aborted === true || (parked ? Date.now() > parkDeadline : sink.aborted());
+    const stopConsuming = () => {
+      const stopped = deps.signal?.aborted === true
+        || (parked ? Date.now() > parkDeadline : sink.aborted());
+      if (stopped) cancelFiller();
+      return stopped;
+    };
     const consumption = (async () => {
       const trimmed = (async function* (): AsyncGenerator<string> {
         for await (const raw of segmentSentences(abortable(
@@ -1151,9 +1204,11 @@ async function streamReply(
           pretokens !== undefined,
           deps.trackBackground,
         ))) {
-          cancelFiller(); // the real reply arrived — an unfired filler stays silent
           const sentence = raw.trim();
-          if (sentence) yield sentence;
+          if (sentence) {
+            cancelFiller(); // first real content owns the floor from here on
+            yield sentence;
+          }
         }
       })();
       // One chunk per synthesis call, but still one `parts` entry per sentence:
@@ -1318,6 +1373,30 @@ async function streamReply(
       deps.signal?.removeEventListener("abort", abortFromTransport);
     }
   }
+}
+
+function boundedFillerDelay(value: number | undefined): number {
+  const delay = value ?? DEFAULT_FILLER_DELAY_MS;
+  if (!Number.isSafeInteger(delay) || delay < 0 || delay > 2_147_483_647) {
+    throw new RangeError("filler delay must be an integer between 0 and 2147483647ms");
+  }
+  return delay;
+}
+
+function boundedFillerInterval(value: number | undefined): number {
+  const interval = value ?? DEFAULT_FILLER_REASSURANCE_INTERVAL_MS;
+  if (!Number.isSafeInteger(interval) || interval <= 0 || interval > 2_147_483_647) {
+    throw new RangeError("filler reassurance interval must be an integer between 1 and 2147483647ms");
+  }
+  return interval;
+}
+
+function boundedFillerReassurances(value: number | undefined): number {
+  const count = value ?? DEFAULT_FILLER_MAX_REASSURANCES;
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new RangeError("filler reassurance count must be a non-negative integer");
+  }
+  return Math.min(count, MAX_FILLER_REASSURANCES_PER_TURN);
 }
 
 export async function captureOperationalContext(

--- a/src/web-voice/turn.ts
+++ b/src/web-voice/turn.ts
@@ -1151,7 +1151,17 @@ async function streamReply(
         timer.mark(reassurance ? "reassurance_audio" : "filler_audio");
         if (reassurancesSpoken >= maxReassurances) return;
         const next = nextDistinctFiller();
-        if (next) armFiller(next, reassuranceIntervalMs, true);
+        if (next) {
+          const durationMs = wavDurationMs(clip.audio);
+          // A malformed header cannot safely extend the pacing delay, but an
+          // optional reassurance must not break the chain after audio emission.
+          // Falling back preserves the configured interval used before duration
+          // awareness instead of throwing or silently ending slow-turn coverage.
+          const nextDelayMs = durationMs === null
+            ? reassuranceIntervalMs
+            : Math.max(reassuranceIntervalMs, Math.ceil(durationMs));
+          armFiller(next, nextDelayMs, true);
+        }
       }, delayMs);
     };
     if (firstFiller) {

--- a/tests/web-voice/turn.test.ts
+++ b/tests/web-voice/turn.test.ts
@@ -381,17 +381,23 @@ test("streamWebTurn clears filler timers when aborted mid-wait", async () => {
   const running = streamWebTextTurn("wait for this", deps, sink);
   await waiting;
 
-  jest.advanceTimersByTime(5);
-  expect(calls.sentence).toEqual(["Working."]);
+  // The chain has to be RUNNING when the abort lands, or the test proves
+  // nothing: aborting after a single filler leaves one clip spoken under the
+  // old one-shot behavior too. Two clips is what says a timer was armed, and
+  // the count below is what says the cancel latched instead of re-arming.
+  jest.advanceTimersByTime(55);
+  expect(calls.sentence).toEqual(["Working.", "Still working."]);
   controller.abort(new Error("caller left"));
   await running;
   jest.advanceTimersByTime(10_000);
 
-  expect(calls.sentence).toEqual(["Working."]);
-  expect(calls.audio).toBe(1);
+  expect(calls.sentence).toEqual(["Working.", "Still working."]);
+  expect(calls.audio).toBe(2);
 });
 
 test("streamWebTurn emits no filler or reassurance when a fast reply beats the gate", async () => {
+  // This is a forward guard for fast turns, not evidence that reassurances repeat:
+  // both the old one-shot filler and the repeating chain must leave a fast reply unchanged.
   jest.useFakeTimers();
   const lines = ["Thinking.", "Still thinking."];
   let picks = 0;
@@ -410,6 +416,49 @@ test("streamWebTurn emits no filler or reassurance when a fast reply beats the g
   expect(calls.sentence).toEqual(["Immediate reply."]);
   expect(calls.audio).toBe(1);
   expect(picks).toBe(1);
+});
+
+test("streamWebTurn stops a running reassurance chain at the first content sentence", async () => {
+  // The discriminating half of the fast-reply guard above. A reply that beats
+  // the first filler looks identical under both implementations, so the rule
+  // that actually needs proving is the other one: once the chain is speaking,
+  // the first real sentence has to stop it — and arrive exactly once itself.
+  jest.useFakeTimers();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let started!: () => void;
+  const waiting = new Promise<void>((resolve) => { started = resolve; });
+  const lines = ["Thinking.", "Still thinking.", "Nearly there."];
+  let picks = 0;
+  const deps: WebStreamDeps = {
+    ...streamDeps(),
+    brain: {
+      send: async () => "",
+      sendStream: () => (async function* () {
+        started();
+        await gate;
+        yield "Here is the answer.";
+      })(),
+    },
+    filler: () => ({ text: lines[picks++]!, audio: tinyWav([picks]) }),
+    fillerDelayMs: 5,
+    fillerReassuranceIntervalMs: 50,
+    fillerMaxReassurances: 3,
+  };
+  const { sink, calls } = capturingSink();
+  const running = streamWebTextTurn("take your time", deps, sink);
+  await waiting;
+
+  jest.advanceTimersByTime(55);
+  expect(calls.sentence).toEqual(["Thinking.", "Still thinking."]);
+
+  release();
+  await running;
+  jest.advanceTimersByTime(10_000);
+
+  expect(calls.sentence).toEqual(["Thinking.", "Still thinking.", "Here is the answer."]);
+  expect(calls.sentence.filter((sentence) => sentence === "Here is the answer.")).toHaveLength(1);
+  expect(calls.audio).toBe(3);
 });
 
 test("streaming turns reject malformed provider audio before forwarding it", async () => {

--- a/tests/web-voice/turn.test.ts
+++ b/tests/web-voice/turn.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { afterEach, test, expect, jest } from "bun:test";
 import { OPERATIONAL_CONTEXT_CAPTURE_TIMEOUT_MS, silenceWavLike, SPEAKER_BEAT_MS, processWebTurn, streamWebTurn, streamWebTextTurn, isExpandRequest, isRepeatRequest, isResumeRequest, applyVoiceControl, concatWavs, type WebTurnDeps, type WebStreamDeps, type WebReplySink } from "../../src/web-voice/turn";
 
 async function* tokens(...parts: string[]) { for (const p of parts) yield p; }
@@ -17,6 +17,10 @@ function capturingSink(abortWhen?: (c: SinkCalls) => boolean) {
   return { sink, calls };
 }
 interface SinkCalls { transcript: string[]; sentence: string[]; audio: number; control: Array<{ type: string; delta?: number; volume?: number; rate?: number }>; done: number; error: string[]; }
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 function streamDeps(over: Partial<{ transcript: string; stream: string[]; reply: string }> = {}): WebStreamDeps {
   return {
@@ -271,6 +275,141 @@ test("streamWebTurn stays silent (no filler) when the reply beats the gate", asy
   expect(calls.sentence).toEqual(["Hello there."]); // no verbal tic on a fast turn
   expect(calls.audio).toBe(1);
   expect(calls.done).toBe(1);
+});
+
+test("streamWebTurn repeats cached reassurances while the turn is pending", async () => {
+  jest.useFakeTimers();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let started!: () => void;
+  const waiting = new Promise<void>((resolve) => { started = resolve; });
+  const lines = ["Still working.", "Still working.", "One more moment.", "Almost there."];
+  let picks = 0;
+  let syntheses = 0;
+  const deps: WebStreamDeps = {
+    ...streamDeps(),
+    brain: {
+      send: async () => "",
+      sendStream: () => (async function* () {
+        started();
+        await gate;
+        yield "Finished.";
+      })(),
+    },
+    tts: { generateAudio: async () => { syntheses += 1; return tinyWav([9]); } },
+    filler: () => ({ text: lines[picks++] ?? "Almost there.", audio: tinyWav([picks]) }),
+    fillerDelayMs: 5,
+    fillerReassuranceIntervalMs: 10,
+    fillerMaxReassurances: 3,
+  };
+  const { sink, calls } = capturingSink();
+  const running = streamWebTextTurn("do the slow thing", deps, sink);
+  await waiting;
+
+  jest.advanceTimersByTime(25);
+  expect(calls.sentence).toEqual(["Still working.", "One more moment.", "Almost there."]);
+  expect(calls.audio).toBe(3);
+
+  release();
+  await running;
+  expect(calls.sentence).toEqual(["Still working.", "One more moment.", "Almost there.", "Finished."]);
+  expect(syntheses).toBe(1); // content only; every reassurance used cached audio
+});
+
+test("streamWebTurn enforces the reassurance cap", async () => {
+  jest.useFakeTimers();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let started!: () => void;
+  const waiting = new Promise<void>((resolve) => { started = resolve; });
+  const lines = ["First.", "Second.", "Third.", "Fourth."];
+  let picks = 0;
+  const deps: WebStreamDeps = {
+    ...streamDeps(),
+    brain: {
+      send: async () => "",
+      sendStream: () => (async function* () {
+        started();
+        await gate;
+        yield "Done.";
+      })(),
+    },
+    filler: () => ({ text: lines[picks++]!, audio: tinyWav([picks]) }),
+    fillerDelayMs: 5,
+    fillerReassuranceIntervalMs: 10,
+    fillerMaxReassurances: 1,
+  };
+  const { sink, calls } = capturingSink();
+  const running = streamWebTextTurn("keep working", deps, sink);
+  await waiting;
+
+  jest.advanceTimersByTime(1_000);
+  expect(calls.sentence).toEqual(["First.", "Second."]);
+  expect(picks).toBe(2);
+
+  release();
+  await running;
+  expect(calls.sentence).toEqual(["First.", "Second.", "Done."]);
+});
+
+test("streamWebTurn clears filler timers when aborted mid-wait", async () => {
+  jest.useFakeTimers();
+  const controller = new AbortController();
+  let started!: () => void;
+  const waiting = new Promise<void>((resolve) => { started = resolve; });
+  const lines = ["Working.", "Still working.", "Nearly there."];
+  let picks = 0;
+  const deps: WebStreamDeps = {
+    ...streamDeps(),
+    signal: controller.signal,
+    brain: {
+      send: async () => "",
+      sendStream: (_text, options) => (async function* () {
+        started();
+        await new Promise<void>((resolve) => {
+          if (options?.signal?.aborted) resolve();
+          else options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+      })(),
+    },
+    filler: () => ({ text: lines[picks++]!, audio: tinyWav([picks]) }),
+    fillerDelayMs: 5,
+    fillerReassuranceIntervalMs: 50,
+    fillerMaxReassurances: 3,
+  };
+  const { sink, calls } = capturingSink();
+  const running = streamWebTextTurn("wait for this", deps, sink);
+  await waiting;
+
+  jest.advanceTimersByTime(5);
+  expect(calls.sentence).toEqual(["Working."]);
+  controller.abort(new Error("caller left"));
+  await running;
+  jest.advanceTimersByTime(10_000);
+
+  expect(calls.sentence).toEqual(["Working."]);
+  expect(calls.audio).toBe(1);
+});
+
+test("streamWebTurn emits no filler or reassurance when a fast reply beats the gate", async () => {
+  jest.useFakeTimers();
+  const lines = ["Thinking.", "Still thinking."];
+  let picks = 0;
+  const deps: WebStreamDeps = {
+    ...streamDeps({ stream: ["Immediate reply."] }),
+    filler: () => ({ text: lines[picks++]!, audio: tinyWav([picks]) }),
+    fillerDelayMs: 50,
+    fillerReassuranceIntervalMs: 50,
+    fillerMaxReassurances: 3,
+  };
+  const { sink, calls } = capturingSink();
+
+  await streamWebTextTurn("quick question", deps, sink);
+  jest.advanceTimersByTime(10_000);
+
+  expect(calls.sentence).toEqual(["Immediate reply."]);
+  expect(calls.audio).toBe(1);
+  expect(picks).toBe(1);
 });
 
 test("streaming turns reject malformed provider audio before forwarding it", async () => {

--- a/tests/web-voice/turn.test.ts
+++ b/tests/web-voice/turn.test.ts
@@ -316,6 +316,89 @@ test("streamWebTurn repeats cached reassurances while the turn is pending", asyn
   expect(syntheses).toBe(1); // content only; every reassurance used cached audio
 });
 
+test("streamWebTurn waits for a long reassurance clip to finish before emitting another", async () => {
+  jest.useFakeTimers();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let started!: () => void;
+  const waiting = new Promise<void>((resolve) => { started = resolve; });
+  const lines = ["Long clip.", "Next clip."];
+  let picks = 0;
+  const deps: WebStreamDeps = {
+    ...streamDeps(),
+    brain: {
+      send: async () => "",
+      sendStream: () => (async function* () {
+        started();
+        await gate;
+        yield "Done.";
+      })(),
+    },
+    filler: () => ({
+      text: lines[picks]!,
+      audio: pcm8Wav(picks++ === 0 ? 320 : 1),
+    }),
+    fillerDelayMs: 5,
+    fillerReassuranceIntervalMs: 10,
+    fillerMaxReassurances: 1,
+  };
+  const { sink, calls } = capturingSink();
+  const running = streamWebTextTurn("keep working", deps, sink);
+  await waiting;
+
+  jest.advanceTimersByTime(44);
+  expect(calls.sentence).toEqual(["Long clip."]);
+  jest.advanceTimersByTime(1);
+  expect(calls.sentence).toEqual(["Long clip.", "Next clip."]);
+
+  release();
+  await running;
+  expect(calls.sentence.at(-1)).toBe("Done.");
+});
+
+test("streamWebTurn returns to the configured interval after a shorter reassurance clip", async () => {
+  jest.useFakeTimers();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  let started!: () => void;
+  const waiting = new Promise<void>((resolve) => { started = resolve; });
+  const lines = ["Long clip.", "Short clip.", "Following clip."];
+  const frames = [160, 8, 8];
+  let picks = 0;
+  const deps: WebStreamDeps = {
+    ...streamDeps(),
+    brain: {
+      send: async () => "",
+      sendStream: () => (async function* () {
+        started();
+        await gate;
+        yield "Done.";
+      })(),
+    },
+    filler: () => {
+      const index = picks++;
+      return { text: lines[index]!, audio: pcm8Wav(frames[index]!) };
+    },
+    fillerDelayMs: 5,
+    fillerReassuranceIntervalMs: 10,
+    fillerMaxReassurances: 2,
+  };
+  const { sink, calls } = capturingSink();
+  const running = streamWebTextTurn("keep working", deps, sink);
+  await waiting;
+
+  jest.advanceTimersByTime(25);
+  expect(calls.sentence).toEqual(["Long clip.", "Short clip."]);
+  jest.advanceTimersByTime(9);
+  expect(calls.sentence).toEqual(["Long clip.", "Short clip."]);
+  jest.advanceTimersByTime(1);
+  expect(calls.sentence).toEqual(["Long clip.", "Short clip.", "Following clip."]);
+
+  release();
+  await running;
+  expect(calls.sentence.at(-1)).toBe("Done.");
+});
+
 test("streamWebTurn enforces the reassurance cap", async () => {
   jest.useFakeTimers();
   let release!: () => void;


### PR DESCRIPTION
## Why

A turn speaks exactly **one** cached filler, then goes quiet — for as long as it runs.

A lane cold start takes seconds. On the 2026-07-30 call it took **14 seconds** to bring up the
ACP `think` lane. The caller got "One moment." and then nothing. Hearing dead air, they spoke
again — that barge-in superseded the pending turn and the transfer was lost entirely. The
sidecar log for that call shows the only replies it ever received were 11 and 8 characters:
filler-length, nothing else.

## What changes

While a turn is still pending, further cached clips play at a bounded interval, until the first
content sentence arrives or the turn ends.

- **Bounded twice** — a configurable cap (`fillerMaxReassurances`, default 3) *and* a hard
  per-turn ceiling of 10. It cannot speak indefinitely.
- **No back-to-back repeats.** If no distinct clip is available the chain stops rather than
  stuttering.
- **Never synthesizes.** Every clip is pre-rendered and passed through the existing
  `admitProviderAudio` gate, so a reassurance adds no latency. It now also *snapshots* the
  buffer instead of retaining the caller's.
- **One owner, one cleanup path.** Cancelled on caller abort, transport abort, sink abort, the
  first real content sentence, and normal completion. The cancel **latches**, so a timer cannot
  re-arm after it.
- `thinking_filler: false` disables the whole chain (the picker returns nothing, so nothing arms).

Fast turns are unchanged — a reply that beats the gate still gets natural silence.

## Verification

Codex implemented this; I verified by execution, not by its report.

- `bun run typecheck` — clean
- `bun test tests/web-voice/ tests/speaker/` — 358 pass, 0 fail
- Full `bun test` — 2420 pass / 6 skip / 2 fail / 1 error vs **2416 / 6 / 2 / 1 measured on this
  exact base commit**: +4 (its new tests), identical failure count. Both failures are
  pre-existing and environmental (`terminal-send-errors` asserts stderr that Bun colorizes with
  ANSI codes under a TTY).
- `git diff --check` — clean. Scope: 3 files, all within the contract.

### Independent QA probes (mine, separate from Codex's tests)

| Probe | Result |
|---|---|
| Repeats during a long turn, never back-to-back | `["One moment.","Hold on.","One sec.","Give me a second."]` ✅ |
| Cap enforced (`max=2`) | 3 clips total — 1 filler + 2 ✅ |
| Abort mid-chain, then 5s of fake time past every interval | 1 before, **1 after** ✅ |
| Fast reply | `["Instant."]` only ✅ |
| Picker returns nothing (`thinking_filler: false`) | silent ✅ |

**Negative control:** I broke cancellation deliberately (transport abort no longer cancels; the
timer stops consulting the signal) and re-ran my abort probe — it failed, `after=2` instead of
`1`. The probe detects the bug it claims to guard, so the passing result means something.

I also checked Codex's own abort test rather than assuming: it speaks one clip with the cap at
3 (chain still armed), aborts, advances 10s, and asserts nothing more. Genuinely rigorous.

## Two findings from QA — flagged, not fixed

1. **The reassurance lines reuse the opening filler bucket.** There is no dedicated
   "still working" set, so a long wait can sound like it keeps restarting rather than
   continuing. For connect-flavored transcripts the lines happen to fit
   ("Connecting you now.", "Patching you through."); elsewhere they're generic.

2. **`CONNECT_RE` misses the phrasing that caused the incident.** Measured:

   | Utterance | Bucket |
   |---|---|
   | `"get Rick"` | `default` |
   | `"get me Rick"` | `default` |
   | `"have Rick call me"` | `default` |
   | `"let me talk to Rick"` | `connect` |
   | `"get me the coder"` | `connect` |

   It requires `get me the`, so a bare lane name doesn't match. I did **not** widen it: the
   obvious change (`get (me )?…`) would steal `lookup` intents like "get me the status", since
   CONNECT is tested before LOOKUP. The clean fix is probably to let the control plane say
   "this is a connect" rather than re-guessing from the transcript — separate change.

Not verified by CI: no real call was placed; timing is exercised with fake timers.

Third of three from the same incident: #73 (dial-back superseding its own turn), #74 (transfer
dropped by barge-in during a cold start), #75 (bare group-action name fanning out to all lanes).
This one and #74 are complementary — #74 stops the request being lost, this stops the wait
sounding dead. Independent; either can land alone.
